### PR TITLE
fix(sbom): update template permissions and clarify license scope

### DIFF
--- a/workflow-templates/python-sbom.yml
+++ b/workflow-templates/python-sbom.yml
@@ -24,7 +24,9 @@ on:
     # Run weekly on Monday at 00:00 UTC
     - cron: '0 0 * * 1'
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   sbom:
@@ -35,8 +37,7 @@ jobs:
       fail-on-vulnerabilities: true
       severity-threshold: 'CRITICAL,HIGH'
       artifact-retention-days: 90
+      # Only flag GPL for application dependencies, not OS packages
+      # The SBOM workflow scans the Python venv, so this only affects pip packages
       forbidden-licenses: '["GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-only", "GPL-3.0-or-later", "AGPL-3.0-only", "AGPL-3.0-or-later"]'
-      fail-on-forbidden-licenses: false
-    permissions:
-      contents: read
-      security-events: write
+      fail-on-forbidden-licenses: false  # Warn only, don't fail


### PR DESCRIPTION
## Summary

- Changes workflow-level permissions from `read-all` to explicit `contents: read` and `security-events: write`
- Removes redundant job-level permissions block
- Adds clarifying comments that license scanning only affects Python packages (from venv), not OS packages

## Context

This aligns the template with the reusable workflow's permission requirements (updated in #18) and documents that GPL license checks apply only to application dependencies, not container OS packages.

## Test plan

- [ ] Verify template can be used by downstream repos without permission issues

<!-- wtd:summary -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to implement granular access controls.
  * Enhanced workflow configuration with improved documentation and comments.
  * Reorganized workflow settings structure for better clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->