### PR TITLE
feat(workflows): add trivyignore support, JUnit test analytics, and per-flag Codecov uploads

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -282,6 +282,8 @@ jobs:
             --cov-report=xml:coverage-unit.xml \
             --cov-report=term-missing \
             --cov-branch \
+            --junitxml=junit-unit.xml \
+            -o junit_family=xunit2 \
             -v
           echo "::endgroup::"
 
@@ -296,6 +298,8 @@ jobs:
             --cov-report=term-missing \
             --cov-branch \
             --cov-append \
+            --junitxml=junit-integration.xml \
+            -o junit_family=xunit2 \
             -v || echo "No integration tests found or all skipped"
           echo "::endgroup::"
 
@@ -310,6 +314,8 @@ jobs:
             --cov-report=term-missing \
             --cov-branch \
             --cov-append \
+            --junitxml=junit-security.xml \
+            -o junit_family=xunit2 \
             -v || echo "No security tests found or all skipped"
           echo "::endgroup::"
 
@@ -348,10 +354,45 @@ jobs:
           path: |
             coverage.xml
             coverage-*.xml
+            junit-*.xml
             htmlcov/
           retention-days: 7
 
-      - name: Upload coverage to Codecov
+      # Upload per-flag coverage so codecov.yml flag_management thresholds are enforced
+      - name: Upload unit coverage to Codecov
+        if: inputs.enable-codecov
+        uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          files: ./coverage-unit.xml
+          flags: unit
+          name: unit-coverage
+          fail_ci_if_error: false
+
+      - name: Upload integration coverage to Codecov
+        if: inputs.enable-codecov && inputs.run-integration-tests
+        uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          files: ./coverage-integration.xml
+          flags: integration
+          name: integration-coverage
+          fail_ci_if_error: false
+
+      - name: Upload security coverage to Codecov
+        if: inputs.enable-codecov && inputs.run-security-tests
+        uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          files: ./coverage-security.xml
+          flags: security
+          name: security-coverage
+          fail_ci_if_error: false
+
+      - name: Upload combined coverage to Codecov
         if: inputs.enable-codecov
         uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
         with:
@@ -360,6 +401,40 @@ jobs:
           files: ./coverage.xml
           flags: python-${{ inputs.python-version }}
           name: combined-coverage
+          fail_ci_if_error: false
+
+      # Upload JUnit XML for Codecov Test Analytics (flaky tests, timing, pass/fail trends)
+      - name: Upload unit test analytics to Codecov
+        if: inputs.enable-codecov
+        uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          files: ./junit-unit.xml
+          flags: unit
+          report_type: test_results
+          fail_ci_if_error: false
+
+      - name: Upload integration test analytics to Codecov
+        if: inputs.enable-codecov && inputs.run-integration-tests
+        uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          files: ./junit-integration.xml
+          flags: integration
+          report_type: test_results
+          fail_ci_if_error: false
+
+      - name: Upload security test analytics to Codecov
+        if: inputs.enable-codecov && inputs.run-security-tests
+        uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          files: ./junit-security.xml
+          flags: security
+          report_type: test_results
           fail_ci_if_error: false
 
   # ============================================================================

--- a/.github/workflows/python-codecov.yml
+++ b/.github/workflows/python-codecov.yml
@@ -42,10 +42,16 @@ on:
         default: 'coverage-reports'
 
       coverage-files:
-        description: 'Glob pattern for coverage files within artifact'
+        description: 'Glob pattern for coverage XML files within artifact'
         type: string
         required: false
-        default: '*.xml'
+        default: 'coverage*.xml'
+
+      junit-files:
+        description: 'Glob pattern for JUnit XML files for Test Analytics (leave empty to skip)'
+        type: string
+        required: false
+        default: 'junit-*.xml'
 
       flags:
         description: 'Codecov flags (comma-separated)'
@@ -130,7 +136,7 @@ jobs:
           echo "Coverage files found:"
           find coverage/ -name "${{ inputs.coverage-files }}" -type f | head -20
 
-      - name: Upload to Codecov
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
         with:
           directory: coverage/
@@ -144,6 +150,20 @@ jobs:
           # For workflow_run triggers, specify the commit
           commit_parent: ${{ inputs.commit-sha || github.sha }}
 
+      - name: Upload test analytics to Codecov
+        if: ${{ inputs.junit-files != '' }}
+        uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1
+        with:
+          directory: coverage/
+          files: ${{ inputs.junit-files }}
+          flags: ${{ inputs.flags }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          report_type: test_results
+          fail_ci_if_error: ${{ inputs.fail-ci-if-error }}
+          verbose: ${{ inputs.verbose }}
+          commit_parent: ${{ inputs.commit-sha || github.sha }}
+
       - name: Coverage Upload Summary
         if: always()
         env:
@@ -154,8 +174,10 @@ jobs:
           echo "## Codecov Upload Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          FILE_COUNT=$(find coverage/ -name "$COVERAGE_FILES" -type f | wc -l)
-          echo "**Files Uploaded:** $FILE_COUNT" >> $GITHUB_STEP_SUMMARY
+          COVERAGE_COUNT=$(find coverage/ -name "$COVERAGE_FILES" -type f 2>/dev/null | wc -l)
+          JUNIT_COUNT=$(find coverage/ -name "junit-*.xml" -type f 2>/dev/null | wc -l)
+          echo "**Coverage Files Uploaded:** $COVERAGE_COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "**Test Analytics (JUnit) Files:** $JUNIT_COUNT" >> $GITHUB_STEP_SUMMARY
 
           if [ -n "$CODECOV_FLAGS" ]; then
             echo "**Flags:** $CODECOV_FLAGS" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Extends the reusable Python CI/SBOM workflows with three enhancements: trivyignore
support for suppressing known CVEs in SBOM scans, per-flag Codecov coverage uploads
so flag-level thresholds are independently enforced, and JUnit XML test analytics
for flaky test detection and timing trends in Codecov.

## Changes

- **python-sbom.yml**: Add `trivyignore-path` input (default `.trivyignore`); checkout repo early and conditionally pass `trivyignores` to both trivy scans
- **python-ci.yml**: Add `--junitxml` + `-o junit_family=xunit2` to pytest runs; split combined Codecov upload into per-flag uploads (unit, integration, security, combined); add test analytics uploads using `report_type: test_results`
- **python-codecov.yml**: Add `junit-files` input for test analytics; add second upload step for JUnit files; fix `coverage-files` default from `*.xml` → `coverage*.xml` to prevent JUnit files from being treated as coverage; improve summary counts

## Impact

- ✅ Downstream repos can suppress known/accepted CVEs via `.trivyignore`
- ✅ Flag-level Codecov thresholds (unit/integration/security) now enforced independently
- ✅ Codecov Test Analytics enabled for flaky test detection and timing history
- ✅ No breaking changes — all new inputs have safe defaults

## Testing

- [ ] Workflow syntax valid (`actionlint` / GitHub Actions parser)
- [ ] Downstream repo runs CI with `.trivyignore` to confirm suppression
- [ ] Codecov dashboard shows per-flag coverage and test analytics after first run

## Notes

`scripts/calculate-image-storage.sh` is untracked locally and excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipelines to generate and upload detailed test analytics alongside coverage reports to Codecov
  * Improved coverage tracking with separate reporting for unit, integration, and security test suites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->