### PR TITLE
fix(sbom): change permissions from read-all to explicit write access

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -64,7 +64,9 @@ on:
         description: 'Infisical client secret (optional, for future use)'
         required: false
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   # ============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ venv/
 .tmp-*
 tmp/
 tmp_cleanup/
+actionlint


### PR DESCRIPTION
## Summary

Fixes `startup_failure` in the SBOM workflow when called from downstream repositories.

## Problem

The `permissions: read-all` at workflow level was preventing job-level permissions from escalating to `security-events: write` needed for SARIF uploads to GitHub Security tab.

## Solution

Changed to explicit permissions that include the write access needed by the `scan-runtime` job:

```yaml
permissions:
  contents: read
  security-events: write
```

## Related

This fixes the SBOM workflow failure documented in homelab-infra's `WORKFLOW-FAILURES-HANDOFF.md`.

**Remaining issue for homelab-infra:**
- `security-analysis.yml` caller still has a `concurrency:` block (lines 25-27) that conflicts with the org-level workflow's concurrency and needs to be removed.

<!-- wtd:summary -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)