### PR TITLE
fix(ci): remove concurrency from reusable workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -128,11 +128,6 @@ on:
         description: 'Codecov token'
         required: false
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
## Summary

- Removes the top-level `concurrency:` block from `python-ci.yml`
- GitHub does not support `concurrency:` at the workflow level in reusable workflows triggered only by `workflow_call`
- This block was added December 10, 2025 and has caused every downstream CI run to fail with 0 jobs ever since

## Root Cause

After bisecting CI run history:
- **Last passing run**: `audio-processor` on 2025-12-06 at SHA `000bb33c2e84` (before the concurrency block)
- **First failing run**: All runs after 2025-12-10 when `concurrency:` was added in commit `26537d898500`

Affected repos: `llc-manager`, `audio-processor`, `template-sample`, `rag-processor` -- all show `failure` with 0 jobs when calling this reusable workflow.

## Fix

Remove 5 lines:
```yaml
# Cancel in-progress runs for same PR/branch
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

Each caller (`ci.yml` in each repo) already has its own `concurrency:` block, so cancel-in-progress behavior is preserved at the caller level.

## Test Plan
- [ ] After merge, trigger a CI run on `audio-processor` or `llc-manager` -- it should start running jobs for the first time since December 2025

Generated with [Claude Code](https://claude.ai/claude-code)