### PR TITLE
fix(python-sonarcloud): replace deprecated sonarcloud-github-action with sonarqube-scan-action

### DIFF
--- a/.github/workflows/python-sonarcloud.yml
+++ b/.github/workflows/python-sonarcloud.yml
@@ -266,7 +266,7 @@ jobs:
           fi
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@b5bd00b9b0fc1e6b296f84e7e6965f09cfebbdf6  # v3.1.0
+        uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203  # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Replaces the deprecated and archived `SonarSource/sonarcloud-github-action` with the recommended `SonarSource/sonarqube-scan-action@v4.2.1`
- Fixes invalid SHA reference (`b5bd00b9b0fc1e6b296f84e7e6965f09cfebbdf6`) that was causing workflow failures
- The sonarcloud-github-action repository was archived on October 22, 2025; SonarSource now recommends using sonarqube-scan-action for both platforms

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test SonarCloud analysis runs successfully on a downstream repository

Fixes #7

<!-- wtd:summary -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)