### PR TITLE
fix(docs): address remaining audit followup items

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -455,7 +455,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -590,7 +590,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -656,7 +656,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-codecov.yml
+++ b/.github/workflows/python-codecov.yml
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-container-security.yml
+++ b/.github/workflows/python-container-security.yml
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -231,7 +231,7 @@ jobs:
 
       - name: Trivy vulnerability scan
         if: steps.image.outputs.ref != ''
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.image.outputs.ref }}
           format: 'table'
@@ -241,7 +241,7 @@ jobs:
 
       - name: Trivy SARIF report
         if: ${{ inputs.upload-sarif && steps.image.outputs.ref != '' }}
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.image.outputs.ref }}
           format: 'sarif'
@@ -258,7 +258,7 @@ jobs:
 
       - name: Generate container SBOM
         if: ${{ inputs.generate-sbom && steps.image.outputs.ref != '' }}
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.image.outputs.ref }}
           format: 'cyclonedx'

--- a/.github/workflows/python-docker.yml
+++ b/.github/workflows/python-docker.yml
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -316,7 +316,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (local image)
         if: inputs.enable-trivy-scan && steps.push-check.outputs.push != 'true'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           input: '/tmp/image.tar'
           format: 'sarif'
@@ -326,7 +326,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (registry image)
         if: inputs.enable-trivy-scan && steps.push-check.outputs.push == 'true'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.image-name.outputs.name }}:${{ github.sha }}
           format: 'sarif'

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-fips-compatibility.yml
+++ b/.github/workflows/python-fips-compatibility.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -332,7 +332,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-fuzzing.yml
+++ b/.github/workflows/python-fuzzing.yml
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-mutation.yml
+++ b/.github/workflows/python-mutation.yml
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-pr-validation.yml
+++ b/.github/workflows/python-pr-validation.yml
@@ -197,7 +197,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -281,7 +281,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -341,7 +341,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -387,7 +387,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -457,7 +457,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-qlty-coverage.yml
+++ b/.github/workflows/python-qlty-coverage.yml
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -153,7 +153,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -119,7 +119,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -308,7 +308,7 @@ jobs:
       url: https://pypi.org/project/${{ inputs.pypi-package-name }}/
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-reuse.yml
+++ b/.github/workflows/python-reuse.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -158,7 +158,7 @@ jobs:
       security-events: write  # Required for SARIF upload
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -188,7 +188,7 @@ jobs:
           fi
 
       - name: Trivy SBOM scan (runtime)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: sbom
           scan-ref: sbom-runtime.json
@@ -199,7 +199,7 @@ jobs:
 
       - name: Trivy SBOM scan (runtime - detailed report)
         if: always()
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: sbom
           scan-ref: sbom-runtime.json
@@ -225,7 +225,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-scorecard.yml
+++ b/.github/workflows/python-scorecard.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -179,7 +179,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -207,7 +207,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -268,7 +268,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-sonarcloud.yml
+++ b/.github/workflows/python-sonarcloud.yml
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/python-supplemental-checks.yml
+++ b/.github/workflows/python-supplemental-checks.yml
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -227,7 +227,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 
@@ -326,7 +326,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: audit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project's shared workflow templates are documented h
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+This project uses date-based version headers (e.g. `[2025-01-07]`) rather than
+semver because it is a shared workflow library with continuous deployment; there
+are no numbered releases.
+
 ## [Unreleased]
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,8 +17,9 @@ next steps via the Security tab.
 
 This repository is a shared workflow library with continuous deployment. There
 are no numbered releases; the `main` branch is always the supported version.
-Callers that pin to a specific commit SHA will receive security fixes when they
-update their pin. All other commits may not contain the latest security patches.
+Callers that pin to a specific commit SHA must update their pin to a newer
+commit on `main` to receive security fixes. Older commits may not contain the
+latest security patches.
 
 ## Security Practices
 
@@ -38,7 +39,7 @@ We track and publish advisories for all confirmed vulnerabilities:
 
 1. **Request a CVE** for issues rated Moderate or above.
 2. **Draft and publish an advisory** in the Security tab.
-3. **Include remediation steps** in release notes and upgrade guide.
+3. **Include remediation steps** in the Security Advisory and CHANGELOG.
 
 ## Response Timeline
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,14 @@
 # Security Policy
 
-## Reporting a Vulnerability  
+## Reporting a Vulnerability
 
 If you discover a security vulnerability in any project under our organization,
 **please do not open a public issue**.
-Instead, use GitHub’s built-in Security advisories feature:  
+Instead, use GitHub's built-in Security advisories feature:
 
-1. Go to the repository’s **Security** tab
-2. Click **“Report a vulnerability”**  
-3. Fill in the details and submit  
+1. Go to the repository's **Security** tab
+2. Click **"Report a vulnerability"**
+3. Fill in the details and submit
 
 All reports will be kept confidential. We commit to acknowledging receipt and
 next steps via the Security tab.
@@ -20,42 +20,42 @@ are no numbered releases; the `main` branch is always the supported version.
 Callers that pin to a specific commit SHA will receive security fixes when they
 update their pin. All other commits may not contain the latest security patches.
 
-## Security Practices  
+## Security Practices
 
 We strive for proactive security across our codebases and infrastructure.
-Our standard practices include:  
+Our standard practices include:
 
-- **Static Analysis** with CodeQL, Semgrep, Ruff, and Bandit  
-- **Dependency Pinning** for reproducible builds  
-- **Container Scanning** using Trivy  
-- **SBOM Generation** for each release  
-- **Secrets Detection** integrated in CI pipelines  
-- **Hardened CI Runners** with minimal privileges  
+- **Static Analysis** with CodeQL, Semgrep, Ruff, and Bandit
+- **Dependency Pinning** for reproducible builds
+- **Container Scanning** using Trivy
+- **SBOM Generation** for each release
+- **Secrets Detection** integrated in CI pipelines
+- **Hardened CI Runners** with minimal privileges
 
-## CVE & Advisory Workflow  
+## CVE & Advisory Workflow
 
 We track and publish advisories for all confirmed vulnerabilities:
 
-1. **Request a CVE** for issues rated Moderate or above.  
-2. **Draft and publish an advisory** in the Security tab.  
-3. **Include remediation steps** in release notes and upgrade guide.  
+1. **Request a CVE** for issues rated Moderate or above.
+2. **Draft and publish an advisory** in the Security tab.
+3. **Include remediation steps** in release notes and upgrade guide.
 
-## Response Timeline  
+## Response Timeline
 
-- **Acknowledgment:** within 5 business days  
-- **Fix released:** within 30 days of acknowledgment  
-- **Emergency patch:** sooner for critical severity  
+- **Acknowledgment:** within 5 business days
+- **Fix released:** within 30 days of acknowledgment
+- **Emergency patch:** sooner for critical severity
 
-## Disclosure Policy  
+## Disclosure Policy
 
 We follow coordinated disclosure principles. Once a fix is available, we will
 publish details in our Security Advisories page. If you wish to receive credit
 for responsibly disclosing a vulnerability, please let us know; otherwise
 credit will be anonymous.
 
-## Credit  
+## Credit
 
 This policy is based on community best practices and has drawn on elements from
-multiple sources within our organization’s previous drafts.
+multiple sources within our organization's previous drafts.
 
-Last updated: November 16, 2025
+Last updated: April 23, 2026

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,16 +13,12 @@ Instead, use GitHub’s built-in Security advisories feature:
 All reports will be kept confidential. We commit to acknowledging receipt and
 next steps via the Security tab.
 
-## Supported Versions  
+## Supported Versions
 
-The following table shows which major releases we support. For full upgrade
-paths and end-of-life schedules, see our [Upgrade Guide][upgrade-guide].
-
-| Version  | Status       |
-|----------|--------------|
-| v3.x     | Supported    |
-| v2.x     | Security-only support |
-| v1.x     | End of life  |
+This repository is a shared workflow library with continuous deployment. There
+are no numbered releases; the `main` branch is always the supported version.
+Callers that pin to a specific commit SHA will receive security fixes when they
+update their pin. All other commits may not contain the latest security patches.
 
 ## Security Practices  
 
@@ -62,6 +58,4 @@ credit will be anonymous.
 This policy is based on community best practices and has drawn on elements from
 multiple sources within our organization’s previous drafts.
 
-_Last updated: November 16, 2025_  
-
-[upgrade-guide]: https://github.com/ByronWilliamsCPA/.github/blob/main/UPGRADE_GUIDE.md  
+Last updated: November 16, 2025

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -27,9 +27,9 @@ contributions of knowledge, bug reports, and fixes are highly appreciated.
 
 ## Supported Versions
 
-Support is typically provided only for actively maintained releases.
-Consult the [Supported Versions](SECURITY.md#supported-versions) section for
-details on which versions are in scope.
+This repository is a shared workflow library with continuous deployment; the
+`main` branch is always the supported version. See [SECURITY.md](SECURITY.md)
+for the full support policy.
 
 ## Response Expectations
 
@@ -42,4 +42,4 @@ details on which versions are in scope.
 We welcome and encourage contributions to improve our support processes.
 Feel free to submit pull requests against this document or associated workflows.
 
-_Last updated: November 16, 2025_  
+Last updated: April 23, 2026

--- a/docs/RECOMMENDED_NEXT_STEPS.md
+++ b/docs/RECOMMENDED_NEXT_STEPS.md
@@ -21,7 +21,7 @@ Based on analysis of enhancement recommendations, I recommend implementing **Pha
 
 ### ✅ Completed: 4 New Reusable Workflows
 
-Created comprehensive reusable workflows for:
+Created reusable workflows for:
 
 1. **[python-fuzzing.yml](../.github/workflows/python-fuzzing.yml)** - ClusterFuzzLite security fuzzing
 2. **[python-performance-regression.yml](../.github/workflows/python-performance-regression.yml)** - Performance testing


### PR DESCRIPTION
## Summary

**Audit followup (3 items):**
- **CHANGELOG.md**: Added a note explaining the intentional date-based versioning scheme; this is a shared workflow library with continuous deployment and no numbered releases.
- **SECURITY.md**: Replaced the placeholder v1.x/v2.x/v3.x supported-versions table with an accurate description. Also removed the orphaned \`[upgrade-guide]\` link definition and fixed an MD036 lint warning.
- **docs/RECOMMENDED_NEXT_STEPS.md:24**: Removed prose AI-pattern word \"comprehensive\".

**Dependency updates (2 actions):**
- \`aquasecurity/trivy-action\`: v0.35.0 -> v0.36.0 (3 workflow files)
- \`step-security/harden-runner\`: v2.18.0 -> v2.19.0 (21 workflow files)

Note: \`slsa-framework/slsa-github-generator\` was flagged as outdatable to v2.1.0-rc.3 but skipped; v2.1.0 is the stable release. The update script picks up pre-release tags via lexicographic comparison.

## Test plan

- [ ] Verify CHANGELOG.md renders correctly on GitHub (date-based versioning note is readable)
- [ ] Verify SECURITY.md no longer references fictional version numbers or upgrade-guide
- [ ] Confirm markdownlint passes (MD036 and MD053 warnings resolved)
- [ ] Verify workflow files reference correct new action SHAs
- [ ] Confirm no regressions in existing workflow behavior

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pinned GitHub Actions for CI security tooling (harden-runner bumped to v2.19.0; Trivy action bumped to v0.36.0) across workflows.
* **Documentation**
  * Security policy updated to a continuous-deployment model with main as the supported branch and refreshed timestamp.
  * Support docs and changelog clarified repository versioning and minor wording/format tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->