### PR TITLE
feat(sbom): add trivyignore support for suppressing known CVEs

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -53,6 +53,11 @@ on:
         required: false
         type: boolean
         default: false
+      trivyignore-path:
+        description: 'Path to .trivyignore file for suppressing known CVEs (relative to repo root)'
+        required: false
+        type: string
+        default: '.trivyignore'
 
     # Optional secrets - callers may pass these even if unused by this workflow
     # This prevents startup_failure when callers pass extra secrets
@@ -142,10 +147,30 @@ jobs:
         with:
           egress-policy: audit
 
+      # Checkout to get .trivyignore and provide git context for SARIF upload
+      - name: Checkout repository (for trivyignore and SARIF context)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          sparse-checkout: |
+            .trivyignore
+            .git
+
       - name: Download SBOM artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: sboms
+
+      - name: Check for trivyignore file
+        id: trivyignore
+        run: |
+          if [ -f "${{ inputs.trivyignore-path }}" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Found trivyignore at: ${{ inputs.trivyignore-path }}"
+            cat "${{ inputs.trivyignore-path }}"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "No trivyignore file found at: ${{ inputs.trivyignore-path }}"
+          fi
 
       - name: Trivy SBOM scan (runtime)
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
@@ -155,6 +180,7 @@ jobs:
           format: table
           severity: ${{ inputs.severity-threshold }}
           exit-code: ${{ inputs.fail-on-vulnerabilities && '1' || '0' }}
+          trivyignores: ${{ steps.trivyignore.outputs.exists == 'true' && inputs.trivyignore-path || '' }}
 
       - name: Trivy SBOM scan (runtime - detailed report)
         if: always()
@@ -164,13 +190,7 @@ jobs:
           scan-ref: sbom-runtime.json
           format: sarif
           output: trivy-runtime-results.sarif
-
-      # Checkout required for SARIF upload - action needs git context for commit SHA
-      - name: Checkout repository (for SARIF upload context)
-        if: always()
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          sparse-checkout: .  # Minimal checkout, just need .git directory
+          trivyignores: ${{ steps.trivyignore.outputs.exists == 'true' && inputs.trivyignore-path || '' }}
 
       - name: Upload Trivy results to GitHub Security tab
         if: always()


### PR DESCRIPTION
## Summary
- Add `trivyignore-path` input parameter to the Python SBOM reusable workflow
- Allows downstream repos to specify a `.trivyignore` file for suppressing known vulnerabilities

## Changes
- Add `trivyignore-path` input (defaults to `.trivyignore`)
- Checkout repo early to access the trivyignore file
- Check if trivyignore file exists before passing to trivy-action
- Pass `trivyignores` parameter to both trivy scans

## Use Case
This enables repos to document and suppress:
- False positives in security scans
- Vulnerabilities with no available fix (e.g., transitive dependencies)

## Testing
Tested in homelab-infra with CVE-2026-0994 (protobuf vulnerability with no fix available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)