### PR TITLE
fix(ci): downgrade upload-artifact to v4.5.0 to fix glob resolver

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -138,7 +138,7 @@ jobs:
           find "$GITHUB_WORKSPACE" -maxdepth 1 -name "sbom-*.json" -ls
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
         with:
           name: sboms
           path: ${{ github.workspace }}/sbom-*.json


### PR DESCRIPTION
## Summary

`actions/upload-artifact` v4.6.2 (`ea165f8d`) has a broken glob resolver that fails to match files via absolute paths on current GitHub-hosted runners. The SBOM file is confirmed present at `$GITHUB_WORKSPACE/sbom-runtime.json` (17,768 bytes, verified by the diagnostic step added in #26) but the upload step reports "No files were found with the provided path".

Downgrading to v4.5.0 (`6f51ac03`), which uses `@actions/glob` v0.5.x with a working resolver.

## Changes

- **upload-artifact**: `ea165f8d` (v4.6.2) → `6f51ac03` (v4.5.0)
- **download-artifact**: already at `d3f86a10` (v4.3.0) from #25 — no change needed; v4.5.0 upload + v4.3.0 download are compatible

## Evidence

From run 24250664647 (PR #26, after anchoring to `$GITHUB_WORKSPACE`):

```
Verify SBOM files before upload:
  354173  20 -rw-r--r-- 1 runner runner 17768 Apr 10 17:01
    /home/runner/work/.claude/.claude/sbom-runtime.json

Upload SBOM artifacts:
  ##[error] No files were found with the provided path:
    /home/runner/work/.claude/.claude/sbom-*.json
```

File exists, path matches, glob fails — consistent with a resolver bug in v4.6.2.

## Note on version label

The current SHA was annotated `# v4.6.2` (correct — it does resolve to v4.6.2, not v3). The glob breakage is a regression in that release, not a version mismatch.

## Testing

- [ ] Trigger the SBOM workflow and confirm the upload step finds `sbom-runtime.json`
- [ ] Confirm `scan-runtime` and `license-compliance` jobs receive the artifact and complete

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow artifact upload configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->