### PR TITLE
fix(sbom): add checkout step and error handling for SARIF upload

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -159,9 +159,17 @@ jobs:
           format: sarif
           output: trivy-runtime-results.sarif
 
+      # Checkout required for SARIF upload - action needs git context for commit SHA
+      - name: Checkout repository (for SARIF upload context)
+        if: always()
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          sparse-checkout: .  # Minimal checkout, just need .git directory
+
       - name: Upload Trivy results to GitHub Security tab
         if: always()
         uses: github/codeql-action/upload-sarif@8ff85221d12737ec1137e6a892722e5130f32d05  # v3.28.8
+        continue-on-error: true  # Don't fail if Code Scanning not enabled on repo
         with:
           sarif_file: trivy-runtime-results.sarif
           category: trivy-runtime-deps


### PR DESCRIPTION
## Summary

- Adds sparse checkout step before SARIF upload to provide git context
- Adds `continue-on-error: true` to prevent workflow failures when Code Scanning is not available

## Problem

The SARIF upload step was failing with "Resource not accessible by integration" because:

1. The `upload-sarif` action requires git context to determine the commit SHA, but the `scan-runtime` job only downloaded artifacts without checking out the repository
2. If Code Scanning is not enabled on the calling repository, the API call fails even with correct permissions

## Test plan

- [ ] Verify the workflow runs successfully on a repository with Code Scanning enabled
- [ ] Verify the workflow completes (with warning) on a repository without Code Scanning

<!-- wtd:summary -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced repository scanning workflow with improved error handling for Code Scanning operations.
  * Optimized workflow checkout process to streamline scanning context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->