### PR TITLE
fix(ci): resolve upload-artifact path via github.workspace context

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
         with:
           name: sboms
-          path: sbom-*.json
+          path: ${{ github.workspace }}/sbom-*.json
           retention-days: ${{ inputs.artifact-retention-days }}
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary

In a reusable (`workflow_call`) workflow the runner process CWD is not guaranteed to be `$GITHUB_WORKSPACE`. The relative glob `sbom-*.json` therefore resolves to the wrong directory, confirmed failing in run 24256519203 even with the file present at `$GITHUB_WORKSPACE/sbom-runtime.json`.

Using `${{ github.workspace }}/sbom-*.json` gives `upload-artifact@v4` the workspace root as a context expression evaluated before the glob resolver runs, so the path is correct regardless of process CWD.

## Diagnosis path

| PR | Upload path | Result |
|---|---|---|
| #26 | `${{ github.workspace }}/sbom-*.json` with v4.6.2 | failed — v4.6.2 glob bug |
| #27 | `${{ github.workspace }}/sbom-*.json` with v4.5.0 | merged without test run |
| #28 | `sbom-*.json` (relative) with v4.5.0 | failed — CWD ≠ GITHUB_WORKSPACE |
| #29 | `${{ github.workspace }}/sbom-*.json` with v4.5.0 | to test |

The combination of v4.5.0 + `${{ github.workspace }}` context path has not yet had a clean test run.

## Testing

- [ ] Trigger the SBOM workflow and confirm upload succeeds
- [ ] Confirm `scan-runtime` and `license-compliance` jobs receive the artifact

🤖 Generated with [Claude Code](https://claude.ai/code)