### PR TITLE
feat(workflows): add Docker Hardened Images registry authentication

### DIFF
--- a/.github/workflows/python-container-security.yml
+++ b/.github/workflows/python-container-security.yml
@@ -101,6 +101,21 @@ on:
         required: false
         default: 30
 
+      # DHI Registry
+      enable-dhi-login:
+        description: 'Enable login to Docker Hardened Images (dhi.io) registry'
+        type: boolean
+        required: false
+        default: true
+
+    secrets:
+      DHI_USERNAME:
+        description: 'Docker Hardened Images registry username'
+        required: false
+      DHI_PAT:
+        description: 'Docker Hardened Images registry personal access token'
+        required: false
+
 permissions:
   contents: read
   security-events: write
@@ -172,6 +187,15 @@ jobs:
       - name: Checkout repository
         if: ${{ inputs.build-image }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Login to DHI Registry
+        if: inputs.enable-dhi-login
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_PAT }}
+        continue-on-error: true
 
       - name: Check Dockerfile exists
         if: ${{ inputs.build-image }}

--- a/.github/workflows/python-docker.yml
+++ b/.github/workflows/python-docker.yml
@@ -141,6 +141,21 @@ on:
         required: false
         default: true
 
+      # DHI Registry
+      enable-dhi-login:
+        description: 'Enable login to Docker Hardened Images (dhi.io) registry'
+        type: boolean
+        required: false
+        default: true
+
+    secrets:
+      DHI_USERNAME:
+        description: 'Docker Hardened Images registry username'
+        required: false
+      DHI_PAT:
+        description: 'Docker Hardened Images registry personal access token'
+        required: false
+
     outputs:
       image-tags:
         description: 'Generated image tags'
@@ -180,6 +195,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
+
+      - name: Login to DHI Registry
+        if: inputs.enable-dhi-login
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_PAT }}
+        continue-on-error: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a  # v3.3.0

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -63,6 +63,12 @@ on:
       INFISICAL_CLIENT_SECRET:
         description: 'Infisical client secret (optional, for future use)'
         required: false
+      DHI_USERNAME:
+        description: 'Docker Hardened Images registry username (optional, for future use)'
+        required: false
+      DHI_PAT:
+        description: 'Docker Hardened Images registry personal access token (optional, for future use)'
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Add support for authenticating to Docker Hardened Images (dhi.io) registry to enable pulling hardened base images in CI/CD workflows.

## Changes

### 1. python-docker.yml
- ✅ Added `enable-dhi-login` input parameter (boolean, default: `true`)
- ✅ Added `DHI_USERNAME` and `DHI_PAT` secrets
- ✅ Added DHI registry login step before QEMU setup
- ✅ Used `continue-on-error: true` for graceful degradation

### 2. python-container-security.yml
- ✅ Added `enable-dhi-login` input parameter (boolean, default: `true`)
- ✅ Added `DHI_USERNAME` and `DHI_PAT` secrets
- ✅ Added DHI registry login step in `trivy-scan` job before image build
- ✅ Used `continue-on-error: true` for graceful degradation

### 3. python-sbom.yml
- ✅ Added `DHI_USERNAME` and `DHI_PAT` as optional secrets
- ℹ️ No login step needed (workflow doesn't build images, but accepts secrets for consistency)

## Usage

Workflows automatically authenticate to `dhi.io` when org-level secrets are configured:

```yaml
jobs:
  docker:
    uses: ByronWilliamsCPA/.github/.github/workflows/python-docker.yml@main
    with:
      push: true
      # enable-dhi-login: true  # Default, can be disabled if needed
    secrets: inherit  # This passes DHI_USERNAME and DHI_PAT from org secrets
```

## Benefits

- 🔒 **Secure**: Uses GitHub's secret management
- 🔄 **Backward Compatible**: Works with existing workflows without modification
- 🛡️ **Non-blocking**: Gracefully handles missing secrets
- 🎯 **Opt-out Available**: Set `enable-dhi-login: false` if needed
- 🏗️ **Enables Hardened Images**: Allows pulling from dhi.io registry for improved security

## Testing

The workflows have been updated to:
- ✅ Authenticate to `dhi.io` when `DHI_USERNAME` and `DHI_PAT` secrets are present
- ✅ Continue without errors if secrets are not configured
- ✅ Pull hardened base images during Docker builds
- ✅ Work seamlessly with existing downstream repositories

## Related

Addresses requirements from: ByronWilliamsCPA/homelab-infra#158

## Checklist

- [x] Added DHI authentication to all Docker-building workflows
- [x] Implemented opt-out mechanism via `enable-dhi-login` parameter
- [x] Used `continue-on-error` for graceful degradation
- [x] Added secrets to non-building workflows for consistency
- [x] Tested backward compatibility approach
- [x] Conventional commit message used

---

<!-- wtd:summary -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional Docker Hardened Images (DHI) registry authentication support to CI/CD pipeline workflows.
  * Introduced configurable DHI registry login across container security scanning, Docker build, and software bill of materials generation workflows.
  * DHI registry authentication is optional with configuration inputs and credentials, maintaining backward compatibility with existing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->