### PR TITLE
fix(ci): remove concurrency from all reusable workflow callees

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -125,11 +125,6 @@ on:
         description: 'Overall matrix test result'
         value: ${{ jobs.compatibility-summary.outputs.result }}
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/python-docker.yml
+++ b/.github/workflows/python-docker.yml
@@ -164,11 +164,6 @@ on:
         description: 'Image digest'
         value: ${{ jobs.build.outputs.digest }}
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-docker-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -47,11 +47,6 @@ on:
         required: false
         default: 80
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/python-fips-compatibility.yml
+++ b/.github/workflows/python-fips-compatibility.yml
@@ -73,11 +73,6 @@ on:
         required: false
         default: false
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/python-fuzzing.yml
+++ b/.github/workflows/python-fuzzing.yml
@@ -95,11 +95,6 @@ on:
         required: false
         default: false
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/python-mutation.yml
+++ b/.github/workflows/python-mutation.yml
@@ -100,11 +100,6 @@ on:
         description: 'Whether the mutation threshold was met'
         value: ${{ jobs.mutation-testing.outputs.passed }}
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -143,11 +143,6 @@ on:
         required: false
         default: true
 
-# Cancel in-progress runs for same PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -56,11 +56,6 @@ on:
         required: false
         default: 'src'
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   id-token: write  # Required for OIDC

--- a/.github/workflows/python-qlty-coverage.yml
+++ b/.github/workflows/python-qlty-coverage.yml
@@ -97,11 +97,6 @@ on:
         description: 'Qlty Cloud coverage upload token'
         required: false
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -96,11 +96,6 @@ on:
         description: 'The release tag'
         value: ${{ jobs.release.outputs.tag }}
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -68,11 +68,6 @@ on:
         required: false
         default: true
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/python-sonarcloud.yml
+++ b/.github/workflows/python-sonarcloud.yml
@@ -131,11 +131,6 @@ on:
         description: 'SonarCloud authentication token'
         required: false
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/python-supplemental-checks.yml
+++ b/.github/workflows/python-supplemental-checks.yml
@@ -105,11 +105,6 @@ on:
         required: false
         default: 'squash'
 
-# Cancel in-progress runs for same PR/branch
-concurrency:
-  group: ${{ github.workflow }}-supplemental-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
## Summary

- Removes top-level `concurrency:` blocks from all 13 reusable workflows that use only `workflow_call` as their trigger
- Follow-up to PR #42 which fixed `python-ci.yml` alone
- GitHub does not support `concurrency:` in reusable workflows that have no other event trigger

## Workflows Fixed

| Workflow | Impact |
|---|---|
| `python-security-analysis.yml` | Security Analysis in all repos |
| `python-compatibility.yml` | Python Compatibility workflow |
| `python-docker.yml` | Container Security |
| `python-docs.yml` | Documentation workflow |
| `python-fips-compatibility.yml` | FIPS Compatibility |
| `python-fuzzing.yml` | Fuzzing |
| `python-mutation.yml` | Mutation Testing |
| `python-performance-regression.yml` | Performance regression |
| `python-publish-pypi.yml` | PyPI publish |
| `python-qlty-coverage.yml` | Qlty coverage |
| `python-release.yml` | Semantic Release |
| `python-sonarcloud.yml` | SonarCloud (standalone) |
| `python-supplemental-checks.yml` | Supplemental checks |

## Test Plan

- [ ] After merge, trigger Security Analysis on any repo -- it should run jobs
- [ ] Trigger Documentation, Container Security, etc. -- all should start executing

Generated with [Claude Code](https://claude.ai/claude-code)