### PR TITLE
fix(docker): add local image scanning for Trivy when not pushing to registry

### DIFF
--- a/.github/workflows/python-docker.yml
+++ b/.github/workflows/python-docker.yml
@@ -279,8 +279,29 @@ jobs:
           sbom: ${{ inputs.enable-sbom }}
           provenance: ${{ inputs.enable-sbom }}
 
-      - name: Run Trivy vulnerability scanner
-        if: inputs.enable-trivy-scan
+      # Export local image for Trivy scanning when not pushed to registry
+      - name: Export local image for scanning
+        if: inputs.enable-trivy-scan && steps.push-check.outputs.push != 'true'
+        run: |
+          # Get the first tag from metadata (local reference)
+          LOCAL_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          echo "LOCAL_IMAGE_TAG=${LOCAL_TAG}" >> $GITHUB_ENV
+          echo "Exporting local image: ${LOCAL_TAG}"
+          # Export image to tarball for Trivy to scan
+          docker save "${LOCAL_TAG}" -o /tmp/image.tar
+
+      - name: Run Trivy vulnerability scanner (local image)
+        if: inputs.enable-trivy-scan && steps.push-check.outputs.push != 'true'
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0  # v0.29.0
+        with:
+          input: '/tmp/image.tar'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: ${{ inputs.trivy-severity }}
+          exit-code: ${{ inputs.trivy-fail-on-vuln && '1' || '0' }}
+
+      - name: Run Trivy vulnerability scanner (registry image)
+        if: inputs.enable-trivy-scan && steps.push-check.outputs.push == 'true'
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0  # v0.29.0
         with:
           image-ref: ${{ steps.image-name.outputs.name }}:${{ github.sha }}


### PR DESCRIPTION
## Summary

- Adds support for Trivy vulnerability scanning when Docker images are not pushed to a registry
- Exports local images to a tarball for scanning in non-push scenarios (PR builds, local testing)
- Maintains existing registry-based scanning for pushed images

## Problem

Previously, Trivy scanning would fail when `push` was disabled because it tried to reference a non-existent remote image using `image-ref`. This caused scan failures in:
- Pull request builds (where images typically aren't pushed)
- Local testing scenarios
- Dry-run configurations

## Solution

- Added a new step to export the local Docker image to `/tmp/image.tar` when push is disabled
- Created a separate Trivy action step that uses `input` parameter to scan the local tarball
- Original registry-based scanning step now only runs when push is enabled

## Test plan

- [ ] Test with `push: false` - should export and scan local image
- [ ] Test with `push: true` - should scan registry image as before
- [ ] Verify SARIF output is generated in both scenarios

<!-- wtd:summary -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container image vulnerability scanning workflow to comprehensively scan both locally built and registry-pushed images with separate conditional scanning paths, improved image export handling, and comprehensive results reporting for both scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->