### PR TITLE
fix(ci): use relative path for upload-artifact glob

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
         with:
           name: sboms
-          path: ${{ github.workspace }}/sbom-*.json
+          path: sbom-*.json
           retention-days: ${{ inputs.artifact-retention-days }}
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary

`upload-artifact@v4` requires a workspace-relative path. The absolute `${{ github.workspace }}/sbom-*.json` introduced in #26 caused the upload to fail even though the file existed at that exact path — confirmed by the Verify step in run 24256290551:

```
GITHUB_WORKSPACE  : /home/runner/work/.claude/.claude
sbom-*.json files :
  354171  20 -rw-r--r-- 1 runner runner 17768 Apr 10 17:48
    /home/runner/work/.claude/.claude/sbom-runtime.json

path: /home/runner/work/.claude/.claude/sbom-*.json
##[error] No files were found with the provided path:
  /home/runner/work/.claude/.claude/sbom-*.json
```

The action resolves globs from `$GITHUB_WORKSPACE` by default, so the bare relative glob is correct.

## Changes

- `path: ${{ github.workspace }}/sbom-*.json` → `path: sbom-*.json`

## Testing

- [ ] Trigger the SBOM workflow and confirm upload succeeds
- [ ] Confirm `scan-runtime` and `license-compliance` jobs receive the artifact

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact upload configuration in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->