### PR TITLE
chore(security): fix SonarCloud vulnerabilities and coding standards

### DIFF
--- a/.github/workflows/python-codecov.yml
+++ b/.github/workflows/python-codecov.yml
@@ -132,9 +132,11 @@ jobs:
           path: coverage/
 
       - name: List coverage files
+        env:
+          COVERAGE_FILES: ${{ inputs.coverage-files }}
         run: |
           echo "Coverage files found:"
-          find coverage/ -name "${{ inputs.coverage-files }}" -type f | head -20
+          find coverage/ -name "$COVERAGE_FILES" -type f | head -20
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@af2c6347526edfe5ff45ad690affad475d77ddb4  # v5.3.1

--- a/.github/workflows/python-slsa.yml
+++ b/.github/workflows/python-slsa.yml
@@ -31,7 +31,7 @@
 #         actions: read
 #         id-token: write
 #         contents: write
-#       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+#       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563  # v2.0.0
 #       with:
 #         base64-subjects: ${{ needs.build.outputs.hashes }}
 #         upload-assets: true
@@ -91,7 +91,7 @@ jobs:
   provenance:
     name: Generate SLSA Provenance
     # Use the official SLSA generator directly
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563  # v2.0.0
     with:
       base64-subjects: ${{ inputs.base64-subjects }}
       upload-assets: ${{ inputs.upload-assets }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project's shared workflow templates are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Security
+- Fix script injection vulnerability in `python-codecov.yml`: move `inputs.coverage-files` to env var before shell use (SonarCloud S7630)
+- Pin `slsa-framework/slsa-github-generator` to full commit SHA in `python-slsa.yml` (SonarCloud S7637)
+
+### Changed
+- Replace em-dashes with colons in `scripts/update-pinned-actions.sh` and `SUPPORT.md`
+
+## [2026-04-13]
+
+### Fixed
+- LLM governance: replace `fromJSON` with direct numeric comparison for `critical_tags`
+- LLM governance: only block PRs on `#CRITICAL` tags; demote `#ASSUME` to warning
+- Security: add `pull-requests: read` permission to detect-changes job
+- CI: move `fromJSON` to outer level in matrix strategy ternary
+
+## [2026-04-10]
+
+### Changed
+- Update action pins ahead of Node.js 20 deprecation deadlines
+
+### Fixed
+- SBOM: use exact filename for `upload-artifact` path
+- SBOM: resolve `upload-artifact` path via `github.workspace` context
+- SBOM: downgrade `upload-artifact` to v4.5.0 to fix glob resolver
+- SBOM: anchor SBOM output path to `GITHUB_WORKSPACE`
+- SBOM: repair silent generation failure in `python-sbom` workflow
+
+## [2026-04-05]
+
+### Added
+- Trivy `.trivyignore` file support in container security workflow
+- Harbor registry setup documentation
+
+## [2025-11-23]
+
+### Added
+- Initial reusable workflow library for Python projects
+- Workflows: CI, PR validation, coverage upload, SLSA provenance, SBOM, security analysis, SonarCloud, ScoreCard, release, publish to PyPI
+- Shared community health files: SECURITY.md, CONTRIBUTING.md, SUPPORT.md, issue templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix script injection vulnerability in `python-codecov.yml`: move `inputs.coverage-files` to env var before shell use (SonarCloud S7630)
 - Pin `slsa-framework/slsa-github-generator` to full commit SHA in `python-slsa.yml` (SonarCloud S7637)
 
+### Added
+- `scripts/update-pinned-actions.sh`: developer tool to scan workflow files for outdated pinned action SHAs and propose or apply updates within the same major version
+- `CHANGELOG.md`: required OpenSSF baseline file
+
 ### Changed
-- Replace em-dashes with colons in `scripts/update-pinned-actions.sh` and `SUPPORT.md`
+- Replace em-dash with semicolon in `SUPPORT.md`
 
 ## [2026-04-13]
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,7 +1,7 @@
 # Support
 
 Thank you for using projects maintained by our organization. Support is
-provided on a voluntary basis by a solo contributor with zero budget—your
+provided on a voluntary basis by a solo contributor with zero budget; your
 contributions of knowledge, bug reports, and fixes are highly appreciated.
 
 ## Support Channels

--- a/scripts/update-pinned-actions.sh
+++ b/scripts/update-pinned-actions.sh
@@ -46,7 +46,14 @@ usage() {
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --apply)           APPLY=true; shift ;;
-        --workflows-dir)   WORKFLOWS_DIR="$2"; shift 2 ;;
+        --workflows-dir)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo -e "${RED}ERROR: --workflows-dir requires a directory path${NC}"
+                usage
+            fi
+            WORKFLOWS_DIR="$2"
+            shift 2
+            ;;
         -h|--help)         usage ;;
         *) echo -e "${RED}Unknown option: $1${NC}"; usage ;;
     esac
@@ -88,18 +95,13 @@ resolve_tag_sha() {
     local repo="$1"
     local tag="$2"
 
-    local ref_json
-    ref_json=$(gh api "repos/$repo/git/refs/tags/$tag" 2>/dev/null) || { echo ""; return; }
-
     local obj_type obj_sha
-    obj_type=$(echo "$ref_json" | grep -o '"type":"[^"]*"' | head -1 | cut -d'"' -f4)
-    obj_sha=$(echo "$ref_json"  | grep -o '"sha":"[^"]*"'  | head -1 | cut -d'"' -f4)
+    obj_type=$(gh api "repos/$repo/git/refs/tags/$tag" --jq '.object.type' 2>/dev/null) || { echo ""; return; }
+    obj_sha=$(gh api "repos/$repo/git/refs/tags/$tag" --jq '.object.sha' 2>/dev/null) || { echo ""; return; }
 
     if [[ "$obj_type" == "tag" ]]; then
-        # Annotated tag: dereference to get the commit SHA
-        local tag_obj
-        tag_obj=$(gh api "repos/$repo/git/tags/$obj_sha" 2>/dev/null) || { echo ""; return; }
-        obj_sha=$(echo "$tag_obj" | grep -o '"sha":"[^"]*"' | tail -1 | cut -d'"' -f4)
+        # Annotated tag: resolve tag object to its target commit SHA
+        obj_sha=$(gh api "repos/$repo/git/tags/$obj_sha" --jq '.object.sha' 2>/dev/null) || { echo ""; return; }
     fi
 
     echo "$obj_sha"
@@ -116,7 +118,7 @@ trap 'rm -f "$UNIQUE_ACTIONS_FILE" "$CHANGE_LOG"' EXIT
 grep -rh "uses:" "$WORKFLOWS_DIR"/ \
     | grep -oE '[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_./-]*)?@[a-f0-9]{40}[[:space:]]+#[[:space:]]+v[0-9]+(\.[0-9.]+)*' \
     | sort -u \
-    > "$UNIQUE_ACTIONS_FILE"
+    > "$UNIQUE_ACTIONS_FILE" || true
 
 TOTAL=$(wc -l < "$UNIQUE_ACTIONS_FILE" | tr -d ' ')
 echo "Found $TOTAL unique pinned action references"
@@ -133,7 +135,7 @@ while IFS= read -r entry; do
 
     # Parse fields from the entry string
     full_action="${entry%%@*}"
-    current_sha=$(echo "$entry" | grep -oE '[a-f0-9]{40}')
+    current_sha=$(echo "$entry" | grep -oE '[a-f0-9]{40}' | head -1)
     current_version=$(echo "$entry" | grep -oE 'v[0-9]+(\.[0-9]+)*$')
 
     # Derive the repo (first two path segments, strip any sub-action path)
@@ -145,7 +147,7 @@ while IFS= read -r entry; do
     # Find the latest release tag within the same major version
     latest_version=$(
         gh release list --repo "$repo" --limit 50 --json tagName \
-            --jq "[.[] | select(.tagName | test(\"^${major}[.]\"))] | first | .tagName // empty" \
+            --jq "[.[] | select(.tagName | test(\"^${major}[.]\")) | .tagName] | sort_by(split(\".\") | map(ltrimstr(\"v\") | tonumber? // 0)) | reverse | first // empty" \
             2>/dev/null || true
     )
 
@@ -235,9 +237,11 @@ declare -A FILES_CHANGED
 while IFS='|' read -r full_action current_sha current_version new_sha latest_version; do
     # Find every workflow file containing this action+sha and update it
     while IFS= read -r wf_file; do
-        sed -i \
+        tmp_wf=$(mktemp)
+        sed \
             "s|${full_action}@${current_sha}[[:space:]]*#[[:space:]]*${current_version}|${full_action}@${new_sha}  # ${latest_version}|g" \
-            "$wf_file"
+            "$wf_file" > "$tmp_wf"
+        mv "$tmp_wf" "$wf_file"
         FILES_CHANGED["$wf_file"]=1
     done < <(grep -rl "${full_action}@${current_sha}" "$WORKFLOWS_DIR"/ 2>/dev/null)
 

--- a/scripts/update-pinned-actions.sh
+++ b/scripts/update-pinned-actions.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# =============================================================================
+# GitHub Actions Pin Updater
+# =============================================================================
+# Scans workflow files for pinned GitHub Actions and checks for updates within
+# the same major version. Fetches the latest commit SHA for each action's
+# current major version tag via the GitHub API.
+#
+# Dry-run by default: shows proposed changes without modifying files.
+# After manual review, re-run with --apply to write changes.
+#
+# Usage:
+#   ./scripts/update-pinned-actions.sh
+#   ./scripts/update-pinned-actions.sh --apply
+#   ./scripts/update-pinned-actions.sh --workflows-dir .github/workflows
+#
+# Options:
+#   --apply            Write changes to workflow files (default: dry-run)
+#   --workflows-dir    Override workflow directory (default: .github/workflows)
+#   -h, --help         Show this help
+#
+# Requirements:
+#   - gh CLI installed and authenticated (gh auth login)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+APPLY=false
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+usage() {
+    sed -n '/^# Usage:/,/^# Requirements:/p' "$0" | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply)           APPLY=true; shift ;;
+        --workflows-dir)   WORKFLOWS_DIR="$2"; shift 2 ;;
+        -h|--help)         usage ;;
+        *) echo -e "${RED}Unknown option: $1${NC}"; usage ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+if ! command -v gh &>/dev/null; then
+    echo -e "${RED}ERROR: gh CLI not found. Install from https://cli.github.com${NC}"
+    exit 1
+fi
+
+if ! gh auth status &>/dev/null 2>&1; then
+    echo -e "${RED}ERROR: gh CLI not authenticated. Run: gh auth login${NC}"
+    exit 1
+fi
+
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+    echo -e "${RED}ERROR: Workflows directory not found: $WORKFLOWS_DIR${NC}"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}╔══════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║      GitHub Actions Pin Updater              ║${NC}"
+echo -e "${BLUE}╚══════════════════════════════════════════════╝${NC}"
+echo ""
+echo "  Mode : $([ "$APPLY" = true ] && echo -e "${YELLOW}APPLY: files will be modified${NC}" || echo -e "${CYAN}DRY RUN: no files will be changed${NC}")"
+echo "  Dir  : $WORKFLOWS_DIR"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Resolve a tag to its commit SHA (handles annotated + lightweight tags)
+# ---------------------------------------------------------------------------
+resolve_tag_sha() {
+    local repo="$1"
+    local tag="$2"
+
+    local ref_json
+    ref_json=$(gh api "repos/$repo/git/refs/tags/$tag" 2>/dev/null) || { echo ""; return; }
+
+    local obj_type obj_sha
+    obj_type=$(echo "$ref_json" | grep -o '"type":"[^"]*"' | head -1 | cut -d'"' -f4)
+    obj_sha=$(echo "$ref_json"  | grep -o '"sha":"[^"]*"'  | head -1 | cut -d'"' -f4)
+
+    if [[ "$obj_type" == "tag" ]]; then
+        # Annotated tag: dereference to get the commit SHA
+        local tag_obj
+        tag_obj=$(gh api "repos/$repo/git/tags/$obj_sha" 2>/dev/null) || { echo ""; return; }
+        obj_sha=$(echo "$tag_obj" | grep -o '"sha":"[^"]*"' | tail -1 | cut -d'"' -f4)
+    fi
+
+    echo "$obj_sha"
+}
+
+# ---------------------------------------------------------------------------
+# Extract unique pinned action references from all workflow files
+# Pattern: uses: owner/repo[/subpath]@<40-char-sha>  # vX.Y.Z
+# ---------------------------------------------------------------------------
+UNIQUE_ACTIONS_FILE=$(mktemp)
+CHANGE_LOG=$(mktemp)
+trap 'rm -f "$UNIQUE_ACTIONS_FILE" "$CHANGE_LOG"' EXIT
+
+grep -rh "uses:" "$WORKFLOWS_DIR"/ \
+    | grep -oE '[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_./-]*)?@[a-f0-9]{40}[[:space:]]+#[[:space:]]+v[0-9]+(\.[0-9.]+)*' \
+    | sort -u \
+    > "$UNIQUE_ACTIONS_FILE"
+
+TOTAL=$(wc -l < "$UNIQUE_ACTIONS_FILE" | tr -d ' ')
+echo "Found $TOTAL unique pinned action references"
+echo ""
+printf "%-55s %-10s   %s\n" "Action" "Current" "Latest"
+printf '%0.s─' {1..80}; echo ""
+
+UP_TO_DATE=0
+UPDATES=0
+SKIPPED=0
+
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+
+    # Parse fields from the entry string
+    full_action="${entry%%@*}"
+    current_sha=$(echo "$entry" | grep -oE '[a-f0-9]{40}')
+    current_version=$(echo "$entry" | grep -oE 'v[0-9]+(\.[0-9]+)*$')
+
+    # Derive the repo (first two path segments, strip any sub-action path)
+    repo=$(echo "$full_action" | awk -F/ '{print $1"/"$2}')
+
+    # Major version prefix for filtering releases (e.g. "v4" from "v4.2.2")
+    major=$(echo "$current_version" | grep -oE '^v[0-9]+')
+
+    # Find the latest release tag within the same major version
+    latest_version=$(
+        gh release list --repo "$repo" --limit 50 --json tagName \
+            --jq "[.[] | select(.tagName | test(\"^${major}[.]\"))] | first | .tagName // empty" \
+            2>/dev/null || true
+    )
+
+    # Some repos tag without a patch component (e.g. v2 only); fall back gracefully
+    if [[ -z "$latest_version" ]]; then
+        latest_version=$(
+            gh release list --repo "$repo" --limit 50 --json tagName \
+                --jq "[.[] | select(.tagName == \"${major}\")] | first | .tagName // empty" \
+                2>/dev/null || true
+        )
+    fi
+
+    if [[ -z "$latest_version" ]]; then
+        printf "%-55s %-10s   %b\n" "$full_action" "$current_version" "${YELLOW}SKIP: no releases found${NC}"
+        ((SKIPPED++)) || true
+        continue
+    fi
+
+    # Resolve the latest version tag to its commit SHA
+    new_sha=$(resolve_tag_sha "$repo" "$latest_version")
+
+    if [[ -z "$new_sha" ]]; then
+        printf "%-55s %-10s   %b\n" "$full_action" "$current_version" "${YELLOW}SKIP: could not resolve SHA${NC}"
+        ((SKIPPED++)) || true
+        continue
+    fi
+
+    if [[ "$current_sha" == "$new_sha" && "$current_version" == "$latest_version" ]]; then
+        printf "%-55s %-10s   %b\n" "$full_action" "$current_version" "${GREEN}up to date${NC}"
+        ((UP_TO_DATE++)) || true
+    else
+        printf "%-55s %-10s → %b\n" "$full_action" "$current_version" "${YELLOW}${latest_version}  (${new_sha:0:12}...)${NC}"
+        printf '%s|%s|%s|%s|%s\n' \
+            "$full_action" "$current_sha" "$current_version" "$new_sha" "$latest_version" \
+            >> "$CHANGE_LOG"
+        ((UPDATES++)) || true
+    fi
+
+done < "$UNIQUE_ACTIONS_FILE"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '%0.s─' {1..80}; echo ""
+echo ""
+echo -e "  ${GREEN}Up to date : $UP_TO_DATE${NC}"
+echo -e "  ${YELLOW}Updates    : $UPDATES${NC}"
+[[ $SKIPPED -gt 0 ]] && echo -e "  ${YELLOW}Skipped    : $SKIPPED (check manually)${NC}"
+echo ""
+
+if [[ $UPDATES -eq 0 ]]; then
+    echo -e "${GREEN}All pinned actions are up to date.${NC}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Detailed change summary (always shown, regardless of --apply)
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}Proposed changes:${NC}"
+echo ""
+while IFS='|' read -r full_action current_sha current_version new_sha latest_version; do
+    echo -e "  ${CYAN}$full_action${NC}"
+    echo    "    - $current_version  @$current_sha"
+    echo    "    + $latest_version  @$new_sha"
+    echo ""
+done < "$CHANGE_LOG"
+
+# ---------------------------------------------------------------------------
+# Dry-run exit
+# ---------------------------------------------------------------------------
+if [[ "$APPLY" = false ]]; then
+    echo -e "${CYAN}DRY RUN complete: no files were changed.${NC}"
+    echo ""
+    echo "Review the changes above, then run with --apply to update workflow files:"
+    echo "  ./scripts/update-pinned-actions.sh --apply"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Apply changes
+# ---------------------------------------------------------------------------
+echo -e "${YELLOW}Applying changes...${NC}"
+echo ""
+
+declare -A FILES_CHANGED
+
+while IFS='|' read -r full_action current_sha current_version new_sha latest_version; do
+    # Find every workflow file containing this action+sha and update it
+    while IFS= read -r wf_file; do
+        sed -i \
+            "s|${full_action}@${current_sha}[[:space:]]*#[[:space:]]*${current_version}|${full_action}@${new_sha}  # ${latest_version}|g" \
+            "$wf_file"
+        FILES_CHANGED["$wf_file"]=1
+    done < <(grep -rl "${full_action}@${current_sha}" "$WORKFLOWS_DIR"/ 2>/dev/null)
+
+done < "$CHANGE_LOG"
+
+echo "Files updated:"
+for f in "${!FILES_CHANGED[@]}"; do
+    echo "  $(basename "$f")"
+done | sort
+
+echo ""
+echo -e "${GREEN}Done.${NC}"
+echo ""
+echo "Next steps:"
+echo "  1. git diff .github/workflows/   # review all changes"
+echo "  2. Trigger a workflow run to validate nothing broke"
+echo "  3. git add .github/workflows/ && git commit -m 'chore(ci): bump pinned action SHAs to latest'"


### PR DESCRIPTION
## Summary

- **Fix S7630 (BLOCKER):** Move `inputs.coverage-files` to `env:` block in `python-codecov.yml` before shell use, eliminating script injection vulnerability in the `run:` step
- **Fix S7637 (hotspot):** Pin `slsa-framework/slsa-github-generator` to full commit SHA `5a775b36` instead of mutable `@v2.0.0` tag in `python-slsa.yml`
- **Coding standards:** Replace all em-dashes with colons/semicolons in `scripts/update-pinned-actions.sh` and `SUPPORT.md` per global writing rules
- **OpenSSF baseline:** Add missing `CHANGELOG.md` (required alongside LICENSE, SECURITY.md, CONTRIBUTING.md, README.md)

## Test Plan

- [ ] SonarCloud re-analysis confirms S7630 and S7637 are resolved after merge
- [ ] Quality gate remains PASSED (was OK before this branch)
- [ ] No em-dashes present in any file (`grep -r "—" .` returns nothing)
- [ ] `CHANGELOG.md` exists and passes any future OpenSSF file checks

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Mitigated a script-injection risk in workflow usage and pinned a workflow dependency to a specific commit SHA.

* **Documentation**
  * Added a comprehensive changelog documenting recent fixes, tooling, and history; minor wording cleanup in support docs.

* **New Features**
  * Added a utility to detect and (optionally) update pinned workflow action SHAs.

* **Chores**
  * Updated workflow configurations for more robust dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->