### PR TITLE
fix(ci): anchor SBOM output path to GITHUB_WORKSPACE

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -120,19 +120,28 @@ jobs:
         run: |
           cyclonedx-py environment \
             --output-format JSON \
-            --outfile sbom-runtime.json \
+            --outfile "$GITHUB_WORKSPACE/sbom-runtime.json" \
             .venv/bin/python3
-          if [ ! -f sbom-runtime.json ]; then
-            echo "::error::cyclonedx-py exited 0 but sbom-runtime.json was not created"
+          if [ ! -s "$GITHUB_WORKSPACE/sbom-runtime.json" ]; then
+            echo "::error::sbom-runtime.json is missing or empty in $GITHUB_WORKSPACE"
+            echo "Workspace contents:"
+            ls -la "$GITHUB_WORKSPACE"
             exit 1
           fi
-          echo "SBOM generated: $(wc -c < sbom-runtime.json) bytes"
+          echo "SBOM generated: $(wc -c < "$GITHUB_WORKSPACE/sbom-runtime.json") bytes"
+
+      - name: Verify SBOM files before upload
+        run: |
+          echo "Working directory : $(pwd)"
+          echo "GITHUB_WORKSPACE  : $GITHUB_WORKSPACE"
+          echo "sbom-*.json files :"
+          find "$GITHUB_WORKSPACE" -maxdepth 1 -name "sbom-*.json" -ls
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: sboms
-          path: sbom-*.json
+          path: ${{ github.workspace }}/sbom-*.json
           retention-days: ${{ inputs.artifact-retention-days }}
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary

The `Generate runtime SBOM` step was writing `sbom-runtime.json` relative to the shell's CWD. In a reusable workflow (`workflow_call`) the shell CWD and `$GITHUB_WORKSPACE` can diverge, so the file landed outside the workspace root that `upload-artifact` v4 resolves globs against. The upload step then reported "No files were found with the provided path: sbom-*.json" even though `wc -c` showed the file at 17768 bytes (confirmed in run 24250664647).

## Changes

- **Absolute `--outfile` path**: `--outfile "$GITHUB_WORKSPACE/sbom-runtime.json"` anchors the output file to the same root that `upload-artifact` uses, eliminating the CWD vs workspace ambiguity.
- **Hardened guard**: upgraded from `-f` (file exists) to `-s` (file non-empty) so the guard also catches the 0-byte output that `cyclonedx-py` produces when the interpreter path is missing.
- **Absolute upload `path`**: changed from `sbom-*.json` to `${{ github.workspace }}/sbom-*.json` so the upload glob roots from the same absolute location the file was written to.
- **Diagnostic step**: added `Verify SBOM files before upload` that logs `pwd`, `$GITHUB_WORKSPACE`, and a `find` listing of matching files — provides immediate evidence if this class of failure recurs without needing to re-diagnose from scratch.

## Impact

- Fixes the artifact-not-found failure that has been breaking every SBOM run since at least March 2026
- No interface changes for callers

## Testing

- [ ] Trigger the SBOM workflow in a calling repo and confirm the `Verify SBOM files before upload` step shows the file
- [ ] Confirm `scan-runtime` and `license-compliance` jobs run and complete

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved SBOM artifact generation with enhanced validation and diagnostic checks to ensure more reliable build process artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->