### PR TITLE
fix(container): add scanners config to separate vuln from license scanning

### DIFF
--- a/.github/workflows/python-container-security.yml
+++ b/.github/workflows/python-container-security.yml
@@ -212,6 +212,7 @@ jobs:
           image-ref: ${{ steps.image.outputs.ref }}
           format: 'table'
           severity: ${{ inputs.severity-threshold }}
+          scanners: 'vuln'  # Only scan for vulnerabilities, not licenses
           exit-code: ${{ inputs.fail-on-vulnerabilities && '1' || '0' }}
 
       - name: Trivy SARIF report
@@ -221,6 +222,7 @@ jobs:
           image-ref: ${{ steps.image.outputs.ref }}
           format: 'sarif'
           output: 'trivy-container-results.sarif'
+          scanners: 'vuln'  # Only scan for vulnerabilities, not licenses
 
       - name: Upload Trivy SARIF
         if: ${{ inputs.upload-sarif && steps.image.outputs.ref != '' }}


### PR DESCRIPTION
## Summary

- Adds `scanners: 'vuln'` to Trivy container scan steps to only scan for vulnerabilities, not licenses

## Context

This separates vulnerability management from license compliance, allowing each to be handled with appropriate policies:

- **Container security workflow**: Scans for vulnerabilities in container images (OS packages, installed binaries)
- **SBOM workflow**: Handles license compliance for Python application dependencies (from venv)

Without this fix, Trivy's default behavior scans for both vulnerabilities and licenses, which can cause failures on GPL-licensed OS packages that are perfectly acceptable in containers.

## Test plan

- [ ] Verify container security workflow no longer flags license issues
- [ ] Verify vulnerability scanning still works correctly

<!-- wtd:summary -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration in CI/CD pipeline to focus on vulnerability detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->