### PR TITLE
fix(security): eliminate input injection vectors and harden supply chain

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -557,8 +557,9 @@ jobs:
         if: ${{ steps.check-tags.outputs.critical_tags > 0 }}
         env:
           SRC_DIR: ${{ inputs.source-directory }}
+          CRITICAL_TAGS: ${{ steps.check-tags.outputs.critical_tags }}
         run: |
-          echo "::error::PR blocked: Found ${{ steps.check-tags.outputs.critical_tags }} unverified #CRITICAL production risk tags"
+          echo "::error::PR blocked: Found $CRITICAL_TAGS unverified #CRITICAL production risk tags"
           echo ""
           echo "Please verify and remove these tags before merging:"
           grep -rn "#CRITICAL" --include="*.py" "$SRC_DIR"/ || true
@@ -570,8 +571,9 @@ jobs:
         if: ${{ inputs.fail-on-llm-tags && fromJSON(steps.check-tags.outputs.llm_tags) > 0 }}
         env:
           SRC_DIR: ${{ inputs.source-directory }}
+          LLM_TAGS: ${{ steps.check-tags.outputs.llm_tags }}
         run: |
-          echo "::error::PR blocked: Found ${{ steps.check-tags.outputs.llm_tags }} LLM debt tags"
+          echo "::error::PR blocked: Found $LLM_TAGS LLM debt tags"
           echo ""
           echo "Please address LLM debt before merging:"
           grep -rn "#LLM-" --include="*.py" "$SRC_DIR"/ || true
@@ -657,9 +659,10 @@ jobs:
       - name: Quality Gate Result
         env:
           SONAR_PROJECT_KEY: ${{ inputs.sonarcloud-project-key }}
+          QUALITY_GATE_STATUS: ${{ steps.quality-gate.outputs.quality-gate-status }}
         run: |
           echo "::group::Quality Gate Status"
-          echo "Quality Gate Status: ${{ steps.quality-gate.outputs.quality-gate-status }}"
+          echo "Quality Gate Status: $QUALITY_GATE_STATUS"
           echo "View detailed results: https://sonarcloud.io/project/overview?id=$SONAR_PROJECT_KEY"
           echo "::endgroup::"
 
@@ -715,8 +718,9 @@ jobs:
       - name: Run tests
         env:
           SRC_DIR: ${{ inputs.source-directory }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          echo "::group::Testing on Python ${{ matrix.python-version }}"
+          echo "::group::Testing on Python $PYTHON_VERSION"
           uv run pytest \
             --cov="$SRC_DIR" \
             --cov-report=term-missing \
@@ -734,27 +738,33 @@ jobs:
 
     steps:
       - name: Check CI results
+        env:
+          RESULT_CHECK_SECRETS: ${{ needs.check-secrets.result }}
+          RESULT_QUALITY_CHECKS: ${{ needs.quality-checks.result }}
+          RESULT_LLM_GOVERNANCE: ${{ needs.llm-governance.result }}
+          RESULT_SONARCLOUD: ${{ needs.sonarcloud-quality-gate.result }}
+          RESULT_MATRIX_TESTING: ${{ needs.matrix-testing.result }}
         run: |
           is_acceptable() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
 
-          if ! is_acceptable "${{ needs.check-secrets.result }}"; then
-            echo "::error::CI Gate failed: check-secrets is ${{ needs.check-secrets.result }}"
+          if ! is_acceptable "$RESULT_CHECK_SECRETS"; then
+            echo "::error::CI Gate failed: check-secrets is $RESULT_CHECK_SECRETS"
             exit 1
           fi
-          if ! is_acceptable "${{ needs.quality-checks.result }}"; then
-            echo "::error::CI Gate failed: quality-checks is ${{ needs.quality-checks.result }}"
+          if ! is_acceptable "$RESULT_QUALITY_CHECKS"; then
+            echo "::error::CI Gate failed: quality-checks is $RESULT_QUALITY_CHECKS"
             exit 1
           fi
-          if ! is_acceptable "${{ needs.llm-governance.result }}"; then
-            echo "::error::CI Gate failed: llm-governance is ${{ needs.llm-governance.result }}"
+          if ! is_acceptable "$RESULT_LLM_GOVERNANCE"; then
+            echo "::error::CI Gate failed: llm-governance is $RESULT_LLM_GOVERNANCE"
             exit 1
           fi
-          if ! is_acceptable "${{ needs.sonarcloud-quality-gate.result }}"; then
-            echo "::error::CI Gate failed: sonarcloud-quality-gate is ${{ needs.sonarcloud-quality-gate.result }}"
+          if ! is_acceptable "$RESULT_SONARCLOUD"; then
+            echo "::error::CI Gate failed: sonarcloud-quality-gate is $RESULT_SONARCLOUD"
             exit 1
           fi
-          if ! is_acceptable "${{ needs.matrix-testing.result }}"; then
-            echo "::error::CI Gate failed: matrix-testing is ${{ needs.matrix-testing.result }}"
+          if ! is_acceptable "$RESULT_MATRIX_TESTING"; then
+            echo "::error::CI Gate failed: matrix-testing is $RESULT_MATRIX_TESTING"
             exit 1
           fi
           echo "CI Gate passed"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -236,6 +236,7 @@ jobs:
         env:
           SRC_DIR: ${{ inputs.source-directory }}
           DEAD_CODE_CONFIDENCE: ${{ inputs.dead-code-confidence }}
+          FAIL_ON_DEAD_CODE: ${{ inputs.fail-on-dead-code }}
         run: |
           echo "::group::Vulture Dead Code Detection"
 
@@ -266,7 +267,7 @@ jobs:
             echo "> **Note:** Review these findings. Some may be false positives (e.g., pytest fixtures, CLI entry points)." >> $GITHUB_STEP_SUMMARY
             echo "> Use a `.vulture_whitelist.py` file to suppress known false positives." >> $GITHUB_STEP_SUMMARY
 
-            if [ "${{ inputs.fail-on-dead-code }}" == "true" ]; then
+            if [ "$FAIL_ON_DEAD_CODE" == "true" ]; then
               echo "::error::Dead code detected. Set 'fail-on-dead-code: false' to make this a warning."
               exit 1
             else
@@ -343,12 +344,14 @@ jobs:
           if [ $EXIT -ne 0 ] && [ $EXIT -ne 5 ]; then exit $EXIT; fi
 
       - name: Generate combined coverage report
+        env:
+          COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
         run: |
           echo "::group::Combined Coverage"
           uv run coverage combine --keep || true
           uv run coverage xml -o coverage.xml
           uv run coverage html
-          uv run coverage report --fail-under=${{ inputs.coverage-threshold }}
+          uv run coverage report --fail-under="$COVERAGE_THRESHOLD"
           echo "::endgroup::"
 
       - name: Security scan with Bandit
@@ -493,21 +496,23 @@ jobs:
 
       - name: Check for unverified assumption tags
         id: check-tags
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::Scanning for Unverified Assumption Tags"
 
           # Check for RAD tags (Layer 1: Production Runtime Risks)
-          CRITICAL_TAGS=$(grep -r "#CRITICAL" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
-          ASSUME_TAGS=$(grep -r "#ASSUME" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
-          EDGE_TAGS=$(grep -r "#EDGE" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
+          CRITICAL_TAGS=$(grep -r "#CRITICAL" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
+          ASSUME_TAGS=$(grep -r "#ASSUME" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
+          EDGE_TAGS=$(grep -r "#EDGE" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
 
           # Check for LLM debt tags (Layer 2: LLM Development Debt)
-          LLM_MOCK=$(grep -r "#LLM-MOCK" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
-          LLM_PLACEHOLDER=$(grep -r "#LLM-PLACEHOLDER" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
-          LLM_LOGIC=$(grep -r "#LLM-LOGIC" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
-          LLM_SCAFFOLD=$(grep -r "#LLM-SCAFFOLD" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
-          LLM_INFERRED=$(grep -r "#LLM-INFERRED" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
-          LLM_TEST_FIRST=$(grep -r "#LLM-TEST-FIRST" --include="*.py" ${{ inputs.source-directory }}/ 2>/dev/null | wc -l || echo "0")
+          LLM_MOCK=$(grep -r "#LLM-MOCK" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
+          LLM_PLACEHOLDER=$(grep -r "#LLM-PLACEHOLDER" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
+          LLM_LOGIC=$(grep -r "#LLM-LOGIC" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
+          LLM_SCAFFOLD=$(grep -r "#LLM-SCAFFOLD" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
+          LLM_INFERRED=$(grep -r "#LLM-INFERRED" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
+          LLM_TEST_FIRST=$(grep -r "#LLM-TEST-FIRST" --include="*.py" "$SRC_DIR"/ 2>/dev/null | wc -l || echo "0")
 
           TOTAL_RAD=$((CRITICAL_TAGS + ASSUME_TAGS))
           TOTAL_LLM=$((LLM_MOCK + LLM_PLACEHOLDER + LLM_LOGIC + LLM_SCAFFOLD + LLM_INFERRED + LLM_TEST_FIRST))
@@ -550,38 +555,44 @@ jobs:
 
       - name: Block PR if critical tags found
         if: ${{ steps.check-tags.outputs.critical_tags > 0 }}
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::error::PR blocked: Found ${{ steps.check-tags.outputs.critical_tags }} unverified #CRITICAL production risk tags"
           echo ""
           echo "Please verify and remove these tags before merging:"
-          grep -rn "#CRITICAL" --include="*.py" ${{ inputs.source-directory }}/ || true
+          grep -rn "#CRITICAL" --include="*.py" "$SRC_DIR"/ || true
           echo ""
           echo "See CLAUDE.md for verification workflow"
           exit 1
 
       - name: Fail on LLM tags (if configured)
         if: ${{ inputs.fail-on-llm-tags && fromJSON(steps.check-tags.outputs.llm_tags) > 0 }}
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::error::PR blocked: Found ${{ steps.check-tags.outputs.llm_tags }} LLM debt tags"
           echo ""
           echo "Please address LLM debt before merging:"
-          grep -rn "#LLM-" --include="*.py" ${{ inputs.source-directory }}/ || true
+          grep -rn "#LLM-" --include="*.py" "$SRC_DIR"/ || true
           exit 1
 
       - name: Detect LLM anti-patterns
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::LLM Anti-Pattern Detection"
 
           # Hardcoded localhost/URLs
           echo "Checking for hardcoded localhost/URLs..."
-          if grep -rE "(localhost|127\.0\.0\.1|http://|https://)" --include="*.py" ${{ inputs.source-directory }}/ | \
+          if grep -rE "(localhost|127\.0\.0\.1|http://|https://)" --include="*.py" "$SRC_DIR"/ | \
              grep -v "#LLM-PLACEHOLDER" | grep -v "^[[:space:]]*#"; then
             echo "::warning::Found hardcoded URLs without #LLM-PLACEHOLDER tag"
           fi
 
           # Hardcoded secrets patterns
           echo "Checking for potential hardcoded secrets..."
-          if grep -rE "(api_key|password|secret|token)\s*=\s*[\"'][^\"']+[\"']" --include="*.py" ${{ inputs.source-directory }}/ | \
+          if grep -rE "(api_key|password|secret|token)\s*=\s*[\"'][^\"']+[\"']" --include="*.py" "$SRC_DIR"/ | \
              grep -v "#LLM-PLACEHOLDER" | grep -v "^[[:space:]]*#"; then
             echo "::error::Potential hardcoded secret detected"
             exit 1
@@ -589,7 +600,7 @@ jobs:
 
           # Magic numbers
           echo "Checking for magic numbers..."
-          MAGIC_NUMBERS=$(grep -rE "\b[0-9]{2,}\b" --include="*.py" ${{ inputs.source-directory }}/ | \
+          MAGIC_NUMBERS=$(grep -rE "\b[0-9]{2,}\b" --include="*.py" "$SRC_DIR"/ | \
                           grep -v "#LLM-PLACEHOLDER" | \
                           grep -v "^[[:space:]]*#" | \
                           wc -l || echo "0")
@@ -644,21 +655,26 @@ jobs:
         id: quality-gate
 
       - name: Quality Gate Result
+        env:
+          SONAR_PROJECT_KEY: ${{ inputs.sonarcloud-project-key }}
         run: |
           echo "::group::Quality Gate Status"
           echo "Quality Gate Status: ${{ steps.quality-gate.outputs.quality-gate-status }}"
-          echo "View detailed results: https://sonarcloud.io/project/overview?id=${{ inputs.sonarcloud-project-key }}"
+          echo "View detailed results: https://sonarcloud.io/project/overview?id=$SONAR_PROJECT_KEY"
           echo "::endgroup::"
 
       - name: Block PR if quality gate fails
         if: steps.quality-gate.outputs.quality-gate-status == 'FAILED'
+        env:
+          SONAR_PROJECT_KEY: ${{ inputs.sonarcloud-project-key }}
+          COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
         run: |
           echo "::error::Quality Gate FAILED"
           echo ""
           echo "SonarQube quality gate did not pass. Please fix the issues:"
-          echo "- Review issues at: https://sonarcloud.io/project/overview?id=${{ inputs.sonarcloud-project-key }}"
+          echo "- Review issues at: https://sonarcloud.io/project/overview?id=$SONAR_PROJECT_KEY"
           echo "- Fix all BLOCKER and CRITICAL issues"
-          echo "- Ensure test coverage >= ${{ inputs.coverage-threshold }}%"
+          echo "- Ensure test coverage >= $COVERAGE_THRESHOLD%"
           echo "- Reduce code duplication"
           exit 1
 
@@ -697,10 +713,12 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::Testing on Python ${{ matrix.python-version }}"
           uv run pytest \
-            --cov=${{ inputs.source-directory }} \
+            --cov="$SRC_DIR" \
             --cov-report=term-missing \
             -v
           echo "::endgroup::"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -710,7 +710,9 @@ jobs:
           enable-cache: true
 
       - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -130,8 +130,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
 
 jobs:
   # ============================================================================
@@ -194,37 +192,50 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install ${{ inputs.python-version }}
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
         run: |
           uv sync --all-extras
 
       - name: Run Ruff formatter check
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          TEST_DIR: ${{ inputs.test-directory }}
         run: |
           echo "::group::Ruff Formatting"
-          uv run ruff format --check ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/ || {
-            echo "::error::Code formatting issues detected. Run 'uv run ruff format ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/' to fix."
+          uv run ruff format --check "$SRC_DIR"/ "$TEST_DIR"/ || {
+            echo "::error::Code formatting issues detected. Run 'uv run ruff format "$SRC_DIR"/ "$TEST_DIR"/' to fix."
             exit 1
           }
           echo "::endgroup::"
 
       - name: Run Ruff linter
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          TEST_DIR: ${{ inputs.test-directory }}
         run: |
           echo "::group::Ruff Linting"
-          uv run ruff check ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/ --output-format=github
+          uv run ruff check "$SRC_DIR"/ "$TEST_DIR"/ --output-format=github
           echo "::endgroup::"
 
       - name: Run BasedPyright type checker
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::BasedPyright Type Checking"
-          uv run basedpyright ${{ inputs.source-directory }}/ || {
+          uv run basedpyright "$SRC_DIR"/ || {
             echo "::warning::Type checking found issues"
           }
           echo "::endgroup::"
 
       - name: Dead code detection with Vulture
         if: inputs.enable-dead-code-check
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          DEAD_CODE_CONFIDENCE: ${{ inputs.dead-code-confidence }}
         run: |
           echo "::group::Vulture Dead Code Detection"
 
@@ -232,10 +243,10 @@ jobs:
           uv pip install vulture 2>/dev/null || true
 
           # Run vulture with configurable confidence threshold
-          echo "Scanning for dead code (min confidence: ${{ inputs.dead-code-confidence }}%)..."
+          echo "Scanning for dead code (min confidence: $DEAD_CODE_CONFIDENCE%)..."
 
           # Capture output for reporting
-          VULTURE_OUTPUT=$(uv run vulture ${{ inputs.source-directory }}/ --min-confidence ${{ inputs.dead-code-confidence }} 2>&1) || true
+          VULTURE_OUTPUT=$(uv run vulture "$SRC_DIR"/ --min-confidence "$DEAD_CODE_CONFIDENCE" 2>&1) || true
 
           if [ -n "$VULTURE_OUTPUT" ]; then
             echo "$VULTURE_OUTPUT"
@@ -246,7 +257,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Dead Code Detection (Vulture)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Found $DEAD_CODE_COUNT potential dead code issue(s)** (confidence ≥${{ inputs.dead-code-confidence }}%)" >> $GITHUB_STEP_SUMMARY
+            echo "**Found $DEAD_CODE_COUNT potential dead code issue(s)** (confidence >=$DEAD_CODE_CONFIDENCE%)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "$VULTURE_OUTPUT" >> $GITHUB_STEP_SUMMARY
@@ -262,21 +273,23 @@ jobs:
               echo "::warning::Potential dead code detected. Review vulture output above."
             fi
           else
-            echo "No dead code detected at ${{ inputs.dead-code-confidence }}% confidence threshold."
+            echo "No dead code detected at $DEAD_CODE_CONFIDENCE% confidence threshold."
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Dead Code Detection (Vulture)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "✅ No dead code detected (confidence ≥${{ inputs.dead-code-confidence }}%)" >> $GITHUB_STEP_SUMMARY
+            echo "No dead code detected (confidence >=$DEAD_CODE_CONFIDENCE%)" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "::endgroup::"
 
       - name: Run unit tests with coverage
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::Unit Test Execution"
           uv run pytest \
             -m "unit or not (integration or security or slow)" \
-            --cov=${{ inputs.source-directory }} \
+            --cov="$SRC_DIR" \
             --cov-report=xml:coverage-unit.xml \
             --cov-report=term-missing \
             --cov-branch \
@@ -287,35 +300,47 @@ jobs:
 
       - name: Run integration tests with coverage
         if: inputs.run-integration-tests
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::Integration Test Execution"
+          set +e
           uv run pytest \
             -m "integration" \
-            --cov=${{ inputs.source-directory }} \
+            --cov="$SRC_DIR" \
             --cov-report=xml:coverage-integration.xml \
             --cov-report=term-missing \
             --cov-branch \
             --cov-append \
             --junitxml=junit-integration.xml \
             -o junit_family=xunit2 \
-            -v || echo "No integration tests found or all skipped"
+            -v
+          EXIT=$?
+          set -e
           echo "::endgroup::"
+          if [ $EXIT -ne 0 ] && [ $EXIT -ne 5 ]; then exit $EXIT; fi
 
       - name: Run security tests with coverage
         if: inputs.run-security-tests
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::Security Test Execution"
+          set +e
           uv run pytest \
             -m "security" \
-            --cov=${{ inputs.source-directory }} \
+            --cov="$SRC_DIR" \
             --cov-report=xml:coverage-security.xml \
             --cov-report=term-missing \
             --cov-branch \
             --cov-append \
             --junitxml=junit-security.xml \
             -o junit_family=xunit2 \
-            -v || echo "No security tests found or all skipped"
+            -v
+          EXIT=$?
+          set -e
           echo "::endgroup::"
+          if [ $EXIT -ne 0 ] && [ $EXIT -ne 5 ]; then exit $EXIT; fi
 
       - name: Generate combined coverage report
         run: |
@@ -327,9 +352,11 @@ jobs:
           echo "::endgroup::"
 
       - name: Security scan with Bandit
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::Bandit Security Scan"
-          uv run bandit -r ${{ inputs.source-directory }}/ -f json -o bandit-report.json || {
+          uv run bandit -r "$SRC_DIR"/ -f json -o bandit-report.json || {
             echo "::warning::Security issues detected"
             cat bandit-report.json
           }

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -139,22 +139,27 @@ jobs:
     steps:
       - name: Build matrix configuration
         id: set-matrix
+        env:
+          OS_INPUT: ${{ inputs.operating-systems }}
+          PYTHON_INPUT: ${{ inputs.python-versions }}
+          INCLUDE_WINDOWS: ${{ inputs.include-windows }}
+          INCLUDE_MACOS: ${{ inputs.include-macos }}
         run: |
           # Start with the provided operating systems
-          OS_LIST='${{ inputs.operating-systems }}'
+          OS_LIST="$OS_INPUT"
 
           # Add additional platforms if requested
-          if [ "${{ inputs.include-windows }}" == "true" ]; then
+          if [ "$INCLUDE_WINDOWS" == "true" ]; then
             OS_LIST=$(echo "$OS_LIST" | jq '. + ["windows-latest"] | unique')
           fi
 
-          if [ "${{ inputs.include-macos }}" == "true" ]; then
+          if [ "$INCLUDE_MACOS" == "true" ]; then
             OS_LIST=$(echo "$OS_LIST" | jq '. + ["macos-latest"] | unique')
           fi
 
           # Build the full matrix (use -c for compact single-line JSON)
           MATRIX=$(jq -c -n \
-            --argjson python '${{ inputs.python-versions }}' \
+            --argjson python "$PYTHON_INPUT" \
             --argjson os "$OS_LIST" \
             '{python: $python, os: $os}')
 
@@ -194,22 +199,48 @@ jobs:
 
       - name: Install system dependencies (Ubuntu)
         if: runner.os == 'Linux' && inputs.system-deps-ubuntu != ''
+        env:
+          SYSTEM_DEPS_UBUNTU: ${{ inputs.system-deps-ubuntu }}
         run: |
-          echo "📦 Installing system dependencies: ${{ inputs.system-deps-ubuntu }}"
-          sudo apt-get update
-          sudo apt-get install -y ${{ inputs.system-deps-ubuntu }}
+          PKGS="$SYSTEM_DEPS_UBUNTU"
+          if [[ "$PKGS" =~ ^[a-zA-Z0-9_\-\. ]+$ ]]; then
+            echo "Installing system dependencies: $PKGS"
+            sudo apt-get update
+            # shellcheck disable=SC2086
+            sudo apt-get install -y $PKGS
+          else
+            echo "::error::Invalid package name characters in system-deps-ubuntu"
+            exit 1
+          fi
 
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS' && inputs.system-deps-macos != ''
+        env:
+          SYSTEM_DEPS_MACOS: ${{ inputs.system-deps-macos }}
         run: |
-          echo "📦 Installing system dependencies: ${{ inputs.system-deps-macos }}"
-          brew install ${{ inputs.system-deps-macos }}
+          PKGS="$SYSTEM_DEPS_MACOS"
+          if [[ "$PKGS" =~ ^[a-zA-Z0-9_\-\. ]+$ ]]; then
+            echo "Installing system dependencies: $PKGS"
+            # shellcheck disable=SC2086
+            brew install $PKGS
+          else
+            echo "::error::Invalid package name characters in system-deps-macos"
+            exit 1
+          fi
 
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows' && inputs.system-deps-windows != ''
+        env:
+          SYSTEM_DEPS_WINDOWS: ${{ inputs.system-deps-windows }}
         run: |
-          echo "📦 Installing system dependencies: ${{ inputs.system-deps-windows }}"
-          choco install ${{ inputs.system-deps-windows }} -y
+          $Pkgs = $env:SYSTEM_DEPS_WINDOWS
+          if ($Pkgs -match '^[a-zA-Z0-9_\-\. ]+$') {
+            Write-Output "Installing system dependencies: $Pkgs"
+            choco install $Pkgs.Split(' ') -y
+          } else {
+            Write-Output "::error::Invalid package name characters in system-deps-windows"
+            exit 1
+          }
         shell: pwsh
 
       - name: Install dependencies
@@ -217,16 +248,22 @@ jobs:
 
       - name: Run tests
         id: tests
+        env:
+          COVERAGE_REPORT: ${{ inputs.coverage-report }}
+          TEST_COMMAND: ${{ inputs.test-command }}
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "Running tests on Python ${{ matrix.python }} (${{ matrix.os }})..."
 
-          if [ "${{ inputs.coverage-report }}" == "true" ]; then
-            uv run ${{ inputs.test-command }} \
-              --cov=${{ inputs.source-directory }} \
+          if [ "$COVERAGE_REPORT" == "true" ]; then
+            # shellcheck disable=SC2086
+            uv run $TEST_COMMAND \
+              --cov="$SRC_DIR" \
               --cov-report=xml:coverage-${{ matrix.python }}-${{ matrix.os }}.xml \
               --cov-report=term-missing
           else
-            uv run ${{ inputs.test-command }}
+            # shellcheck disable=SC2086
+            uv run $TEST_COMMAND
           fi
         shell: bash
 
@@ -253,12 +290,14 @@ jobs:
         run: echo "result=${{ needs.test-matrix.result }}" >> $GITHUB_OUTPUT
 
       - name: Generate compatibility matrix summary
+        env:
+          SKIP_ON_DRAFT: ${{ inputs.skip-on-draft }}
         run: |
           echo "## Python Compatibility Matrix Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Check if matrix was skipped due to draft PR
-          if [ "${{ inputs.skip-on-draft }}" == "true" ] && [ "${{ github.event.pull_request.draft }}" == "true" ]; then
+          if [ "$SKIP_ON_DRAFT" == "true" ] && [ "${{ github.event.pull_request.draft }}" == "true" ]; then
             echo "### Draft PR Mode" >> $GITHUB_STEP_SUMMARY
             echo "Matrix testing skipped to reduce costs during development." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -252,14 +252,16 @@ jobs:
           COVERAGE_REPORT: ${{ inputs.coverage-report }}
           TEST_COMMAND: ${{ inputs.test-command }}
           SRC_DIR: ${{ inputs.source-directory }}
+          MATRIX_PYTHON: ${{ matrix.python }}
+          MATRIX_OS: ${{ matrix.os }}
         run: |
-          echo "Running tests on Python ${{ matrix.python }} (${{ matrix.os }})..."
+          echo "Running tests on Python $MATRIX_PYTHON ($MATRIX_OS)..."
 
           if [ "$COVERAGE_REPORT" == "true" ]; then
             # shellcheck disable=SC2086
             uv run $TEST_COMMAND \
               --cov="$SRC_DIR" \
-              --cov-report=xml:coverage-${{ matrix.python }}-${{ matrix.os }}.xml \
+              --cov-report=xml:coverage-${MATRIX_PYTHON}-${MATRIX_OS}.xml \
               --cov-report=term-missing
           else
             # shellcheck disable=SC2086
@@ -287,17 +289,22 @@ jobs:
     steps:
       - name: Set result output
         id: result
-        run: echo "result=${{ needs.test-matrix.result }}" >> $GITHUB_OUTPUT
+        env:
+          TEST_MATRIX_RESULT: ${{ needs.test-matrix.result }}
+        run: echo "result=$TEST_MATRIX_RESULT" >> $GITHUB_OUTPUT
 
       - name: Generate compatibility matrix summary
         env:
           SKIP_ON_DRAFT: ${{ inputs.skip-on-draft }}
+          GH_PR_DRAFT: ${{ github.event.pull_request.draft }}
+          BUILD_MATRIX: ${{ needs.build-matrix.outputs.matrix }}
+          TEST_MATRIX_RESULT: ${{ needs.test-matrix.result }}
         run: |
           echo "## Python Compatibility Matrix Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Check if matrix was skipped due to draft PR
-          if [ "$SKIP_ON_DRAFT" == "true" ] && [ "${{ github.event.pull_request.draft }}" == "true" ]; then
+          if [ "$SKIP_ON_DRAFT" == "true" ] && [ "$GH_PR_DRAFT" == "true" ]; then
             echo "### Draft PR Mode" >> $GITHUB_STEP_SUMMARY
             echo "Matrix testing skipped to reduce costs during development." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -307,7 +314,7 @@ jobs:
             exit 0
           fi
 
-          MATRIX='${{ needs.build-matrix.outputs.matrix }}'
+          MATRIX="$BUILD_MATRIX"
           PYTHON_VERSIONS=$(echo "$MATRIX" | jq -r '.python | join(", ")')
           OS_LIST=$(echo "$MATRIX" | jq -r '.os | join(", ")')
 
@@ -317,12 +324,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           echo "### Results" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.test-matrix.result }}" == "success" ]; then
+          if [ "$TEST_MATRIX_RESULT" == "success" ]; then
             echo "**Status:** All matrix combinations passed" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.test-matrix.result }}" == "failure" ]; then
+          elif [ "$TEST_MATRIX_RESULT" == "failure" ]; then
             echo "**Status:** Some matrix combinations failed" >> $GITHUB_STEP_SUMMARY
           else
-            echo "**Status:** ${{ needs.test-matrix.result }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Status:** $TEST_MATRIX_RESULT" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Check matrix result

--- a/.github/workflows/python-docker.yml
+++ b/.github/workflows/python-docker.yml
@@ -132,7 +132,13 @@ on:
         description: 'Generate Software Bill of Materials'
         type: boolean
         required: false
-        default: false
+        default: true
+
+      enable-provenance:
+        description: 'Generate SLSA provenance attestation for the Docker image'
+        type: boolean
+        required: false
+        default: true
 
       # PR comment
       enable-pr-comment:
@@ -296,7 +302,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           sbom: ${{ inputs.enable-sbom }}
-          provenance: ${{ inputs.enable-sbom }}
+          provenance: ${{ inputs.enable-provenance }}
 
       # Export local image for Trivy scanning when not pushed to registry
       - name: Export local image for scanning

--- a/.github/workflows/python-docker.yml
+++ b/.github/workflows/python-docker.yml
@@ -227,9 +227,13 @@ jobs:
 
       - name: Check if fork PR
         id: check-fork
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+          if [ "$GH_EVENT_NAME" == "pull_request" ]; then
+            if [ "$GH_HEAD_REPO" != "$GH_REPOSITORY" ]; then
               echo "is_fork=true" >> $GITHUB_OUTPUT
               echo "This is a fork PR"
             else
@@ -242,12 +246,16 @@ jobs:
 
       - name: Determine if push is allowed
         id: push-check
+        env:
+          INPUT_PUSH: ${{ inputs.push }}
+          INPUT_PUSH_ON_FORK: ${{ inputs.push-on-fork }}
+          IS_FORK: ${{ steps.check-fork.outputs.is_fork }}
         run: |
           SHOULD_PUSH="false"
 
-          if [ "${{ inputs.push }}" == "true" ]; then
-            if [ "${{ steps.check-fork.outputs.is_fork }}" == "true" ]; then
-              if [ "${{ inputs.push-on-fork }}" == "true" ]; then
+          if [ "$INPUT_PUSH" == "true" ]; then
+            if [ "$IS_FORK" == "true" ]; then
+              if [ "$INPUT_PUSH_ON_FORK" == "true" ]; then
                 SHOULD_PUSH="true"
                 echo "::warning::Pushing from fork PR (push-on-fork enabled)"
               else
@@ -307,9 +315,11 @@ jobs:
       # Export local image for Trivy scanning when not pushed to registry
       - name: Export local image for scanning
         if: inputs.enable-trivy-scan && steps.push-check.outputs.push != 'true'
+        env:
+          META_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           # Get the first tag from metadata (local reference)
-          LOCAL_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          LOCAL_TAG=$(echo "$META_TAGS" | head -n1)
           echo "LOCAL_IMAGE_TAG=${LOCAL_TAG}" >> $GITHUB_ENV
           echo "Exporting local image: ${LOCAL_TAG}"
           # Export image to tarball for Trivy to scan

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -50,7 +50,6 @@ on:
 permissions:
   contents: read
   pages: write
-  id-token: write
 
 jobs:
   build:
@@ -82,20 +81,17 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}-docs
-
       - name: Install dependencies
         run: uv sync --all-extras
 
       - name: Check docstring coverage
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          DOCSTRING_THRESHOLD: ${{ inputs.docstring-threshold }}
         run: |
           echo "📝 Checking docstring coverage..."
-          uv run interrogate ${{ inputs.source-directory }} \
-            --fail-under=${{ inputs.docstring-threshold }} \
+          uv run interrogate "$SRC_DIR" \
+            --fail-under="$DOCSTRING_THRESHOLD" \
             --verbose || echo "⚠️  Docstring coverage below threshold"
 
       - name: Build MkDocs site
@@ -125,6 +121,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+
       - name: Download documentation artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -124,9 +124,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
+          egress-policy: audit
 
       - name: Download documentation artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -41,6 +41,9 @@
 #
 #   Expected JSON output format:
 #     {"p95_ms": 100.0, "mean_ms": 95.0, "throughput_rps": 1000.0}
+#
+# Caller convention: place data-generation script at scripts/generate_test_data.py
+# in the calling repository. The script is invoked when generate-synthetic-data: true.
 # ============================================================================
 
 name: Performance Regression Testing (Reusable)
@@ -108,16 +111,10 @@ on:
         default: true
 
       generate-synthetic-data:
-        description: 'Generate synthetic test data (requires synthetic-data-script)'
+        description: 'Generate synthetic test data (calls scripts/generate_test_data.py)'
         type: boolean
         required: false
         default: false
-
-      synthetic-data-script:
-        description: 'Python code to generate synthetic test data'
-        type: string
-        required: false
-        default: ''
 
       test-data-directory:
         description: 'Directory for test data (default: /tmp/perf_test_data)'
@@ -182,14 +179,14 @@ jobs:
           fi
 
       - name: Generate Synthetic Test Data
-        if: inputs.generate-synthetic-data && inputs.synthetic-data-script != ''
+        if: inputs.generate-synthetic-data
+        env:
+          TEST_DATA_DIR: ${{ inputs.test-data-directory }}
         run: |
-          mkdir -p "${{ inputs.test-data-directory }}"
-          uv run python - <<'EOF'
-          ${{ inputs.synthetic-data-script }}
-          EOF
-          echo "✅ Synthetic test data generated in ${{ inputs.test-data-directory }}"
-          ls -lh "${{ inputs.test-data-directory }}" | head -20
+          mkdir -p "$TEST_DATA_DIR"
+          uv run python scripts/generate_test_data.py
+          echo "Synthetic test data generated in $TEST_DATA_DIR"
+          ls -lh "$TEST_DATA_DIR" | head -20
 
       - name: Validate Benchmark Script
         run: |

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -330,6 +330,11 @@ jobs:
 
       - name: Compare Performance
         id: compare
+        env:
+          PRIMARY_METRIC: ${{ inputs.primary-metric }}
+          REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
+          IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
+          FAIL_ON_REGRESSION: ${{ inputs.fail-on-regression }}
         run: |
           uv run python - <<'EOF'
           import json
@@ -342,45 +347,42 @@ jobs:
           baseline_results = json.loads(Path("/tmp/baseline_benchmark.json").read_text())
 
           # Extract primary metric
-          primary_metric = "${{ inputs.primary-metric }}"
+          primary_metric = os.environ["PRIMARY_METRIC"]
           pr_value = pr_results.get(primary_metric, 0.0)
           baseline_value = baseline_results.get(primary_metric, 0.0)
 
           # Get thresholds from inputs
-          regression_threshold = ${{ inputs.regression-threshold }}
-          improvement_threshold = ${{ inputs.improvement-threshold }}
+          regression_threshold = float(os.environ["REGRESSION_THRESHOLD"])
+          improvement_threshold = float(os.environ["IMPROVEMENT_THRESHOLD"])
 
           # Handle missing or zero values
           if baseline_value == 0:
-              print(f"⚠️  WARNING: Baseline {primary_metric} is 0 - cannot calculate regression")
+              print(f"WARNING: Baseline {primary_metric} is 0 - cannot calculate regression")
               regression_pct = 0
               regression_detected = False
               improvement_detected = False
           else:
-              # Calculate regression/improvement
               regression_pct = ((pr_value - baseline_value) / baseline_value) * 100
-
-              # Check thresholds
               regression_detected = regression_pct > regression_threshold
               improvement_detected = regression_pct < -improvement_threshold
 
           # Print results
-          print(f"📊 Performance Comparison:")
+          print(f"Performance Comparison:")
           print(f"  Metric: {primary_metric}")
           print(f"  Baseline: {baseline_value:.2f}")
           print(f"  PR: {pr_value:.2f}")
           print(f"  Change: {regression_pct:+.1f}%")
-          print(f"  Threshold: ±{regression_threshold}%")
+          print(f"  Threshold: +/-{regression_threshold}%")
           print()
 
           if regression_detected:
-              print(f"❌ REGRESSION DETECTED ({regression_pct:+.1f}%)")
+              print(f"REGRESSION DETECTED ({regression_pct:+.1f}%)")
               status = "regression"
           elif improvement_detected:
-              print(f"✅ IMPROVEMENT DETECTED ({regression_pct:+.1f}%)")
+              print(f"IMPROVEMENT DETECTED ({regression_pct:+.1f}%)")
               status = "improvement"
           else:
-              print(f"✅ PERFORMANCE OK ({regression_pct:+.1f}%)")
+              print(f"PERFORMANCE OK ({regression_pct:+.1f}%)")
               status = "ok"
 
           # Extract additional metrics for summary
@@ -407,13 +409,12 @@ jobs:
               f.write(f"improvement_detected={str(improvement_detected).lower()}\n")
               f.write(f"status={status}\n")
               f.write(f"primary_metric={primary_metric}\n")
-
-              # Write additional metrics as JSON
-              import json
-              f.write(f"summary_metrics={json.dumps(summary_metrics)}\n")
+              import json as json2
+              f.write(f"summary_metrics={json2.dumps(summary_metrics)}\n")
 
           # Exit with error if regression detected and fail-on-regression is true
-          if regression_detected and ${{ inputs.fail-on-regression }}:
+          fail_on_regression = os.environ.get("FAIL_ON_REGRESSION", "false").lower() == "true"
+          if regression_detected and fail_on_regression:
               sys.exit(1)
           else:
               sys.exit(0)

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -409,8 +409,7 @@ jobs:
               f.write(f"improvement_detected={str(improvement_detected).lower()}\n")
               f.write(f"status={status}\n")
               f.write(f"primary_metric={primary_metric}\n")
-              import json as json2
-              f.write(f"summary_metrics={json2.dumps(summary_metrics)}\n")
+              f.write(f"summary_metrics={json.dumps(summary_metrics)}\n")
 
           # Exit with error if regression detected and fail-on-regression is true
           fail_on_regression = os.environ.get("FAIL_ON_REGRESSION", "false").lower() == "true"

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -189,31 +189,40 @@ jobs:
           ls -lh "$TEST_DATA_DIR" | head -20
 
       - name: Validate Benchmark Script
+        env:
+          BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
+          PRIMARY_METRIC: ${{ inputs.primary-metric }}
         run: |
-          if [ ! -f "${{ inputs.benchmark-script }}" ]; then
-            echo "❌ ERROR: Benchmark script not found: ${{ inputs.benchmark-script }}"
+          if [ ! -f "$BENCHMARK_SCRIPT" ]; then
+            echo "❌ ERROR: Benchmark script not found: $BENCHMARK_SCRIPT"
             echo ""
             echo "Ensure the script exists and outputs JSON with metrics:"
-            echo '  {"${{ inputs.primary-metric }}": 100.0, "mean_ms": 95.0, ...}'
+            echo "  {\"$PRIMARY_METRIC\": 100.0, \"mean_ms\": 95.0, ...}"
             exit 1
           fi
-          echo "✅ Benchmark script found: ${{ inputs.benchmark-script }}"
+          echo "✅ Benchmark script found: $BENCHMARK_SCRIPT"
 
       - name: Run PR Benchmarks
         id: pr_bench
+        env:
+          BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
+          BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup-iterations }}
+          BENCHMARK_ITERATIONS: ${{ inputs.benchmark-iterations }}
+          PRIMARY_METRIC: ${{ inputs.primary-metric }}
         run: |
           echo "🏃 Running benchmark on PR branch..."
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          if uv run python ${{ inputs.benchmark-script }} --help 2>&1 | grep -q -- '--output'; then
+          if uv run python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
             echo "ℹ️  Script supports --output argument"
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          if uv run python ${{ inputs.benchmark-script }} --help 2>&1 | grep -q -- '--iterations'; then
+          if uv run python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
             echo "ℹ️  Script supports --warmup/--iterations arguments"
           fi
@@ -221,29 +230,32 @@ jobs:
           # Run benchmark with detected capabilities
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # Full interface support
-            uv run python ${{ inputs.benchmark-script }} \
-              --warmup ${{ inputs.warmup-iterations }} \
-              --iterations ${{ inputs.benchmark-iterations }} \
+            # shellcheck disable=SC2086
+            uv run python "$BENCHMARK_SCRIPT" \
+              --warmup "$WARMUP_ITERATIONS" \
+              --iterations "$BENCHMARK_ITERATIONS" \
               --output /tmp/pr_benchmark.json \
-              ${{ inputs.benchmark-args }} || {
+              $BENCHMARK_ARGS || {
                 echo "⚠️ Benchmark execution failed, creating fallback results"
-                echo '{"${{ inputs.primary-metric }}": 0, "status": "failed"}' > /tmp/pr_benchmark.json
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
               }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # Only --output supported
-            uv run python ${{ inputs.benchmark-script }} \
+            # shellcheck disable=SC2086
+            uv run python "$BENCHMARK_SCRIPT" \
               --output /tmp/pr_benchmark.json \
-              ${{ inputs.benchmark-args }} || {
+              $BENCHMARK_ARGS || {
                 echo "⚠️ Benchmark execution failed, creating fallback results"
-                echo '{"${{ inputs.primary-metric }}": 0, "status": "failed"}' > /tmp/pr_benchmark.json
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
               }
           else
             # Minimal interface - capture stdout as JSON
             echo "ℹ️  Script uses stdout for output (no --output flag)"
-            uv run python ${{ inputs.benchmark-script }} \
-              ${{ inputs.benchmark-args }} > /tmp/pr_benchmark.json 2>&1 || {
+            # shellcheck disable=SC2086
+            uv run python "$BENCHMARK_SCRIPT" \
+              $BENCHMARK_ARGS > /tmp/pr_benchmark.json 2>&1 || {
                 echo "⚠️ Benchmark execution failed, creating fallback results"
-                echo '{"${{ inputs.primary-metric }}": 0, "status": "failed"}' > /tmp/pr_benchmark.json
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
               }
           fi
 
@@ -275,44 +287,53 @@ jobs:
 
       - name: Run Baseline Benchmarks
         if: steps.baseline_source.outputs.source == 'generated'
+        env:
+          BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
+          BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup-iterations }}
+          BENCHMARK_ITERATIONS: ${{ inputs.benchmark-iterations }}
+          PRIMARY_METRIC: ${{ inputs.primary-metric }}
         run: |
           echo "🏃 Running baseline benchmark on main branch..."
           uv sync $(echo "${{ inputs.extra-dependencies }}" | tr ' ' '\n' | sed 's/^/--extra /' | tr '\n' ' ')
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          if uv run python ${{ inputs.benchmark-script }} --help 2>&1 | grep -q -- '--output'; then
+          if uv run python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          if uv run python ${{ inputs.benchmark-script }} --help 2>&1 | grep -q -- '--iterations'; then
+          if uv run python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
           fi
 
           # Run benchmark with detected capabilities
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
-            uv run python ${{ inputs.benchmark-script }} \
-              --warmup ${{ inputs.warmup-iterations }} \
-              --iterations ${{ inputs.benchmark-iterations }} \
+            # shellcheck disable=SC2086
+            uv run python "$BENCHMARK_SCRIPT" \
+              --warmup "$WARMUP_ITERATIONS" \
+              --iterations "$BENCHMARK_ITERATIONS" \
               --output /tmp/baseline_benchmark.json \
-              ${{ inputs.benchmark-args }} || {
+              $BENCHMARK_ARGS || {
                 echo "⚠️ Baseline benchmark failed, using fallback"
-                echo '{"${{ inputs.primary-metric }}": 0, "status": "failed"}' > /tmp/baseline_benchmark.json
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
               }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
-            uv run python ${{ inputs.benchmark-script }} \
+            # shellcheck disable=SC2086
+            uv run python "$BENCHMARK_SCRIPT" \
               --output /tmp/baseline_benchmark.json \
-              ${{ inputs.benchmark-args }} || {
+              $BENCHMARK_ARGS || {
                 echo "⚠️ Baseline benchmark failed, using fallback"
-                echo '{"${{ inputs.primary-metric }}": 0, "status": "failed"}' > /tmp/baseline_benchmark.json
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
               }
           else
-            uv run python ${{ inputs.benchmark-script }} \
-              ${{ inputs.benchmark-args }} > /tmp/baseline_benchmark.json 2>&1 || {
+            # shellcheck disable=SC2086
+            uv run python "$BENCHMARK_SCRIPT" \
+              $BENCHMARK_ARGS > /tmp/baseline_benchmark.json 2>&1 || {
                 echo "⚠️ Baseline benchmark failed, using fallback"
-                echo '{"${{ inputs.primary-metric }}": 0, "status": "failed"}' > /tmp/baseline_benchmark.json
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
               }
           fi
 

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -170,9 +170,12 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
+        env:
+          EXTRA_DEPENDENCIES: ${{ inputs.extra-dependencies }}
         run: |
-          if [ -n "${{ inputs.extra-dependencies }}" ]; then
-            EXTRAS=$(echo "${{ inputs.extra-dependencies }}" | tr ' ' '\n' | sed 's/^/--extra /' | tr '\n' ' ')
+          if [ -n "$EXTRA_DEPENDENCIES" ]; then
+            EXTRAS=$(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n' | sed 's/^/--extra /' | tr '\n' ' ')
+            # shellcheck disable=SC2086
             uv sync $EXTRAS
           else
             uv sync
@@ -274,11 +277,13 @@ jobs:
 
       - name: Determine Baseline Source
         id: baseline_source
+        env:
+          BASELINE_FILE: ${{ inputs.baseline-file }}
         run: |
-          if [ -n "${{ inputs.baseline-file }}" ] && [ -f "${{ inputs.baseline-file }}" ]; then
+          if [ -n "$BASELINE_FILE" ] && [ -f "$BASELINE_FILE" ]; then
             echo "source=committed" >> $GITHUB_OUTPUT
-            echo "file=${{ inputs.baseline-file }}" >> $GITHUB_OUTPUT
-            echo "✅ Using committed baseline: ${{ inputs.baseline-file }}"
+            echo "file=$BASELINE_FILE" >> $GITHUB_OUTPUT
+            echo "✅ Using committed baseline: $BASELINE_FILE"
           else
             echo "source=generated" >> $GITHUB_OUTPUT
             echo "file=/tmp/baseline_benchmark.json" >> $GITHUB_OUTPUT
@@ -293,9 +298,16 @@ jobs:
           WARMUP_ITERATIONS: ${{ inputs.warmup-iterations }}
           BENCHMARK_ITERATIONS: ${{ inputs.benchmark-iterations }}
           PRIMARY_METRIC: ${{ inputs.primary-metric }}
+          EXTRA_DEPENDENCIES: ${{ inputs.extra-dependencies }}
         run: |
           echo "🏃 Running baseline benchmark on main branch..."
-          uv sync $(echo "${{ inputs.extra-dependencies }}" | tr ' ' '\n' | sed 's/^/--extra /' | tr '\n' ' ')
+          if [ -n "$EXTRA_DEPENDENCIES" ]; then
+            EXTRAS=$(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n' | sed 's/^/--extra /' | tr '\n' ' ')
+            # shellcheck disable=SC2086
+            uv sync $EXTRAS
+          else
+            uv sync
+          fi
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
@@ -344,8 +356,10 @@ jobs:
 
       - name: Copy Committed Baseline
         if: steps.baseline_source.outputs.source == 'committed'
+        env:
+          BASELINE_FILE: ${{ inputs.baseline-file }}
         run: |
-          cp "${{ inputs.baseline-file }}" /tmp/baseline_benchmark.json
+          cp "$BASELINE_FILE" /tmp/baseline_benchmark.json
           echo "📊 Committed Baseline:"
           cat /tmp/baseline_benchmark.json | python3 -m json.tool
 
@@ -443,14 +457,32 @@ jobs:
       - name: Post PR Comment
         if: inputs.comment-on-pr && github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          COMPARE_BASELINE: ${{ steps.compare.outputs.baseline_value }}
+          COMPARE_PR: ${{ steps.compare.outputs.pr_value }}
+          COMPARE_REGRESSION_PCT: ${{ steps.compare.outputs.regression_pct }}
+          COMPARE_STATUS: ${{ steps.compare.outputs.status }}
+          COMPARE_PRIMARY_METRIC: ${{ steps.compare.outputs.primary_metric }}
+          COMPARE_SUMMARY_METRICS: ${{ steps.compare.outputs.summary_metrics }}
+          REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup-iterations }}
+          BENCHMARK_ITERATIONS: ${{ inputs.benchmark-iterations }}
+          BASELINE_SOURCE: ${{ steps.baseline_source.outputs.source }}
+          BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
+          BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
         with:
           script: |
-            const baseline = '${{ steps.compare.outputs.baseline_value }}';
-            const pr_value = '${{ steps.compare.outputs.pr_value }}';
-            const regression_pct = '${{ steps.compare.outputs.regression_pct }}';
-            const status = '${{ steps.compare.outputs.status }}';
-            const primary_metric = '${{ steps.compare.outputs.primary_metric }}';
-            const threshold = '${{ inputs.regression-threshold }}';
+            const baseline = process.env.COMPARE_BASELINE;
+            const pr_value = process.env.COMPARE_PR;
+            const regression_pct = process.env.COMPARE_REGRESSION_PCT;
+            const status = process.env.COMPARE_STATUS;
+            const primary_metric = process.env.COMPARE_PRIMARY_METRIC;
+            const threshold = process.env.REGRESSION_THRESHOLD;
+            const warmup = process.env.WARMUP_ITERATIONS;
+            const iterations = process.env.BENCHMARK_ITERATIONS;
+            const baselineSource = process.env.BASELINE_SOURCE;
+            const benchmarkScript = process.env.BENCHMARK_SCRIPT;
+            const benchmarkArgs = process.env.BENCHMARK_ARGS;
 
             let icon, statusText, actionText;
             if (status === 'regression') {
@@ -470,7 +502,7 @@ jobs:
             // Parse additional metrics
             let additionalMetricsTable = '';
             try {
-              const summaryMetrics = JSON.parse('${{ steps.compare.outputs.summary_metrics }}');
+              const summaryMetrics = JSON.parse(process.env.COMPARE_SUMMARY_METRICS || '{}');
               if (Object.keys(summaryMetrics).length > 0) {
                 additionalMetricsTable = '\n\n### Additional Metrics\n\n';
                 additionalMetricsTable += '| Metric | Baseline | PR | Change |\n';
@@ -492,7 +524,7 @@ jobs:
             |--------|-----------------|-----------|--------|
             | ${primary_metric} | ${baseline} | ${pr_value} | ${regression_pct}% |
 
-            **Threshold**: ±${threshold}% allowed regression
+            **Threshold**: +/-${threshold}% allowed regression
 
             ${actionText}
             ${additionalMetricsTable}
@@ -503,13 +535,13 @@ jobs:
             This automated check compares \`${primary_metric}\` on this PR against the main branch baseline.
 
             - **Regression Threshold**: ${threshold}%
-            - **Warmup Iterations**: ${{ inputs.warmup-iterations }}
-            - **Benchmark Iterations**: ${{ inputs.benchmark-iterations }}
-            - **Baseline Source**: ${{ steps.baseline_source.outputs.source }}
+            - **Warmup Iterations**: ${warmup}
+            - **Benchmark Iterations**: ${iterations}
+            - **Baseline Source**: ${baselineSource}
 
             To reproduce locally:
             \`\`\`bash
-            uv run python ${{ inputs.benchmark-script }} --iterations 1000 ${{ inputs.benchmark-args }}
+            uv run python ${benchmarkScript} --iterations 1000 ${benchmarkArgs}
             \`\`\`
             </details>
             `;
@@ -523,28 +555,36 @@ jobs:
 
       - name: Performance Summary
         if: always()
+        env:
+          COMPARE_PRIMARY_METRIC: ${{ steps.compare.outputs.primary_metric }}
+          COMPARE_BASELINE: ${{ steps.compare.outputs.baseline_value }}
+          COMPARE_PR: ${{ steps.compare.outputs.pr_value }}
+          COMPARE_REGRESSION_PCT: ${{ steps.compare.outputs.regression_pct }}
+          COMPARE_STATUS: ${{ steps.compare.outputs.status }}
+          REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
+          BASELINE_SOURCE: ${{ steps.baseline_source.outputs.source }}
         run: |
           echo "# 📊 Performance Regression Test Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Primary Metric | ${{ steps.compare.outputs.primary_metric }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Baseline | ${{ steps.compare.outputs.baseline_value }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| PR | ${{ steps.compare.outputs.pr_value }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Change | ${{ steps.compare.outputs.regression_pct }}% |" >> $GITHUB_STEP_SUMMARY
-          echo "| Status | ${{ steps.compare.outputs.status }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Threshold | ±${{ inputs.regression-threshold }}% |" >> $GITHUB_STEP_SUMMARY
-          echo "| Baseline Source | ${{ steps.baseline_source.outputs.source }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Primary Metric | $COMPARE_PRIMARY_METRIC |" >> $GITHUB_STEP_SUMMARY
+          echo "| Baseline | $COMPARE_BASELINE |" >> $GITHUB_STEP_SUMMARY
+          echo "| PR | $COMPARE_PR |" >> $GITHUB_STEP_SUMMARY
+          echo "| Change | $COMPARE_REGRESSION_PCT% |" >> $GITHUB_STEP_SUMMARY
+          echo "| Status | $COMPARE_STATUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Threshold | +/-$REGRESSION_THRESHOLD% |" >> $GITHUB_STEP_SUMMARY
+          echo "| Baseline Source | $BASELINE_SOURCE |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.compare.outputs.status }}" == "regression" ]; then
+          if [ "$COMPARE_STATUS" == "regression" ]; then
             echo "## ❌ Performance Regression Detected" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Performance has degraded by ${{ steps.compare.outputs.regression_pct }}%." >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ steps.compare.outputs.status }}" == "improvement" ]; then
+            echo "Performance has degraded by $COMPARE_REGRESSION_PCT%." >> $GITHUB_STEP_SUMMARY
+          elif [ "$COMPARE_STATUS" == "improvement" ]; then
             echo "## 🎉 Performance Improved" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Performance has improved by ${{ steps.compare.outputs.regression_pct }}%." >> $GITHUB_STEP_SUMMARY
+            echo "Performance has improved by $COMPARE_REGRESSION_PCT%." >> $GITHUB_STEP_SUMMARY
           else
             echo "## ✅ Performance OK" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -553,6 +593,9 @@ jobs:
 
       - name: Fail on Regression
         if: inputs.fail-on-regression && steps.compare.outputs.regression_detected == 'true'
+        env:
+          COMPARE_REGRESSION_PCT: ${{ steps.compare.outputs.regression_pct }}
+          REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
         run: |
-          echo "::error::Performance regression detected: ${{ steps.compare.outputs.regression_pct }}% (threshold: ${{ inputs.regression-threshold }}%)"
+          echo "::error::Performance regression detected: $COMPARE_REGRESSION_PCT% (threshold: $REGRESSION_THRESHOLD%)"
           exit 1

--- a/.github/workflows/python-pr-validation.yml
+++ b/.github/workflows/python-pr-validation.yml
@@ -253,11 +253,14 @@ jobs:
 
       - name: PR Metadata Summary
         if: always()
+        env:
+          REQUIRE_CONVENTIONAL_COMMITS: ${{ inputs.require-conventional-commits }}
+          REQUIRE_DESCRIPTION: ${{ inputs.require-description }}
         run: |
           echo "## PR Metadata Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ inputs.require-conventional-commits }}" == "true" ]; then
+          if [ "$REQUIRE_CONVENTIONAL_COMMITS" == "true" ]; then
             if [ "${{ steps.validate-title.outputs.valid }}" == "true" ]; then
               echo "- Title: Valid (Conventional Commits)" >> $GITHUB_STEP_SUMMARY
             else
@@ -265,7 +268,7 @@ jobs:
             fi
           fi
 
-          if [ "${{ inputs.require-description }}" == "true" ]; then
+          if [ "$REQUIRE_DESCRIPTION" == "true" ]; then
             if [ "${{ steps.validate-description.outputs.valid }}" == "true" ]; then
               echo "- Description: Valid" >> $GITHUB_STEP_SUMMARY
             else
@@ -304,22 +307,30 @@ jobs:
         run: uv sync --all-extras
 
       - name: Check formatting (Ruff)
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          TEST_DIR: ${{ inputs.test-directory }}
         run: |
           echo "Checking code formatting..."
-          uv run ruff format --check ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/ || {
+          uv run ruff format --check "$SRC_DIR/" "$TEST_DIR/" || {
             echo "::error::Code formatting issues detected. Run 'ruff format' to fix."
             exit 1
           }
 
       - name: Run linter (Ruff)
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          TEST_DIR: ${{ inputs.test-directory }}
         run: |
           echo "Running linter..."
-          uv run ruff check ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/ --output-format=github
+          uv run ruff check "$SRC_DIR/" "$TEST_DIR/" --output-format=github
 
       - name: Run type checker (BasedPyright)
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "Running type checker..."
-          uv run basedpyright ${{ inputs.source-directory }}/ || {
+          uv run basedpyright "$SRC_DIR/" || {
             echo "::warning::Type checking found issues"
           }
 
@@ -362,12 +373,15 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests with coverage
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
         run: |
           uv run pytest \
-            --cov=${{ inputs.source-directory }} \
+            --cov="$SRC_DIR" \
             --cov-report=xml:coverage.xml \
             --cov-report=term-missing \
-            --cov-fail-under=${{ inputs.coverage-threshold }} \
+            --cov-fail-under="$COVERAGE_THRESHOLD" \
             -v
 
       - name: Upload coverage artifact

--- a/.github/workflows/python-pr-validation.yml
+++ b/.github/workflows/python-pr-validation.yml
@@ -256,12 +256,14 @@ jobs:
         env:
           REQUIRE_CONVENTIONAL_COMMITS: ${{ inputs.require-conventional-commits }}
           REQUIRE_DESCRIPTION: ${{ inputs.require-description }}
+          TITLE_VALID: ${{ steps.validate-title.outputs.valid }}
+          DESCRIPTION_VALID: ${{ steps.validate-description.outputs.valid }}
         run: |
           echo "## PR Metadata Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ "$REQUIRE_CONVENTIONAL_COMMITS" == "true" ]; then
-            if [ "${{ steps.validate-title.outputs.valid }}" == "true" ]; then
+            if [ "$TITLE_VALID" == "true" ]; then
               echo "- Title: Valid (Conventional Commits)" >> $GITHUB_STEP_SUMMARY
             else
               echo "- Title: Invalid" >> $GITHUB_STEP_SUMMARY
@@ -269,7 +271,7 @@ jobs:
           fi
 
           if [ "$REQUIRE_DESCRIPTION" == "true" ]; then
-            if [ "${{ steps.validate-description.outputs.valid }}" == "true" ]; then
+            if [ "$DESCRIPTION_VALID" == "true" ]; then
               echo "- Description: Valid" >> $GITHUB_STEP_SUMMARY
             else
               echo "- Description: Invalid or too short" >> $GITHUB_STEP_SUMMARY
@@ -414,6 +416,7 @@ jobs:
         id: breaking
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Check PR title for breaking change indicator
           if [[ "$PR_TITLE" =~ "!" ]] || [[ "$PR_TITLE" =~ "BREAKING" ]]; then
@@ -432,7 +435,7 @@ jobs:
             "public/"
           )
 
-          git diff --name-only origin/${{ github.base_ref }}...HEAD > changed_files.txt
+          git diff --name-only "origin/$BASE_REF"...HEAD > changed_files.txt
 
           BREAKING_FILES=""
           for pattern in "${BREAKING_PATTERNS[@]}"; do
@@ -448,18 +451,21 @@ jobs:
 
       - name: Breaking Change Summary
         if: always()
+        env:
+          HAS_BREAKING: ${{ steps.breaking.outputs.has_breaking }}
+          BREAKING_FILES: ${{ steps.breaking.outputs.breaking_files }}
         run: |
           echo "## Breaking Change Analysis" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.breaking.outputs.has_breaking }}" == "true" ]; then
+          if [ "$HAS_BREAKING" == "true" ]; then
             echo "**Breaking change indicator found in PR title**" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ -n "${{ steps.breaking.outputs.breaking_files }}" ]; then
+          if [ -n "$BREAKING_FILES" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Potentially breaking files modified:**" >> $GITHUB_STEP_SUMMARY
-            echo "${{ steps.breaking.outputs.breaking_files }}" >> $GITHUB_STEP_SUMMARY
+            echo "$BREAKING_FILES" >> $GITHUB_STEP_SUMMARY
           fi
 
   # PR size labeling
@@ -535,23 +541,33 @@ jobs:
 
     steps:
       - name: Generate validation summary
+        env:
+          PR_META_RESULT: ${{ needs.pr-metadata.result }}
+          CODE_QUALITY_RESULT: ${{ needs.code-quality.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+          BREAKING_CHANGES_RESULT: ${{ needs.breaking-changes.result }}
+          SIZE_LABELING_RESULT: ${{ needs.size-labeling.result }}
         run: |
           echo "## Dependency & Standards Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| PR Metadata | ${{ needs.pr-metadata.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Code Quality | ${{ needs.code-quality.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Tests | ${{ needs.tests.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Breaking Changes | ${{ needs.breaking-changes.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Size Labeling | ${{ needs.size-labeling.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| PR Metadata | $PR_META_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Code Quality | $CODE_QUALITY_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tests | $TESTS_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Breaking Changes | $BREAKING_CHANGES_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Size Labeling | $SIZE_LABELING_RESULT |" >> $GITHUB_STEP_SUMMARY
 
       - name: Check validation result
+        env:
+          PR_META_RESULT: ${{ needs.pr-metadata.result }}
+          CODE_QUALITY_RESULT: ${{ needs.code-quality.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
         run: |
           # Check critical jobs
-          if [ "${{ needs.pr-metadata.result }}" == "failure" ] || \
-             [ "${{ needs.code-quality.result }}" == "failure" ] || \
-             [ "${{ needs.tests.result }}" == "failure" ]; then
+          if [ "$PR_META_RESULT" == "failure" ] || \
+             [ "$CODE_QUALITY_RESULT" == "failure" ] || \
+             [ "$TESTS_RESULT" == "failure" ]; then
             echo "::error::PR validation failed"
             exit 1
           fi

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -91,19 +91,12 @@ jobs:
 
       - name: Run security checks
         if: ${{ inputs.run-security-checks }}
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
-          echo "🔒 Running pre-publish security checks..."
-
-          # Install security tools
-          pip install safety bandit
-
-          # Check for known vulnerabilities in dependencies
-          echo "📦 Checking dependencies for vulnerabilities..."
-          safety check || echo "⚠️  Safety check found issues - review before publishing"
-
-          # Scan source code for security issues
-          echo "🔍 Scanning source code..."
-          bandit -r ${{ inputs.source-directory }} -ll || echo "⚠️  Bandit found issues - review before publishing"
+          echo "Running pre-publish security checks..."
+          uv run pip-audit --strict
+          uv run bandit -r "$SRC_DIR" -c pyproject.toml -ll
 
       - name: Build distribution packages
         run: |
@@ -161,12 +154,14 @@ jobs:
           verbose: true
 
       - name: Publication summary
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
         run: |
           echo "## 🎉 Published to PyPI!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Project**: https://pypi.org/project/${{ inputs.package-name }}/" >> $GITHUB_STEP_SUMMARY
+          echo "**Project**: https://pypi.org/project/$PACKAGE_NAME/" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Install**: \`pip install ${{ inputs.package-name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Install**: \`pip install $PACKAGE_NAME\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🔒 Security" >> $GITHUB_STEP_SUMMARY
           echo "- Published using OIDC Trusted Publishing" >> $GITHUB_STEP_SUMMARY
@@ -211,14 +206,16 @@ jobs:
           verbose: true
 
       - name: Publication summary
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
         run: |
           echo "## 🧪 Published to TestPyPI!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Project**: https://test.pypi.org/project/${{ inputs.package-name }}/" >> $GITHUB_STEP_SUMMARY
+          echo "**Project**: https://test.pypi.org/project/$PACKAGE_NAME/" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Test Install**:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "pip install --index-url https://test.pypi.org/simple/ ${{ inputs.package-name }}" >> $GITHUB_STEP_SUMMARY
+          echo "pip install --index-url https://test.pypi.org/simple/ $PACKAGE_NAME" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🔒 Security" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -95,8 +95,8 @@ jobs:
           SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "Running pre-publish security checks..."
-          uv run pip-audit --strict
-          uv run bandit -r "$SRC_DIR" -c pyproject.toml -ll
+          uvx pip-audit
+          uvx bandit -r "$SRC_DIR" -c pyproject.toml -ll
 
       - name: Build distribution packages
         run: |

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -285,13 +285,13 @@ jobs:
         env:
           SIGN_ARTIFACTS: ${{ inputs.sign-artifacts }}
           GENERATE_SBOM: ${{ inputs.generate-sbom }}
+          RELEASE_VERSION: ${{ steps.semantic-release.outputs.version || steps.manual-release.outputs.version }}
+          RELEASE_TAG: ${{ steps.semantic-release.outputs.tag || steps.manual-release.outputs.tag }}
         run: |
-          VERSION="${{ steps.semantic-release.outputs.version || steps.manual-release.outputs.version }}"
-          TAG="${{ steps.semantic-release.outputs.tag || steps.manual-release.outputs.tag }}"
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** $TAG" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $RELEASE_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** $RELEASE_TAG" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Security Features" >> $GITHUB_STEP_SUMMARY
           if [ "$SIGN_ARTIFACTS" == "true" ]; then

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -97,11 +97,7 @@ on:
         value: ${{ jobs.release.outputs.tag }}
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   # ============================================================================
@@ -129,24 +125,33 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install ${{ inputs.python-version }}
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
         run: uv sync --all-extras
 
       - name: Run tests
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
         run: |
           uv run pytest \
-            --cov=${{ inputs.source-directory }} \
+            --cov="$SRC_DIR" \
             --cov-report=term-missing \
-            --cov-fail-under=${{ inputs.coverage-threshold }} \
+            --cov-fail-under="$COVERAGE_THRESHOLD" \
             -v
 
       - name: Run type checker
-        run: uv run basedpyright ${{ inputs.source-directory }}/
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+        run: uv run basedpyright "$SRC_DIR/"
 
       - name: Run linter
-        run: uv run ruff check ${{ inputs.source-directory }}/
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+        run: uv run ruff check "$SRC_DIR/"
 
   # ============================================================================
   # Job 2: Build and Create Release
@@ -157,6 +162,10 @@ jobs:
     if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     outputs:
       released: ${{ steps.semantic-release.outputs.released || steps.manual-release.outputs.released }}
       version: ${{ steps.semantic-release.outputs.version || steps.manual-release.outputs.version }}
@@ -264,6 +273,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload distribution artifacts
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: release-dist
@@ -272,6 +282,9 @@ jobs:
 
       - name: Release Summary
         if: steps.semantic-release.outputs.released == 'true' || steps.manual-release.outputs.released == 'true'
+        env:
+          SIGN_ARTIFACTS: ${{ inputs.sign-artifacts }}
+          GENERATE_SBOM: ${{ inputs.generate-sbom }}
         run: |
           VERSION="${{ steps.semantic-release.outputs.version || steps.manual-release.outputs.version }}"
           TAG="${{ steps.semantic-release.outputs.tag || steps.manual-release.outputs.tag }}"
@@ -281,10 +294,10 @@ jobs:
           echo "**Tag:** $TAG" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Security Features" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ inputs.sign-artifacts }}" == "true" ]; then
+          if [ "$SIGN_ARTIFACTS" == "true" ]; then
             echo "- Sigstore signing: enabled" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ "${{ inputs.generate-sbom }}" == "true" ]; then
+          if [ "$GENERATE_SBOM" == "true" ]; then
             echo "- SBOM generated: enabled" >> $GITHUB_STEP_SUMMARY
           fi
           echo "- SHA256 hashes: available" >> $GITHUB_STEP_SUMMARY
@@ -298,6 +311,8 @@ jobs:
     if: ${{ inputs.publish-to-pypi && (needs.release.outputs.released == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/project/${{ inputs.pypi-package-name }}/
@@ -323,9 +338,12 @@ jobs:
           UV_PUBLISH_URL: ${{ inputs.pypi-url }}
 
       - name: PyPI Summary
+        env:
+          PYPI_PACKAGE: ${{ inputs.pypi-package-name }}
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
         run: |
           echo "## PyPI Publication" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Published **${{ inputs.pypi-package-name }}** version **${{ needs.release.outputs.version }}** to PyPI" >> $GITHUB_STEP_SUMMARY
+          echo "Published **$PYPI_PACKAGE** version **$RELEASE_VERSION** to PyPI" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "[View on PyPI](https://pypi.org/project/${{ inputs.pypi-package-name }}/${{ needs.release.outputs.version }}/)" >> $GITHUB_STEP_SUMMARY
+          echo "[View on PyPI](https://pypi.org/project/$PYPI_PACKAGE/$RELEASE_VERSION/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -166,6 +166,8 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      issues: write        # semantic-release posts release notes to referenced issues
+      pull-requests: write # semantic-release comments on merged PRs in release notes
     outputs:
       released: ${{ steps.semantic-release.outputs.released || steps.manual-release.outputs.released }}
       version: ${{ steps.semantic-release.outputs.version || steps.manual-release.outputs.version }}

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -405,21 +405,26 @@ jobs:
 
     steps:
       - name: Validate Security Results
+        env:
+          RESULT_CODEQL: ${{ needs.codeql.result }}
+          RESULT_DEP_REVIEW: ${{ needs.dependency-review.result }}
+          RESULT_PYTHON_SECURITY: ${{ needs.python-security.result }}
+          RESULT_OSV_SCANNER: ${{ needs.osv-scanner.result }}
         run: |
           echo "🔒 Security Analysis Results:"
-          echo "CodeQL: ${{ needs.codeql.result }}"
-          echo "Dependency Review: ${{ needs.dependency-review.result }}"
-          echo "Python Security: ${{ needs.python-security.result }}"
-          echo "OSV Scanner: ${{ needs.osv-scanner.result }}"
+          echo "CodeQL: $RESULT_CODEQL"
+          echo "Dependency Review: $RESULT_DEP_REVIEW"
+          echo "Python Security: $RESULT_PYTHON_SECURITY"
+          echo "OSV Scanner: $RESULT_OSV_SCANNER"
 
           is_acceptable() {
             [[ "$1" == "success" || "$1" == "skipped" ]]
           }
 
-          if is_acceptable "${{ needs.codeql.result }}" && \
-             is_acceptable "${{ needs.dependency-review.result }}" && \
-             is_acceptable "${{ needs.python-security.result }}" && \
-             is_acceptable "${{ needs.osv-scanner.result }}"; then
+          if is_acceptable "$RESULT_CODEQL" && \
+             is_acceptable "$RESULT_DEP_REVIEW" && \
+             is_acceptable "$RESULT_PYTHON_SECURITY" && \
+             is_acceptable "$RESULT_OSV_SCANNER"; then
             echo "✅ Security gate passed"
             echo "🔐 All security checks completed successfully"
           else

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -321,8 +321,8 @@ jobs:
 
               return 'UNKNOWN'
 
-          fail_on_high = os.environ.get("FAIL_ON_HIGH", "false").lower() == "true"
-          fail_on_medium = os.environ.get("FAIL_ON_MEDIUM", "false").lower() == "true"
+          fail_on_high = os.environ["FAIL_ON_HIGH"] == "true"
+          fail_on_medium = os.environ["FAIL_ON_MEDIUM"] == "true"
 
           try:
               with open('osv-results.json', 'r') as f:

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -224,12 +224,14 @@ jobs:
 
       - name: Bandit Static Analysis
         if: ${{ inputs.run-bandit }}
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "🔒 Running Bandit security analysis..."
-          uv run bandit -r ${{ inputs.source-directory }} \
+          uv run bandit -r "$SRC_DIR" \
             -f json -o bandit-report.json \
             -c pyproject.toml || true
-          uv run bandit -r ${{ inputs.source-directory }} -c pyproject.toml
+          uv run bandit -r "$SRC_DIR" -c pyproject.toml
 
       - name: Safety Vulnerability Scan
         if: ${{ inputs.run-safety }}
@@ -279,10 +281,14 @@ jobs:
             --output=osv-results.json
 
       - name: Analyze OSV Results
+        env:
+          FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
+          FAIL_ON_MEDIUM: ${{ inputs.fail-on-medium }}
         run: |
           echo "🔍 Analyzing OSV scan results..."
           python3 << 'EOF'
           import json
+          import os
           import sys
 
           def extract_severity(vuln):
@@ -314,6 +320,9 @@ jobs:
                   return 'MEDIUM' if max_severity == 'MODERATE' else max_severity
 
               return 'UNKNOWN'
+
+          fail_on_high = os.environ.get("FAIL_ON_HIGH", "false").lower() == "true"
+          fail_on_medium = os.environ.get("FAIL_ON_MEDIUM", "false").lower() == "true"
 
           try:
               with open('osv-results.json', 'r') as f:
@@ -355,13 +364,13 @@ jobs:
                   print(f'❌ HIGH/CRITICAL: {len(high_crit)} vulnerabilities')
                   for v in high_crit[:5]:
                       print(f'   - {v}')
-                  if '${{ inputs.fail-on-high }}' == 'true':
+                  if fail_on_high:
                       print('\n❌ Build FAILED: HIGH/CRITICAL vulnerabilities found')
                       sys.exit(1)
 
               if medium:
                   print(f'⚠️  MEDIUM: {len(medium)} vulnerabilities')
-                  if '${{ inputs.fail-on-medium }}' == 'true':
+                  if fail_on_medium:
                       print('\n❌ Build FAILED: MEDIUM vulnerabilities found')
                       sys.exit(1)
 

--- a/.github/workflows/python-slsa.yml
+++ b/.github/workflows/python-slsa.yml
@@ -14,12 +14,12 @@
 #       outputs:
 #         hashes: ${{ steps.hash.outputs.hashes }}
 #       steps:
-#         - uses: actions/checkout@v4
+#         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 #         - run: pip install build && python -m build
 #         - id: hash
 #           run: |
 #             cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
-#         - uses: actions/upload-artifact@v4
+#         - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
 #           with:
 #             name: dist
 #             path: dist/
@@ -50,6 +50,13 @@
 #   you must call it directly from your workflow.
 #
 # See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations
+#
+# IMPORTANT: SLSA provenance is NOT included in python-release.yml.
+# Every caller must add the provenance job from this template directly
+# into their own top-level release workflow. GitHub Actions prohibits
+# nested reusable workflow calls, so this job cannot be called from
+# python-release.yml.
+#
 # ============================================================================
 
 name: SLSA Provenance (Template)

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ actionlint
 
 # Git worktrees
 .worktrees/
+
+# Internal planning and brainstorming docs (not for public consumption)
+docs/superpowers/

--- a/docs/planning/PROJECT-PLAN.md
+++ b/docs/planning/PROJECT-PLAN.md
@@ -1,0 +1,394 @@
+# Project Plan: Workflow Security and Architecture Remediation
+
+**Date:** 2026-04-30
+**Status:** Active
+**ADR:** [ADR-001](adr/adr-001-workflow-security-remediation-delivery.md)
+**Source Spec:** `docs/superpowers/specs/2026-04-30-workflow-security-architecture-remediation-design.md`
+
+---
+
+## Executive Summary
+
+A parallel agent audit of the 23 reusable org-level GitHub Actions workflows in
+`ByronWilliamsCPA/.github` identified 3 critical findings (one arbitrary Python RCE vector,
+one code injection vector, one missing SLSA provenance), 6 high findings (permission
+over-scoping, shell injection via unquoted inputs), and multiple medium findings spanning
+egress policy, artifact integrity, and false-assurance security gates. Architecture gaps
+(duplicated tooling with divergent configs, wrong org references, missing workflows) and
+supply chain gaps (Docker SBOM and provenance off by default, pip-audit not used consistently)
+were identified in parallel.
+
+This plan delivers remediation in three sequential PRs, each gating on the previous merging
+to `main`. Security fixes ship first, in isolation from breaking architectural changes.
+Breaking changes ship second, with in-file migration notes for every affected caller. New
+capabilities ship third, additive only.
+
+---
+
+## Scope
+
+### In Scope
+
+- All 23 reusable workflows in `.github/workflows/`
+- Shell injection remediation: env-var isolation pattern applied to every `run:` block that
+  references `${{ inputs.* }}`
+- Python heredoc injection remediation: all inputs read via `os.environ` instead of direct
+  interpolation
+- Permission scoping: workflow-level permissions moved to the specific jobs that need them
+- Supply chain: Docker SBOM and provenance defaults, pip-audit adoption, SLSA template pins
+- Architecture: remove duplicated SonarCloud and Codecov from `python-ci.yml`, fix org
+  references, add Scorecard score gate, hard-fail removed workflow, fix auto-merge detection
+- New capabilities: `python-precommit.yml`, `python-standard-stack.yml`, commit-lint job
+
+### Out of Scope
+
+| Item | Reason |
+| --- | --- |
+| Egress policy upgrades (`audit` to `block`) across all 23 workflows | High effort; requires per-job endpoint discovery |
+| Mid-job `git checkout origin/main` refactor in `python-performance-regression.yml` (MED-07) | Requires significant job-splitting redesign |
+| SBOM attachment to GitHub Releases from `python-sbom.yml` | Requires `python-release.yml` coordination |
+| `python-codecov.yml` `CODECOV_TOKEN: required: true` to `required: false` | Low priority |
+
+---
+
+## Architecture Overview
+
+### ADR-001: Three Sequential PRs with Hard Dependency Gates (Accepted)
+
+Security fixes, architecture cleanup, and new capabilities are delivered in strict dependency
+order. Each PR merges to `main` before the next branch is created. This isolates breaking
+architecture changes from security fixes and makes each PR independently reviewable.
+
+Rejected alternative: single large PR (too wide for safe review; security and breaking changes
+interact unpredictably in a combined diff).
+
+Rejected alternative: many small PRs per finding (review overhead exceeds value; related fixes
+belong together for atomic validation).
+
+### ADR-001: Parallel Worktrees for Phase 1
+
+Phase 1 splits into two logically independent change sets worked in parallel worktrees and
+merged into the integration branch before the PR opens:
+
+- Worktree A (`fix/perf-regression-rce`): `python-performance-regression.yml` only
+- Worktree B (`fix/workflow-input-quoting`): systematic sweep across ~12 files plus supply chain
+
+Both worktrees live at `.worktrees/<branch-slug>` inside the project root per the mandatory
+convention in `.claude/rules/git-workflow.md`.
+
+### ADR-001: Hard Removal with Migration Notes (No Deprecation Shims)
+
+SonarCloud, Codecov, and `python-pr-validation.yml` are removed entirely rather than gated
+behind deprecation flags. Breaking callers receive migration comments in workflow headers and
+a hard-fail job that exits 1 with a migration message on every trigger.
+
+Rejected alternative: deprecation path with flags kept for one release cycle (adds dead code,
+complicates Phase 2, and signals that removal is negotiable).
+
+### ADR-001: Env-Var Isolation as the Canonical Input-Sanitization Pattern
+
+All inputs used in `run:` shell blocks or Python heredocs must be declared in an `env:` block
+and referenced as `$VAR` (shell) or `os.environ["VAR"]` (Python). Direct
+`${{ inputs.* }}` interpolation in `run:` blocks is prohibited. This pattern is applied
+systematically in Phase 1 and is required for all new workflows in Phase 3.
+
+### ADR-001: Supply Chain Fixes Bundled with Security PR
+
+Docker provenance defaults, pip-audit replacement, and SLSA template fixes are
+security-adjacent and deliver in Phase 1 alongside the shell-injection and Python-injection
+fixes. No justification exists for deferring security posture improvements when already scoped.
+
+---
+
+## Technology Stack
+
+| Layer | Technology |
+| --- | --- |
+| Workflow runtime | GitHub Actions (reusable `workflow_call` workflows) |
+| Shell validation | actionlint, shellcheck (via `qlty check`) |
+| Python toolchain | uv, pip-audit, bandit, ruff, basedpyright |
+| Security hardening | step-security/harden-runner (egress audit/block) |
+| Supply chain | SLSA provenance, Docker SBOM, SHA-pinned actions |
+| Pre-commit | pre-commit (enforced before every commit) |
+| Commit convention | Conventional Commits, signed commits |
+
+---
+
+## Phased Development
+
+### Phase 1: Security Fixes and Supply Chain
+
+**Branch:** `fix/workflow-security-remediation`
+**Depends on:** none (first phase)
+**Breaking:** soft (Docker `enable-sbom` default flips to `true`; callers that set it `false`
+intentionally must add an explicit override)
+
+#### Goal
+
+Eliminate all critical and high security findings before any architectural work. No `${{ inputs.* }}`
+appears unquoted in any `run:` block across all 23 workflows after this phase merges.
+
+#### Worktree Structure
+
+Two parallel worktrees merge into `fix/workflow-security-remediation` before the PR opens.
+Worktree A merges first (smaller, easier to review), then Worktree B (resolve any conflicts).
+
+**Worktree A** at `.worktrees/fix-perf-regression-rce` on branch `fix/perf-regression-rce`:
+touches only `python-performance-regression.yml`.
+
+**Worktree B** at `.worktrees/fix-workflow-input-quoting` on branch `fix/workflow-input-quoting`:
+systematic sweep across ~12 files plus supply chain fixes.
+
+#### Deliverables
+
+**Worktree A:**
+
+- Remove `synthetic-data-script` input from `python-performance-regression.yml` (CRIT-01 RCE);
+  callers place their script at `scripts/generate_test_data.py`; document convention in header
+- Move all Python heredoc inputs to `env:` blocks, read via `os.environ` (CRIT-02); affects
+  lines 185-192, 348, 353-354, 419
+- Move `benchmark-script`, `benchmark-args`, `warmup-iterations`, `benchmark-iterations` to
+  env vars and quote all shell references (HIGH-05)
+
+**Worktree B:**
+
+- `python-ci.yml`: env-var pattern for `source-directory`, `test-directory`, `python-version`,
+  `dead-code-confidence`; move `pull-requests: write` and `checks: write` from workflow level
+  to job level; replace `|| true` swallowing with exit-code-5 check pattern
+- `python-compatibility.yml`: env-var pattern for `operating-systems`, `python-versions`,
+  `system-deps-*`; add pattern validation before sudo install
+- `python-docs.yml`: move `id-token: write` to deploy job level; add harden-runner to deploy
+  job with `egress-policy: block`; remove redundant `actions/cache` step
+- `python-release.yml`: move all permissions to job level; remove `issues: write`; set
+  workflow-level to `contents: read`; add `if: always()` to artifact upload step
+- `python-security-analysis.yml`: move boolean heredoc inputs `fail-on-high`, `fail-on-medium`
+  to env vars
+- `python-pr-validation.yml`: env-var pattern for remaining string inputs (Phase 2 replaces
+  content; Phase 1 only hardens existing inputs)
+- `python-slsa.yml`: SHA-pin comment examples; add prominent SLSA-not-included header note
+- `python-publish-pypi.yml`: replace unpinned `pip install safety bandit` block with
+  `uv run pip-audit --strict` and bandit against `pyproject.toml`
+- `python-docker.yml`: flip `enable-sbom` default to `true`; add `enable-provenance` input
+  (default `true`)
+
+#### Acceptance Criteria
+
+- No `${{ inputs.* }}` appears unquoted in any `run:` shell block across all 23 workflows
+- No `${{ inputs.* }}` interpolated directly as Python syntax inside any heredoc
+- `synthetic-data-script` input does not exist in any workflow
+- `python-release.yml` artifact upload step has `if: always()`
+- Docker `enable-sbom` defaults `true`; `enable-provenance` input exists and defaults `true`
+- All supply chain items updated (SLSA template SHA pins, pip-audit, Docker provenance)
+- `workflow_dispatch` trigger confirmed on downstream test repo before PR marked ready
+
+#### Quality Gates
+
+- `qlty check` (actionlint + shellcheck) passes on all modified workflow YAML before each commit
+- `pre-commit run --all-files` passes before each commit
+- All inputs in `run:` blocks use env-var isolation pattern (zero direct interpolation)
+- Migration notes present in headers of all workflows with breaking input changes
+
+#### Estimated Duration
+
+1 focused session (two parallel worktrees, merge, PR review)
+
+---
+
+### Phase 2: Architecture Cleanup
+
+**Branch:** `fix/workflow-architecture-cleanup`
+**Depends on:** Phase 1 merged to `main`
+**Breaking:** yes; callers using `enable-sonarcloud`, `enable-codecov`, or
+`python-pr-validation.yml` break on merge with no gradual migration window
+
+#### Goal
+
+Remove duplicated tooling, fix wrong org references, add the Scorecard score gate, and retire
+`python-pr-validation.yml` with a hard-fail migration stub. All breaking changes documented
+in workflow headers with migration notes.
+
+#### Deliverables
+
+- `python-ci.yml`: delete `sonarcloud-quality-gate` job (currently lines 579-636); remove
+  `enable-sonarcloud`, `sonarcloud-organization`, `sonarcloud-project-key` inputs and
+  `SONAR_TOKEN` secret; remove job from `ci-gate` `needs:` list; add migration header comment
+  directing callers to `python-sonarcloud.yml`
+- `python-ci.yml`: delete all 7 `codecov/codecov-action` steps and 3 test analytics steps;
+  remove `enable-codecov` input and `CODECOV_TOKEN` secret; add migration header comment
+  pointing callers to `python-codecov.yml`
+- `python-ci.yml`: delete `check-secrets` job (gated only SonarCloud and Codecov, now gone);
+  simplify `ci-gate` to check only `quality-checks`, `llm-governance`, `matrix-testing`
+- `python-ci.yml`: add `-c pyproject.toml` to bandit invocation; replace safety with
+  `uv run pip-audit --strict`
+- `python-fuzzing.yml`, `python-performance-regression.yml`, `python-qlty-coverage.yml`: fix
+  wrong org references from `williaby/.github/` to `ByronWilliamsCPA/.github/` (3 files,
+  line 9 or 12 each)
+- `python-scorecard.yml`: add `min-score` input (number, default 4); add score-gate step that
+  parses SARIF and exits nonzero when any gated check (`Branch-Protection`, `Code-Review`,
+  `Dangerous-Workflow`, `Token-Permissions`, `Pinned-Dependencies`) scores below threshold;
+  all inputs read via `os.environ`
+- `python-sonarcloud.yml`, `python-qlty-coverage.yml`: add `timeout-minutes: 5` to
+  `check-configuration` job
+- `python-compatibility.yml`: add `timeout-minutes: 5` to `build-matrix` and
+  `compatibility-summary` jobs
+- `python-pr-validation.yml`: replace all job content with single `migration-required` job
+  that exits 1 and prints migration message directing callers to `python-ci.yml` and
+  `python-supplemental-checks.yml`
+- `python-supplemental-checks.yml`: replace PR-title string matching for Dependabot
+  major/minor/patch classification with native Dependabot label check (`major`, `minor`,
+  `patch` labels); not spoofable via PR title manipulation
+
+Note: `python-codecov.yml` (the standalone reusable workflow) is retained. Only the inline
+Codecov steps inside `python-ci.yml` are removed.
+
+#### Acceptance Criteria
+
+- `python-ci.yml` has no SonarCloud job, no Codecov steps, no `check-secrets` job
+- `python-ci.yml` bandit invocation includes `-c pyproject.toml`
+- All three wrong org references corrected (`williaby` replaced with `ByronWilliamsCPA`)
+- `python-scorecard.yml` exits nonzero when any gated check scores below `min-score`
+- `python-pr-validation.yml` exits 1 with migration message on every trigger
+- All four missing `timeout-minutes` added
+- `workflow_dispatch` trigger confirmed on downstream test repo before PR marked ready
+
+#### Quality Gates
+
+- `qlty check` (actionlint + shellcheck) passes on all modified workflow YAML before each commit
+- `pre-commit run --all-files` passes before each commit
+- Migration notes present in all headers for removed inputs and jobs
+- No new `${{ inputs.* }}` direct interpolation introduced in any `run:` block
+
+#### Estimated Duration
+
+1 focused session (single worktree, no parallel work needed)
+
+---
+
+### Phase 3: New Capabilities
+
+**Branch:** `feat/workflow-new-capabilities`
+**Depends on:** Phase 2 merged to `main`
+**Breaking:** no; additive only
+
+#### Goal
+
+Add `python-precommit.yml` and `python-standard-stack.yml` as new reusable workflows and wire
+commit-lint into `python-supplemental-checks.yml`. All new workflows use the env-var isolation
+pattern established in Phase 1.
+
+#### Deliverables
+
+- `python-precommit.yml` (new reusable `workflow_call` workflow): inputs `config-path`
+  (string, default `.pre-commit-config.yaml`), `python-version` (string, default `3.12`),
+  `fail-fast` (boolean, default `true`); steps: harden-runner (egress: audit), checkout,
+  setup-uv, `uv sync`, `pre-commit run --all-files`; all inputs via env vars in `run:` blocks
+- `python-standard-stack.yml` (new caller reusable workflow): chains `python-ci.yml`,
+  `python-security-analysis.yml`, `python-sbom.yml` using `needs:`; documents itself as the
+  recommended starting point for new repos; exposes `python-version` (string, default `3.12`),
+  `source-directory` (string, default `src`), `coverage-threshold` (number, default `80`),
+  `fail-on-high` (boolean, default `true`); optional secret passthroughs: `SONAR_TOKEN`,
+  `CODECOV_TOKEN`; nesting depth is 2 levels (caller calls standard-stack which calls
+  ci/security/sbom), within GitHub's 4-level reusable workflow limit
+- `python-supplemental-checks.yml`: add optional `commit-lint` job gated on new boolean input
+  `enable-commit-lint` (default `false`); uses `amannn/action-semantic-pull-request`
+  (SHA-pinned) to validate PR title follows Conventional Commits format
+
+#### Acceptance Criteria
+
+- `python-precommit.yml` exists, is callable via `workflow_call`, and runs pre-commit hooks
+  end-to-end against a test caller
+- `python-standard-stack.yml` exists and chains CI + security + SBOM with minimal caller
+  config (four inputs maximum for a new repo)
+- `python-supplemental-checks.yml` has `enable-commit-lint` input wired to semantic PR title
+  check via SHA-pinned `amannn/action-semantic-pull-request`
+- `workflow_dispatch` trigger confirmed on downstream test repo before PR marked ready
+
+#### Quality Gates
+
+- `qlty check` (actionlint + shellcheck) passes on all new and modified workflow YAML before
+  each commit
+- `pre-commit run --all-files` passes before each commit
+- All inputs in `run:` blocks use env-var isolation pattern (zero direct interpolation)
+- All new action references SHA-pinned with version comment
+
+#### Estimated Duration
+
+1 focused session (single worktree, additive only)
+
+---
+
+## Cross-Cutting Requirements
+
+These requirements apply to every phase and every commit.
+
+| Requirement | Detail |
+| --- | --- |
+| Input isolation | All inputs used in `run:` blocks declared in `env:` and referenced as `$VAR` (shell) or `os.environ["VAR"]` (Python). No direct `${{ inputs.* }}` in `run:` blocks. |
+| Pre-commit | `pre-commit run --all-files` before every commit |
+| Workflow linting | `qlty check` (actionlint + shellcheck) on all modified workflow YAML before each commit |
+| Worktree location | `.worktrees/<branch-slug>` inside the project root; never at global paths |
+| Commit style | Conventional commits, signed commits |
+| Migration notes | In-file migration comments in headers of all workflows with breaking changes |
+| End-to-end validation | `workflow_dispatch` on downstream test repo before each PR is marked ready |
+| Action pins | All action references SHA-pinned with version comment (e.g., `actions/checkout@<sha>  # v4.x.x`) |
+
+---
+
+## Risk Register
+
+| Risk | Source | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- | --- |
+| Merge conflict between Worktree A and Worktree B outputs | ADR-001 | Low | Medium | Worktree A scoped strictly to `python-performance-regression.yml` only; Worktree B touches no files in Worktree A scope |
+| actionlint/shellcheck missed if `qlty check` not run locally | ADR-001 | Medium | High | Enforce `qlty check` as a quality gate before each commit; document in phase acceptance criteria |
+| Callers break on Phase 2 merge with no gradual migration window | ADR-001 | High | Medium | Hard-fail job in `python-pr-validation.yml` provides immediate signal; migration notes in all removed-input headers |
+| Docker `enable-sbom` default flip increases artifact storage costs for opt-out callers | ADR-001 | Low | Low | Document the flip in the workflow header; callers can add `enable-sbom: false` explicitly |
+| `python-standard-stack.yml` nesting depth could approach GitHub's reusable workflow limit | Spec | Low | Medium | Nesting is 2 levels (caller to standard-stack to called workflows); GitHub limit is 4 levels; margin is sufficient |
+| Scorecard SARIF schema differences across runner versions could break score-gate parsing | Spec | Low | Medium | Parse only known fields; add fallback that treats missing score as passing (fail-open on unknown schema) |
+| Supply chain fixes (pip-audit, Docker provenance) may require caller-side `pyproject.toml` changes | Spec | Medium | Medium | Document pip-audit requirement in workflow headers; bandit `-c pyproject.toml` requires a `[tool.bandit]` section |
+
+---
+
+## Success Metrics
+
+**Phase 1 complete when all of the following are true:**
+
+- Zero instances of `${{ inputs.* }}` unquoted in any `run:` shell block across all 23 workflows
+- Zero instances of `${{ inputs.* }}` interpolated directly as Python syntax in any heredoc
+- `synthetic-data-script` input does not exist in any file
+- `python-release.yml` artifact upload step has `if: always()`
+- Docker `enable-sbom` defaults `true`; `enable-provenance` input exists
+- `qlty check` and `pre-commit run --all-files` both pass on all modified files
+
+**Phase 2 complete when all of the following are true:**
+
+- `python-ci.yml` contains no SonarCloud job, no Codecov steps, no `check-secrets` job
+- `python-ci.yml` bandit invocation passes `-c pyproject.toml`
+- All three wrong org references corrected
+- `python-scorecard.yml` exits nonzero when any gated check scores below `min-score`
+- `python-pr-validation.yml` exits 1 with migration message on every trigger
+- All four missing `timeout-minutes` added
+- `qlty check` and `pre-commit run --all-files` both pass on all modified files
+
+**Phase 3 complete when all of the following are true:**
+
+- `python-precommit.yml` exists, is callable, and runs pre-commit hooks end-to-end
+- `python-standard-stack.yml` exists and chains CI + security + SBOM with minimal config
+- `python-supplemental-checks.yml` has `enable-commit-lint` input wired to semantic PR check
+- `qlty check` and `pre-commit run --all-files` both pass on all new and modified files
+
+---
+
+## Phase 0 Checklist: Environment Setup
+
+Before beginning Phase 1, verify the following:
+
+- [ ] Confirm working directory is `/home/byron/dev/.github` (the org-level workflow repo)
+- [ ] Run `git status` to confirm branch is clean and on the intended starting point
+- [ ] Run `git pull origin main` to ensure `main` is current
+- [ ] Verify `.worktrees/` is listed in `.gitignore` (`grep worktrees .gitignore`)
+- [ ] Confirm `qlty check` is available and configured (`qlty check --version`)
+- [ ] Confirm `pre-commit` is installed (`pre-commit --version`)
+- [ ] Confirm a downstream test repo is accessible for `workflow_dispatch` validation
+- [ ] Create Worktree A: `git worktree add .worktrees/fix-perf-regression-rce fix/perf-regression-rce`
+- [ ] Create Worktree B: `git worktree add .worktrees/fix-workflow-input-quoting fix/workflow-input-quoting`
+- [ ] Verify both worktrees appear in `git worktree list`

--- a/docs/planning/adr/adr-001-workflow-security-remediation-delivery.md
+++ b/docs/planning/adr/adr-001-workflow-security-remediation-delivery.md
@@ -1,0 +1,91 @@
+# ADR-001: Workflow Security Remediation Delivery Strategy
+
+**Status:** Accepted
+**Date:** 2026-04-30
+**Deciders:** Byron Williams
+**Source spec:** `docs/superpowers/specs/2026-04-30-workflow-security-architecture-remediation-design.md`
+
+---
+
+## TL;DR
+
+Three sequential PRs deliver security fixes, architecture cleanup, and new capabilities in strict dependency order. PR 1 uses two parallel worktrees merged before the PR opens. All breaking changes use hard removal with in-file migration notes rather than deprecation shims.
+
+---
+
+## Context
+
+A three-domain audit of 23 reusable org-level GitHub Actions workflows identified:
+- 2 critical RCE/injection vectors (arbitrary Python execution, heredoc input interpolation)
+- 6 high findings (permission over-scoping, shell injection via unquoted inputs)
+- Multiple medium findings (egress policy, artifact integrity, false-assurance gates)
+- Architecture gaps (SonarCloud/Codecov duplication, wrong org references, missing workflows)
+- Supply chain gaps (Docker provenance off by default, unpinned security tools)
+
+The remediation spans 23 files and mixes critical security fixes with breaking architectural changes.
+
+---
+
+## Decision
+
+### D1: Three sequential PRs with hard dependency gates
+
+| PR | Focus | Breaking |
+|---|---|---|
+| 1 | Security fixes + supply chain | Soft (Docker defaults flip) |
+| 2 | Architecture cleanup | Yes -- callers must migrate |
+| 3 | New capabilities | No |
+
+Each PR requires the previous to merge to `main` before branching. This isolates breaking architecture changes from security fixes and makes each PR independently reviewable.
+
+**Rejected alternative:** Single large PR -- too wide for safe review; security fixes and breaking architecture changes interact unpredictably in a combined diff.
+
+**Rejected alternative:** Many small PRs per finding -- review overhead exceeds value; related fixes (e.g., all input-quoting changes) belong together for atomic validation.
+
+### D2: Parallel worktrees for PR 1
+
+PR 1 has two logically independent change sets:
+- Worktree A (`fix/perf-regression-rce`): `python-performance-regression.yml` only (CRIT-01, CRIT-02)
+- Worktree B (`fix/workflow-input-quoting`): systematic env-var sweep across ~12 files + supply chain
+
+Both worktrees merge into `fix/workflow-security-remediation` before the PR opens. Worktree paths follow the `.worktrees/<branch-slug>` convention required by CLAUDE.md.
+
+**Rejected alternative:** Sequential worktrees -- the CRIT fixes and the sweep are independent; parallel saves implementation time.
+
+### D3: Hard removal with migration notes (no deprecation shims)
+
+SonarCloud, Codecov, and `python-pr-validation.yml` are removed entirely rather than gated behind deprecation flags. Breaking callers receive:
+- Migration comments in the affected workflow headers
+- A hard-fail job in `python-pr-validation.yml` that exits 1 with a migration message on every trigger
+
+**Rejected alternative:** Deprecation path with `enable-sonarcloud` flag kept for one release cycle -- adds dead code, complicates the architecture cleanup PR, and signals that removal is negotiable.
+
+### D4: Supply chain fixes bundled with security PR (PR 1)
+
+Docker provenance defaults, pip-audit replacement, and SLSA template fixes are security-adjacent and are delivered in PR 1 alongside the shell-injection and Python-injection fixes.
+
+**Rejected alternative:** Defer supply chain to PR 2 -- no justification for deferring security posture improvements when they are already scoped.
+
+### D5: Env-var isolation as the canonical input-sanitization pattern
+
+All inputs used in `run:` shell blocks or Python heredocs must be declared in an `env:` block and referenced via `$VAR` (shell) or `os.environ["VAR"]` (Python). Direct `${{ inputs.* }}` interpolation in `run:` blocks is prohibited.
+
+This pattern is applied systematically across all 23 workflows in PR 1 and is the required pattern for all new workflows in PR 3.
+
+---
+
+## Consequences
+
+**Positive:**
+- Security critical findings resolved in the first PR, before any architecture work
+- Breaking changes isolated to PR 2 with clear migration notes; callers can prepare
+- Env-var isolation pattern is consistent across all 23 workflows after PR 1
+- New workflows in PR 3 inherit the hardened pattern by default
+
+**Negative:**
+- Callers using `enable-sonarcloud`, `enable-codecov`, or `python-pr-validation.yml` break on PR 2 merge with no gradual migration window
+- Docker `enable-sbom` default flip in PR 1 may increase artifact storage costs for callers who set it to false intentionally
+
+**Risks:**
+- Merge conflicts between Worktree A and Worktree B outputs if both touch the same workflow; mitigated by scope restriction (Worktree A touches only `python-performance-regression.yml`)
+- actionlint/shellcheck must validate all modified YAML before each commit; missed by CI if `qlty check` is not run locally

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,0 +1,129 @@
+# Workflow Security and Architecture Remediation Roadmap
+
+**TL;DR:** Three sequential PRs over three implementation sessions. Phase 1 resolves all critical and high security findings. Phase 2 applies breaking architecture cleanup. Phase 3 adds new capabilities. Each phase gates on the previous merging to `main`.
+
+**Source:** `docs/superpowers/specs/2026-04-30-workflow-security-architecture-remediation-design.md`
+**ADR:** `docs/planning/adr/adr-001-workflow-security-remediation-delivery.md`
+
+---
+
+## Phase 1: Security Fixes and Supply Chain
+
+**Branch:** `fix/workflow-security-remediation`
+**Gate:** Merges to `main` before Phase 2 branches
+
+### Phase 1 Deliverables
+
+**Worktree A** (`fix/perf-regression-rce` at `.worktrees/fix-perf-regression-rce`):
+
+- Remove `synthetic-data-script` input from `python-performance-regression.yml` (CRIT-01 RCE)
+- Move all Python heredoc inputs to `env:` blocks, read via `os.environ` (CRIT-02)
+- Move `benchmark-script`, `benchmark-args`, `warmup-iterations`, `benchmark-iterations` to env vars (HIGH-05)
+
+**Worktree B** (`fix/workflow-input-quoting` at `.worktrees/fix-workflow-input-quoting`):
+
+- `python-ci.yml`: env-var pattern for all string inputs; move workflow-level permissions to job level; fix `|| true` swallowing with exit-code-5 pattern (see spec for shell snippet)
+- `python-compatibility.yml`: env-var pattern; pattern-validate package names before sudo install
+- `python-docs.yml`: move `id-token: write` to deploy job; add harden-runner to deploy job; remove redundant cache step
+- `python-release.yml`: move all permissions to job level; remove `issues: write`; add `if: always()` to artifact upload
+- `python-security-analysis.yml`: move boolean heredoc inputs to env vars
+- `python-pr-validation.yml`: env-var pattern for remaining string inputs (note: Phase 2 replaces this workflow's entire job content; Phase 1 only hardens the existing inputs)
+- `python-slsa.yml`: SHA-pin comment examples; add SLSA-not-included header note
+- `python-publish-pypi.yml`: replace unpinned safety block with `uv run pip-audit --strict` + bandit (pip-audit also added to `python-ci.yml` in Phase 2)
+- `python-docker.yml`: flip `enable-sbom` default to `true`; add `enable-provenance` input (default `true`)
+
+### Phase 1 Success Criteria
+
+- No `${{ inputs.* }}` unquoted in any `run:` shell block across all 23 workflows
+- No `${{ inputs.* }}` interpolated directly as Python syntax in any heredoc
+- `synthetic-data-script` input removed
+- `python-release.yml` artifact upload has `if: always()`
+- Docker `enable-sbom` defaults `true`, `enable-provenance` input exists
+- `qlty check` (actionlint + shellcheck) passes on all modified files
+- `pre-commit run --all-files` passes before commit
+
+### Phase 1 Duration
+
+1 focused session (two parallel worktrees, merge, PR review)
+
+---
+
+## Phase 2: Architecture Cleanup
+
+**Branch:** `fix/workflow-architecture-cleanup`
+**Gate:** Requires Phase 1 merged to `main`
+
+### Phase 2 Deliverables
+
+- `python-ci.yml`: delete `sonarcloud-quality-gate` job (lines 579-636), all Codecov steps (7 action steps + 3 analytics), `check-secrets` job; add migration header comments; add `-c pyproject.toml` to bandit; replace safety with `uv run pip-audit --strict`
+- `python-fuzzing.yml`, `python-performance-regression.yml`, `python-qlty-coverage.yml`: fix wrong org references (`williaby` to `ByronWilliamsCPA`)
+- `python-scorecard.yml`: add `min-score` input (default 4); add score-gate step that parses SARIF and exits nonzero when gated checks score below threshold (see spec for exact Python snippet)
+- `python-sonarcloud.yml`, `python-qlty-coverage.yml`: add `timeout-minutes: 5` to `check-configuration` job
+- `python-compatibility.yml`: add `timeout-minutes: 5` to `build-matrix` and `compatibility-summary` jobs
+- `python-pr-validation.yml`: replace all job content with single hard-fail job (exits 1, prints migration message to ci/supplemental-checks)
+- `python-supplemental-checks.yml`: replace PR-title string matching with Dependabot native label check for auto-merge classification
+
+Note: `python-codecov.yml` (the standalone reusable workflow) is retained. Only the inline Codecov steps inside `python-ci.yml` are removed. Callers migrate by calling `python-codecov.yml` directly.
+
+### Phase 2 Success Criteria
+
+- `python-ci.yml` has no SonarCloud job, no Codecov steps, no `check-secrets` job
+- `python-ci.yml` bandit invocation includes `-c pyproject.toml`
+- All three wrong org references corrected
+- `python-scorecard.yml` exits nonzero when gated checks score below `min-score`
+- `python-pr-validation.yml` exits 1 with migration message on every trigger
+- All missing `timeout-minutes` added
+- `qlty check` passes on all modified files
+- `pre-commit run --all-files` passes before commit
+
+### Phase 2 Duration
+
+1 focused session (single worktree, no parallel work needed)
+
+---
+
+## Phase 3: New Capabilities
+
+**Branch:** `feat/workflow-new-capabilities`
+**Gate:** Requires Phase 2 merged to `main`
+
+### Phase 3 Deliverables
+
+- `python-precommit.yml` (new): reusable workflow with harden-runner, checkout, setup-uv, `uv sync`, pre-commit run; inputs `config-path`, `python-version`, `fail-fast` -- all via env vars
+- `python-standard-stack.yml` (new): caller reusable workflow (`workflow_call` trigger) chaining `python-ci.yml`, `python-security-analysis.yml`, `python-sbom.yml` as called workflows via `needs:`; exposes `python-version`, `source-directory`, `coverage-threshold`, `fail-on-high`. Nesting depth: downstream caller calls standard-stack (level 1) which calls ci/security/sbom (level 2) -- within GitHub's 4-level reusable workflow limit.
+- `python-supplemental-checks.yml`: add optional `commit-lint` job gated on `enable-commit-lint` input (default `false`); uses `amannn/action-semantic-pull-request` (SHA-pinned)
+
+### Phase 3 Success Criteria
+
+- `python-precommit.yml` exists, is callable, runs pre-commit hooks end-to-end
+- `python-standard-stack.yml` exists and chains CI + security + SBOM with minimal caller config
+- `python-supplemental-checks.yml` has `enable-commit-lint` input wired to semantic PR title check
+- `qlty check` passes on all new and modified files
+- `pre-commit run --all-files` passes before commit
+
+### Phase 3 Duration
+
+1 focused session (single worktree, additive only)
+
+---
+
+## Deferred (Out of Scope)
+
+| Item | Reason |
+| --- | --- |
+| Egress policy upgrades (`audit` to `block`) across all 23 workflows | High effort, requires per-job endpoint discovery |
+| Mid-job `git checkout origin/main` refactor in `python-performance-regression.yml` (MED-07) | Requires significant job-splitting redesign |
+| SBOM attachment to GitHub Releases from `python-sbom.yml` | Requires `python-release.yml` coordination |
+| `python-codecov.yml` `CODECOV_TOKEN: required: true` to `required: false` | Low priority |
+
+---
+
+## Cross-Cutting Requirements (All Phases)
+
+- All inputs used in `run:` blocks declared in `env:` and referenced as `$VAR` or `os.environ["VAR"]`
+- `qlty check` (actionlint + shellcheck) on all modified workflow YAML before each commit
+- `pre-commit run --all-files` before each commit
+- Worktrees created at `.worktrees/<branch-slug>` inside the project root
+- Conventional commits, signed commits
+- Migration notes in affected workflow headers for all breaking changes
+- Validation: trigger modified workflows via `workflow_dispatch` on a downstream test repo to confirm end-to-end behavior before each PR is marked ready

--- a/docs/superpowers/plans/2026-04-30-phase1-security-supply-chain.md
+++ b/docs/superpowers/plans/2026-04-30-phase1-security-supply-chain.md
@@ -1,0 +1,1505 @@
+# Phase 1: Security Fixes and Supply Chain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate all critical and high security findings from the 23 org-level reusable workflows -- no `${{ inputs.* }}` unquoted in any `run:` block, no Python heredoc injection, and supply chain defaults hardened.
+
+**Architecture:** Two parallel worktrees merge into the integration branch before the PR opens. Worktree A handles the single CRIT file (`python-performance-regression.yml`). Worktree B handles the systematic env-var sweep across nine other files plus supply chain fixes. Both worktrees live at `.worktrees/<branch-slug>` inside the project root per `.claude/rules/git-workflow.md`. All changes are YAML edits only -- no application code exists in this repo.
+
+**Tech Stack:** GitHub Actions YAML, qlty (actionlint + shellcheck validation), pre-commit
+
+---
+
+## File Structure
+
+**Modified in Worktree A** (`fix/perf-regression-rce`):
+- `.github/workflows/python-performance-regression.yml` (541 lines): remove `synthetic-data-script` input, move heredoc inputs to env vars, move benchmark inputs to env vars
+
+**Modified in Worktree B** (`fix/workflow-input-quoting`):
+- `.github/workflows/python-ci.yml` (716 lines): env-var pattern for string inputs, permission scoping, exit-code-5 fix
+- `.github/workflows/python-compatibility.yml` (294 lines): env-var pattern, package name validation
+- `.github/workflows/python-docs.yml` (145 lines): permission scoping, remove redundant cache, add harden-runner to deploy job
+- `.github/workflows/python-release.yml` (332 lines): permission scoping, `if: always()` on artifact upload
+- `.github/workflows/python-security-analysis.yml` (420 lines): move boolean heredoc inputs to env vars
+- `.github/workflows/python-pr-validation.yml` (546 lines): env-var pattern for string inputs in run: blocks
+- `.github/workflows/python-slsa.yml` (100 lines): SHA-pin comment examples, add SLSA-not-included header note
+- `.github/workflows/python-publish-pypi.yml` (228 lines): replace unpinned safety block with pip-audit + bandit
+- `.github/workflows/python-docker.yml` (399 lines): flip `enable-sbom` default to `true`, add `enable-provenance` input
+
+---
+
+## Task 0: Create Branches and Worktrees
+
+**Files:** none (branch and worktree setup)
+
+- [ ] **Step 1: Create the integration branch**
+
+```bash
+cd /home/byron/dev/.github
+git checkout main
+git checkout -b fix/workflow-security-remediation
+git push -u origin fix/workflow-security-remediation
+git checkout main
+```
+
+- [ ] **Step 2: Create Worktree A**
+
+```bash
+git checkout -b fix/perf-regression-rce
+git worktree add .worktrees/fix-perf-regression-rce fix/perf-regression-rce
+git checkout main
+```
+
+- [ ] **Step 3: Create Worktree B**
+
+```bash
+git checkout -b fix/workflow-input-quoting
+git worktree add .worktrees/fix-workflow-input-quoting fix/workflow-input-quoting
+```
+
+- [ ] **Step 4: Verify worktrees**
+
+```bash
+git worktree list
+```
+
+Expected output (three entries):
+```
+/home/byron/dev/.github                     <sha> [main]
+/home/byron/dev/.github/.worktrees/fix-perf-regression-rce    <sha> [fix/perf-regression-rce]
+/home/byron/dev/.github/.worktrees/fix-workflow-input-quoting  <sha> [fix/workflow-input-quoting]
+```
+
+---
+
+## WORKTREE A TASKS
+### Work directory: `.worktrees/fix-perf-regression-rce`
+### All commands in this section run from `.worktrees/fix-perf-regression-rce`
+
+---
+
+## Task 1 (Worktree A): CRIT-01 -- Remove `synthetic-data-script` Input
+
+**Files:**
+- Modify: `.github/workflows/python-performance-regression.yml:110-192`
+
+- [ ] **Step 1: Confirm the target code**
+
+```bash
+grep -n "synthetic-data-script\|synthetic_data_script\|generate-synthetic-data" \
+  .github/workflows/python-performance-regression.yml
+```
+
+Expected: hits on lines 110-120 (input definition) and lines 184-192 (usage step).
+
+- [ ] **Step 2: Remove the `synthetic-data-script` input definition (lines 116-120)**
+
+In `.github/workflows/python-performance-regression.yml`, delete these five lines:
+
+```yaml
+      synthetic-data-script:
+        description: 'Python code to generate synthetic test data'
+        type: string
+        required: false
+        default: ''
+```
+
+- [ ] **Step 3: Replace the Generate Synthetic Test Data step (lines 184-192)**
+
+Replace:
+
+```yaml
+      - name: Generate Synthetic Test Data
+        if: inputs.generate-synthetic-data && inputs.synthetic-data-script != ''
+        run: |
+          mkdir -p "${{ inputs.test-data-directory }}"
+          uv run python - <<'EOF'
+          ${{ inputs.synthetic-data-script }}
+          EOF
+          echo "✅ Synthetic test data generated in ${{ inputs.test-data-directory }}"
+          ls -lh "${{ inputs.test-data-directory }}" | head -20
+```
+
+With:
+
+```yaml
+      - name: Generate Synthetic Test Data
+        if: inputs.generate-synthetic-data
+        env:
+          TEST_DATA_DIR: ${{ inputs.test-data-directory }}
+        run: |
+          mkdir -p "$TEST_DATA_DIR"
+          uv run python scripts/generate_test_data.py
+          echo "Synthetic test data generated in $TEST_DATA_DIR"
+          ls -lh "$TEST_DATA_DIR" | head -20
+```
+
+Add this comment to the workflow header (inside the existing `# ===` block at the top of the file, after the Features section):
+
+```yaml
+# Caller convention: place data-generation script at scripts/generate_test_data.py
+# in the calling repository. The script is invoked when generate-synthetic-data: true.
+```
+
+- [ ] **Step 4: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-performance-regression.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/python-performance-regression.yml
+git commit -m "fix(security): remove synthetic-data-script RCE vector (CRIT-01)
+
+Replace arbitrary Python execution heredoc with fixed-path convention.
+Callers place their script at scripts/generate_test_data.py."
+```
+
+---
+
+## Task 2 (Worktree A): CRIT-02 -- Move Heredoc Inputs to Env Vars
+
+**Files:**
+- Modify: `.github/workflows/python-performance-regression.yml:337-423`
+
+The `Compare Performance` step (lines 335-423) interpolates four inputs directly into Python syntax inside a heredoc. This allows callers to inject arbitrary Python expressions.
+
+- [ ] **Step 1: Confirm injection points**
+
+```bash
+grep -n "\${{ inputs\." .github/workflows/python-performance-regression.yml | grep -v "^[0-9]*:#"
+```
+
+Expected hits inside the heredoc (around lines 348, 353, 354, 419):
+- `primary_metric = "${{ inputs.primary-metric }}"`
+- `regression_threshold = ${{ inputs.regression-threshold }}`
+- `improvement_threshold = ${{ inputs.improvement-threshold }}`
+- `if regression_detected and ${{ inputs.fail-on-regression }}:`
+
+- [ ] **Step 2: Add `env:` block to the Compare Performance step and update Python code**
+
+Find the `- name: Compare Performance` step (line ~334). Replace the `run:` key and its content with:
+
+```yaml
+      - name: Compare Performance
+        id: compare
+        env:
+          PRIMARY_METRIC: ${{ inputs.primary-metric }}
+          REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
+          IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
+          FAIL_ON_REGRESSION: ${{ inputs.fail-on-regression }}
+        run: |
+          uv run python - <<'EOF'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          # Load results
+          pr_results = json.loads(Path("/tmp/pr_benchmark.json").read_text())
+          baseline_results = json.loads(Path("/tmp/baseline_benchmark.json").read_text())
+
+          # Extract primary metric
+          primary_metric = os.environ["PRIMARY_METRIC"]
+          pr_value = pr_results.get(primary_metric, 0.0)
+          baseline_value = baseline_results.get(primary_metric, 0.0)
+
+          # Get thresholds from inputs
+          regression_threshold = float(os.environ["REGRESSION_THRESHOLD"])
+          improvement_threshold = float(os.environ["IMPROVEMENT_THRESHOLD"])
+
+          # Handle missing or zero values
+          if baseline_value == 0:
+              print(f"WARNING: Baseline {primary_metric} is 0 - cannot calculate regression")
+              regression_pct = 0
+              regression_detected = False
+              improvement_detected = False
+          else:
+              regression_pct = ((pr_value - baseline_value) / baseline_value) * 100
+              regression_detected = regression_pct > regression_threshold
+              improvement_detected = regression_pct < -improvement_threshold
+
+          # Print results
+          print(f"Performance Comparison:")
+          print(f"  Metric: {primary_metric}")
+          print(f"  Baseline: {baseline_value:.2f}")
+          print(f"  PR: {pr_value:.2f}")
+          print(f"  Change: {regression_pct:+.1f}%")
+          print(f"  Threshold: +/-{regression_threshold}%")
+          print()
+
+          if regression_detected:
+              print(f"REGRESSION DETECTED ({regression_pct:+.1f}%)")
+              status = "regression"
+          elif improvement_detected:
+              print(f"IMPROVEMENT DETECTED ({regression_pct:+.1f}%)")
+              status = "improvement"
+          else:
+              print(f"PERFORMANCE OK ({regression_pct:+.1f}%)")
+              status = "ok"
+
+          # Extract additional metrics for summary
+          summary_metrics = {}
+          for key in pr_results.keys():
+              if key != "status" and key in baseline_results:
+                  pr_val = pr_results[key]
+                  base_val = baseline_results[key]
+                  if base_val != 0:
+                      change_pct = ((pr_val - base_val) / base_val) * 100
+                      summary_metrics[key] = {
+                          "baseline": base_val,
+                          "pr": pr_val,
+                          "change_pct": change_pct
+                      }
+
+          # Write to GitHub output
+          github_output = os.getenv("GITHUB_OUTPUT", "/tmp/github_output.txt")
+          with open(github_output, "a") as f:
+              f.write(f"baseline_value={baseline_value:.2f}\n")
+              f.write(f"pr_value={pr_value:.2f}\n")
+              f.write(f"regression_pct={regression_pct:+.1f}\n")
+              f.write(f"regression_detected={str(regression_detected).lower()}\n")
+              f.write(f"improvement_detected={str(improvement_detected).lower()}\n")
+              f.write(f"status={status}\n")
+              f.write(f"primary_metric={primary_metric}\n")
+              import json as json2
+              f.write(f"summary_metrics={json2.dumps(summary_metrics)}\n")
+
+          # Exit with error if regression detected and fail-on-regression is true
+          fail_on_regression = os.environ.get("FAIL_ON_REGRESSION", "false").lower() == "true"
+          if regression_detected and fail_on_regression:
+              sys.exit(1)
+          else:
+              sys.exit(0)
+          EOF
+```
+
+- [ ] **Step 3: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-performance-regression.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/python-performance-regression.yml
+git commit -m "fix(security): move heredoc inputs to env vars (CRIT-02)
+
+All inputs previously interpolated as raw Python syntax now read via
+os.environ inside the Compare Performance heredoc."
+```
+
+---
+
+## Task 3 (Worktree A): HIGH-05 -- Move Benchmark Shell Inputs to Env Vars
+
+**Files:**
+- Modify: `.github/workflows/python-performance-regression.yml:194-310`
+
+The benchmark-script, benchmark-args, warmup-iterations, and benchmark-iterations inputs are interpolated directly into shell commands without quoting.
+
+- [ ] **Step 1: Confirm injection points**
+
+```bash
+grep -n "inputs\.benchmark-\|inputs\.warmup\|inputs\.benchmark-args" \
+  .github/workflows/python-performance-regression.yml
+```
+
+Expected hits at lines ~196, 212, 219, 227-231, 300-302 (Validate Benchmark Script and Run PR/Baseline Benchmarks steps).
+
+- [ ] **Step 2: Apply env-var pattern to the Validate Benchmark Script step**
+
+Find the `Validate Benchmark Script` step (line ~194). Replace with:
+
+```yaml
+      - name: Validate Benchmark Script
+        env:
+          BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
+          PRIMARY_METRIC: ${{ inputs.primary-metric }}
+        run: |
+          if [ ! -f "$BENCHMARK_SCRIPT" ]; then
+            echo "ERROR: Benchmark script not found: $BENCHMARK_SCRIPT"
+            echo ""
+            echo "Ensure the script exists and outputs JSON with metrics:"
+            echo "  {\"$PRIMARY_METRIC\": 100.0, \"mean_ms\": 95.0, ...}"
+            exit 1
+          fi
+          echo "Benchmark script found: $BENCHMARK_SCRIPT"
+```
+
+- [ ] **Step 3: Apply env-var pattern to the Run PR Benchmarks step**
+
+Find the `Run PR Benchmarks` step (line ~205). Replace with:
+
+```yaml
+      - name: Run PR Benchmarks
+        id: pr_bench
+        env:
+          BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
+          BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup-iterations }}
+          BENCHMARK_ITERATIONS: ${{ inputs.benchmark-iterations }}
+          PRIMARY_METRIC: ${{ inputs.primary-metric }}
+        run: |
+          echo "Running benchmark on PR branch..."
+
+          SUPPORTS_OUTPUT=false
+          if uv run python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
+            SUPPORTS_OUTPUT=true
+          fi
+
+          SUPPORTS_ITERATIONS=false
+          if uv run python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
+            SUPPORTS_ITERATIONS=true
+          fi
+
+          if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
+            uv run python "$BENCHMARK_SCRIPT" \
+              --warmup "$WARMUP_ITERATIONS" \
+              --iterations "$BENCHMARK_ITERATIONS" \
+              --output /tmp/pr_benchmark.json \
+              $BENCHMARK_ARGS || {
+                echo "Benchmark execution failed, creating fallback results"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+              }
+          elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
+            uv run python "$BENCHMARK_SCRIPT" \
+              --output /tmp/pr_benchmark.json \
+              $BENCHMARK_ARGS || {
+                echo "Benchmark execution failed, creating fallback results"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+              }
+          else
+            uv run python "$BENCHMARK_SCRIPT" $BENCHMARK_ARGS > /tmp/pr_benchmark.json || {
+              echo "Benchmark execution failed, creating fallback results"
+              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+            }
+          fi
+```
+
+- [ ] **Step 4: Apply the same env-var pattern to the Run Baseline Benchmarks step**
+
+Find `Run Baseline Benchmarks` (line ~295). Apply the identical env: block and replace all `${{ inputs.benchmark-script }}`, `${{ inputs.benchmark-args }}`, `${{ inputs.warmup-iterations }}`, `${{ inputs.benchmark-iterations }}`, `${{ inputs.primary-metric }}` with `$BENCHMARK_SCRIPT`, `$BENCHMARK_ARGS`, `$WARMUP_ITERATIONS`, `$BENCHMARK_ITERATIONS`, `$PRIMARY_METRIC` respectively, following the same pattern as Step 3.
+
+- [ ] **Step 5: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-performance-regression.yml
+pre-commit run --all-files
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/python-performance-regression.yml
+git commit -m "fix(security): move benchmark inputs to env vars (HIGH-05)
+
+benchmark-script, benchmark-args, warmup-iterations, benchmark-iterations
+now declared in env: blocks and referenced as quoted shell variables."
+```
+
+---
+
+## WORKTREE B TASKS
+### Work directory: `.worktrees/fix-workflow-input-quoting`
+### All commands in this section run from `.worktrees/fix-workflow-input-quoting`
+
+---
+
+## Task 4 (Worktree B): `python-ci.yml` -- Permission Scoping and Exit-Code-5 Fix
+
+**Files:**
+- Modify: `.github/workflows/python-ci.yml:131-134, 196-238, 290-318`
+
+- [ ] **Step 1: Remove workflow-level over-scoped permissions (lines 131-134)**
+
+Find and replace:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+```
+
+With:
+
+```yaml
+permissions:
+  contents: read
+```
+
+- [ ] **Step 2: Apply env-var pattern to Set up Python step (line 197)**
+
+Find:
+
+```yaml
+      - name: Set up Python
+        run: uv python install ${{ inputs.python-version }}
+```
+
+Replace with:
+
+```yaml
+      - name: Set up Python
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: uv python install "$PYTHON_VERSION"
+```
+
+- [ ] **Step 3: Apply env-var pattern to Run Ruff formatter check step (line 205)**
+
+Find:
+
+```yaml
+      - name: Run Ruff formatter check
+        run: |
+          echo "::group::Ruff Formatting"
+          uv run ruff format --check ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/ || {
+            echo "::error::Code formatting issues detected. Run 'uv run ruff format ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/' to fix."
+            exit 1
+          }
+          echo "::endgroup::"
+```
+
+Replace with:
+
+```yaml
+      - name: Run Ruff formatter check
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          TEST_DIR: ${{ inputs.test-directory }}
+        run: |
+          echo "::group::Ruff Formatting"
+          uv run ruff format --check "$SRC_DIR/" "$TEST_DIR/" || {
+            echo "::error::Code formatting issues detected. Run 'uv run ruff format $SRC_DIR/ $TEST_DIR/' to fix."
+            exit 1
+          }
+          echo "::endgroup::"
+```
+
+- [ ] **Step 4: Apply env-var pattern to Run Ruff linter step (line 212)**
+
+Find:
+
+```yaml
+      - name: Run Ruff linter
+        run: |
+          echo "::group::Ruff Linting"
+          uv run ruff check ${{ inputs.source-directory }}/ ${{ inputs.test-directory }}/ --output-format=github
+          echo "::endgroup::"
+```
+
+Replace with:
+
+```yaml
+      - name: Run Ruff linter
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          TEST_DIR: ${{ inputs.test-directory }}
+        run: |
+          echo "::group::Ruff Linting"
+          uv run ruff check "$SRC_DIR/" "$TEST_DIR/" --output-format=github
+          echo "::endgroup::"
+```
+
+- [ ] **Step 5: Apply env-var pattern to Run BasedPyright type checker step (line 218)**
+
+Find:
+
+```yaml
+      - name: Run BasedPyright type checker
+        run: |
+          echo "::group::BasedPyright Type Checking"
+          uv run basedpyright ${{ inputs.source-directory }}/ || {
+            echo "::warning::Type checking found issues"
+          }
+          echo "::endgroup::"
+```
+
+Replace with:
+
+```yaml
+      - name: Run BasedPyright type checker
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+        run: |
+          echo "::group::BasedPyright Type Checking"
+          uv run basedpyright "$SRC_DIR/" || {
+            echo "::warning::Type checking found issues"
+          }
+          echo "::endgroup::"
+```
+
+- [ ] **Step 6: Apply env-var pattern to Dead code detection with Vulture step (line 226)**
+
+Find the `Dead code detection with Vulture` step and replace the lines that interpolate inputs:
+
+```yaml
+          echo "Scanning for dead code (min confidence: ${{ inputs.dead-code-confidence }}%)..."
+          VULTURE_OUTPUT=$(uv run vulture ${{ inputs.source-directory }}/ --min-confidence ${{ inputs.dead-code-confidence }} 2>&1) || true
+```
+
+Add an `env:` block to the step and update to:
+
+```yaml
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          DEAD_CODE_CONFIDENCE: ${{ inputs.dead-code-confidence }}
+```
+
+And change the run lines to:
+
+```yaml
+          echo "Scanning for dead code (min confidence: $DEAD_CODE_CONFIDENCE%)..."
+          VULTURE_OUTPUT=$(uv run vulture "$SRC_DIR/" --min-confidence "$DEAD_CODE_CONFIDENCE" 2>&1) || true
+```
+
+Also update the step summary line that interpolates `dead-code-confidence`:
+```yaml
+          echo "**Found $DEAD_CODE_COUNT potential dead code issue(s)** (confidence >=$DEAD_CODE_CONFIDENCE%)" >> $GITHUB_STEP_SUMMARY
+```
+
+- [ ] **Step 7: Fix `|| echo` swallowing in Run integration tests step (around line 290)**
+
+Find the `Run integration tests with coverage` step. The current `run:` block ends with:
+
+```bash
+            -v || echo "No integration tests found or all skipped"
+```
+
+Replace the entire `run:` block body to use the exit-code-5 pattern:
+
+```yaml
+        run: |
+          echo "::group::Integration Test Execution"
+          set +e
+          uv run pytest \
+            -m "integration" \
+            --cov=${{ inputs.source-directory }} \
+            --cov-report=xml:coverage-integration.xml \
+            --cov-report=term-missing \
+            --cov-branch \
+            --cov-append \
+            --junitxml=junit-integration.xml \
+            -o junit_family=xunit2 \
+            -v
+          EXIT=$?
+          set -e
+          echo "::endgroup::"
+          if [ $EXIT -ne 0 ] && [ $EXIT -ne 5 ]; then exit $EXIT; fi
+```
+
+Note: also apply the same SRC_DIR env-var substitution to the `--cov=` argument:
+Add `env: SRC_DIR: ${{ inputs.source-directory }}` to the step and change `--cov=${{ inputs.source-directory }}` to `--cov="$SRC_DIR"`.
+
+- [ ] **Step 8: Fix `|| echo` swallowing in Run security tests step (around line 304)**
+
+Apply the same exit-code-5 pattern to the `Run security tests with coverage` step. Replace:
+
+```bash
+            -v || echo "No security tests found or all skipped"
+```
+
+With the same `set +e` / `EXIT=$?` / `set -e` / `if [ $EXIT -ne 0 ] && [ $EXIT -ne 5 ]; then exit $EXIT; fi` pattern as Step 7, including `SRC_DIR` env var substitution.
+
+- [ ] **Step 9: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-ci.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add .github/workflows/python-ci.yml
+git commit -m "fix(security): scope permissions and fix test error suppression in python-ci
+
+Remove workflow-level pull-requests:write and checks:write. Apply env-var
+isolation to source-directory, test-directory, python-version,
+dead-code-confidence inputs. Replace || echo swallowing with exit-code-5
+pattern so real pytest failures propagate correctly."
+```
+
+---
+
+## Task 5 (Worktree B): `python-compatibility.yml` -- Env-Var Pattern and Package Validation
+
+**Files:**
+- Modify: `.github/workflows/python-compatibility.yml:195-212`
+
+- [ ] **Step 1: Confirm the target lines**
+
+```bash
+grep -n "\${{ inputs\." .github/workflows/python-compatibility.yml
+```
+
+Expected: hits at lines ~198-212 (system dep install steps) and ~221-229 (test run step).
+
+- [ ] **Step 2: Replace the Install system dependencies (Ubuntu) step (lines 195-200)**
+
+Find:
+
+```yaml
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux' && inputs.system-deps-ubuntu != ''
+        run: |
+          echo "📦 Installing system dependencies: ${{ inputs.system-deps-ubuntu }}"
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.system-deps-ubuntu }}
+```
+
+Replace with:
+
+```yaml
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux' && inputs.system-deps-ubuntu != ''
+        env:
+          SYSTEM_DEPS_UBUNTU: ${{ inputs.system-deps-ubuntu }}
+        run: |
+          echo "Installing system dependencies: $SYSTEM_DEPS_UBUNTU"
+          if [[ ! "$SYSTEM_DEPS_UBUNTU" =~ ^[a-zA-Z0-9_\-\. ]+$ ]]; then
+            echo "::error::Invalid package name characters in system-deps-ubuntu"
+            exit 1
+          fi
+          sudo apt-get update
+          sudo apt-get install -y $SYSTEM_DEPS_UBUNTU
+```
+
+- [ ] **Step 3: Replace the Install system dependencies (macOS) step (lines 202-206)**
+
+Find:
+
+```yaml
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS' && inputs.system-deps-macos != ''
+        run: |
+          echo "📦 Installing system dependencies: ${{ inputs.system-deps-macos }}"
+          brew install ${{ inputs.system-deps-macos }}
+```
+
+Replace with:
+
+```yaml
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS' && inputs.system-deps-macos != ''
+        env:
+          SYSTEM_DEPS_MACOS: ${{ inputs.system-deps-macos }}
+        run: |
+          echo "Installing system dependencies: $SYSTEM_DEPS_MACOS"
+          if [[ ! "$SYSTEM_DEPS_MACOS" =~ ^[a-zA-Z0-9_\-\. ]+$ ]]; then
+            echo "::error::Invalid package name characters in system-deps-macos"
+            exit 1
+          fi
+          brew install $SYSTEM_DEPS_MACOS
+```
+
+- [ ] **Step 4: Replace the Install system dependencies (Windows) step (lines 208-213)**
+
+Find:
+
+```yaml
+      - name: Install system dependencies (Windows)
+        if: runner.os == 'Windows' && inputs.system-deps-windows != ''
+        run: |
+          echo "📦 Installing system dependencies: ${{ inputs.system-deps-windows }}"
+          choco install ${{ inputs.system-deps-windows }} -y
+        shell: pwsh
+```
+
+Replace with:
+
+```yaml
+      - name: Install system dependencies (Windows)
+        if: runner.os == 'Windows' && inputs.system-deps-windows != ''
+        env:
+          SYSTEM_DEPS_WINDOWS: ${{ inputs.system-deps-windows }}
+        run: |
+          if ($env:SYSTEM_DEPS_WINDOWS -notmatch '^[a-zA-Z0-9_\-\. ]+$') {
+            Write-Error "Invalid package name characters in system-deps-windows"
+            exit 1
+          }
+          choco install $env:SYSTEM_DEPS_WINDOWS -y
+        shell: pwsh
+```
+
+- [ ] **Step 5: Apply env-var pattern to the Run tests step (around line 218)**
+
+Find the `Run tests` step and add:
+
+```yaml
+        env:
+          TEST_COMMAND: ${{ inputs.test-command }}
+          SRC_DIR: ${{ inputs.source-directory }}
+          PYTHON_VER: ${{ matrix.python }}
+          RUNNER_OS: ${{ matrix.os }}
+```
+
+Replace `${{ inputs.test-command }}` with `$TEST_COMMAND`, `${{ inputs.source-directory }}` with `$SRC_DIR`, `${{ matrix.python }}` with `$PYTHON_VER`, `${{ matrix.os }}` with `$RUNNER_OS` in the run: block.
+
+- [ ] **Step 6: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-compatibility.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/python-compatibility.yml
+git commit -m "fix(security): env-var isolation and package name validation in python-compatibility
+
+Move system-deps-* inputs to env: blocks. Add allowlist regex validation
+before sudo/brew/choco install to reject inputs with shell-special characters."
+```
+
+---
+
+## Task 6 (Worktree B): `python-docs.yml` -- Permission Scoping, Remove Redundant Cache, Add Harden-Runner to Deploy
+
+**Files:**
+- Modify: `.github/workflows/python-docs.yml:50-53, 85-89, 113-144`
+
+- [ ] **Step 1: Remove `id-token: write` from workflow-level permissions (line 53)**
+
+Find:
+
+```yaml
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+```
+
+Replace with:
+
+```yaml
+permissions:
+  contents: read
+  pages: write
+```
+
+The `id-token: write` is already correctly scoped at the `deploy` job level (line 121) -- no additional change needed there.
+
+- [ ] **Step 2: Remove the redundant `actions/cache` step (lines 85-89)**
+
+The `setup-uv` action at lines 79-83 already has `enable-cache: true` which provides built-in uv caching. Delete this step entirely:
+
+```yaml
+      - name: Cache dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}-docs
+```
+
+- [ ] **Step 3: Also apply env-var pattern to the Check docstring coverage step (line 94)**
+
+Find:
+
+```yaml
+      - name: Check docstring coverage
+        run: |
+          echo "📝 Checking docstring coverage..."
+          uv run interrogate ${{ inputs.source-directory }} \
+            --fail-under=${{ inputs.docstring-threshold }} \
+            --verbose || echo "⚠️  Docstring coverage below threshold"
+```
+
+Replace with:
+
+```yaml
+      - name: Check docstring coverage
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          DOCSTRING_THRESHOLD: ${{ inputs.docstring-threshold }}
+        run: |
+          echo "Checking docstring coverage..."
+          uv run interrogate "$SRC_DIR" \
+            --fail-under="$DOCSTRING_THRESHOLD" \
+            --verbose || echo "Docstring coverage below threshold"
+```
+
+- [ ] **Step 4: Add harden-runner as first step in the `deploy` job (line 127)**
+
+The `deploy` job currently has no `harden-runner` step. Add it as the first step after the job's `steps:` key:
+
+```yaml
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+          allowed-endpoints: api.github.com:443
+
+      - name: Download documentation artifacts
+```
+
+- [ ] **Step 5: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-docs.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/python-docs.yml
+git commit -m "fix(security): scope id-token permission and harden deploy job in python-docs
+
+Remove id-token:write from workflow level (already at deploy job level).
+Remove redundant actions/cache (setup-uv enable-cache covers this).
+Add harden-runner to deploy job. Apply env-var pattern to source-directory
+and docstring-threshold inputs."
+```
+
+---
+
+## Task 7 (Worktree B): `python-release.yml` -- Permission Scoping and Artifact Upload Fix
+
+**Files:**
+- Modify: `.github/workflows/python-release.yml:99-104, 154-165, 266-271`
+
+- [ ] **Step 1: Replace workflow-level permissions (lines 99-104)**
+
+Find:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+  attestations: write
+```
+
+Replace with:
+
+```yaml
+permissions:
+  contents: read
+```
+
+- [ ] **Step 2: Add job-level permissions to the `release` job (line 154)**
+
+Find the `release:` job definition (line 154). After `timeout-minutes: 15`, add:
+
+```yaml
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+```
+
+The full job opening should look like:
+
+```yaml
+  release:
+    name: Build & Release
+    needs: test
+    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    outputs:
+```
+
+- [ ] **Step 3: Find and add job-level permissions to the `publish-pypi` job**
+
+Read the file to find the `publish-pypi` job definition:
+
+```bash
+grep -n "^  publish-pypi:\|^  publish_pypi:" .github/workflows/python-release.yml
+```
+
+Add `permissions: id-token: write` to that job block in the same manner as Step 2.
+
+- [ ] **Step 4: Add `if: always()` to the artifact upload step (line 266)**
+
+Find:
+
+```yaml
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: release-dist
+          path: dist/
+          retention-days: 5
+```
+
+Replace with:
+
+```yaml
+      - name: Upload distribution artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: release-dist
+          path: dist/
+          retention-days: 5
+```
+
+- [ ] **Step 5: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-release.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/python-release.yml
+git commit -m "fix(security): scope permissions to jobs and add if:always() to artifact upload
+
+Move contents:write, id-token:write, attestations:write to release job.
+Move id-token:write to publish-pypi job. Remove issues:write and
+pull-requests:write (no job uses them). Workflow-level reduced to
+contents:read. Add if:always() to artifact upload to preserve build
+artifacts on release failure."
+```
+
+---
+
+## Task 8 (Worktree B): `python-security-analysis.yml` -- Boolean Heredoc Inputs to Env Vars
+
+**Files:**
+- Modify: `.github/workflows/python-security-analysis.yml:281-365`
+
+The `Analyze OSV Results` step (line 281) uses `${{ inputs.fail-on-high }}` and `${{ inputs.fail-on-medium }}` as Python string comparisons inside a heredoc. These are injected as raw strings.
+
+- [ ] **Step 1: Confirm the injection points**
+
+```bash
+grep -n "inputs\.fail-on" .github/workflows/python-security-analysis.yml
+```
+
+Expected: hits at lines 358 and 364 inside the `python3 << 'EOF'` block.
+
+- [ ] **Step 2: Add `env:` block to the Analyze OSV Results step and update Python code**
+
+Find the `Analyze OSV Results` step (line ~281). It currently has no `env:` block. Add one and update the two Python comparisons.
+
+The step opening becomes:
+
+```yaml
+      - name: Analyze OSV Results
+        env:
+          FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
+          FAIL_ON_MEDIUM: ${{ inputs.fail-on-medium }}
+        run: |
+          echo "Analyzing OSV scan results..."
+          python3 << 'EOF'
+          import json
+          import os
+          import sys
+```
+
+Replace line 358 (`if '${{ inputs.fail-on-high }}' == 'true':`) with:
+
+```python
+                  if os.environ.get("FAIL_ON_HIGH", "false").lower() == "true":
+```
+
+Replace line 364 (`if '${{ inputs.fail-on-medium }}' == 'true':`) with:
+
+```python
+                  if os.environ.get("FAIL_ON_MEDIUM", "false").lower() == "true":
+```
+
+- [ ] **Step 3: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-security-analysis.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/python-security-analysis.yml
+git commit -m "fix(security): move boolean heredoc inputs to env vars in python-security-analysis
+
+fail-on-high and fail-on-medium were interpolated as Python string literals
+inside the OSV scanner heredoc. Now read via os.environ to prevent injection."
+```
+
+---
+
+## Task 9 (Worktree B): `python-pr-validation.yml` -- Env-Var Pattern for String Inputs
+
+**Files:**
+- Modify: `.github/workflows/python-pr-validation.yml`
+
+Note: Phase 2 replaces this workflow's entire job content with a hard-fail migration job. This task only hardens the existing inputs in Phase 1 so no unquoted interpolations exist in the interim.
+
+- [ ] **Step 1: Find all unquoted input interpolations in run: blocks**
+
+```bash
+grep -n "\${{ inputs\." .github/workflows/python-pr-validation.yml | grep -v "^[0-9]*:#"
+```
+
+Review each hit. For any `${{ inputs.<name> }}` appearing inside a `run:` block (not in `if:`, `with:`, or other YAML keys), apply the env-var pattern.
+
+- [ ] **Step 2: For each run: step that interpolates string inputs, add an env: block**
+
+For each affected step, the pattern is:
+
+```yaml
+        env:
+          INPUT_NAME: ${{ inputs.input-name }}
+        run: |
+          command "$INPUT_NAME"
+```
+
+Apply this to every step found in Step 1. Common inputs in this file:
+- `python-version` (used in uv python install)
+- `source-directory` (used in test commands)
+- `test-directory` (used in test commands)
+- `min-description-length` (used in validation logic)
+- `coverage-threshold` (used in pytest)
+
+- [ ] **Step 3: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-pr-validation.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/python-pr-validation.yml
+git commit -m "fix(security): env-var isolation for string inputs in python-pr-validation
+
+Apply env: block pattern to all run: steps that interpolate string inputs.
+Note: this workflow's job content will be replaced by a hard-fail migration
+job in Phase 2 (fix/workflow-architecture-cleanup)."
+```
+
+---
+
+## Task 10 (Worktree B): `python-slsa.yml` -- SHA-Pin Comment Examples and Add Header Note
+
+**Files:**
+- Modify: `.github/workflows/python-slsa.yml:1-53`
+
+The comment block at lines 17-25 uses mutable `@v4` tags in the usage example, which defeats the SHA-pinning intent for callers copying this template.
+
+- [ ] **Step 1: Replace mutable tags in comment examples (lines 17-25)**
+
+Find:
+
+```yaml
+#         - uses: actions/checkout@v4
+#         - run: pip install build && python -m build
+#         - id: hash
+#           run: |
+#             cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
+#         - uses: actions/upload-artifact@v4
+```
+
+Replace with:
+
+```yaml
+#         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+#         - run: pip install build && python -m build
+#         - id: hash
+#           run: |
+#             cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
+#         - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+```
+
+- [ ] **Step 2: Add SLSA-not-included note to the header**
+
+After the existing header comment block (before the closing `# ===` line), add:
+
+```yaml
+# IMPORTANT: SLSA provenance is NOT included in python-release.yml.
+# Every caller must add the provenance job from this template directly
+# into their own top-level release workflow. GitHub Actions prohibits
+# nested reusable workflow calls, so this job cannot be called from
+# python-release.yml.
+```
+
+- [ ] **Step 3: Validate**
+
+```bash
+qlty check --plugin actionlint \
+  .github/workflows/python-slsa.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/python-slsa.yml
+git commit -m "fix(supply-chain): SHA-pin comment examples and add SLSA-not-included warning
+
+Replace @v4 mutable tags in template examples with pinned SHAs.
+Add prominent note that SLSA provenance must be added to each caller's
+own top-level workflow -- it cannot be nested inside python-release.yml."
+```
+
+---
+
+## Task 11 (Worktree B): `python-publish-pypi.yml` -- Replace Unpinned Safety with pip-audit
+
+**Files:**
+- Modify: `.github/workflows/python-publish-pypi.yml:92-106`
+
+The `Run security checks` step uses `pip install safety bandit` (unpinned, network fetch) and suppresses failures with `|| echo`.
+
+- [ ] **Step 1: Confirm the target block**
+
+```bash
+sed -n '90,110p' .github/workflows/python-publish-pypi.yml
+```
+
+Expected: the `pip install safety bandit` block at lines 92-106.
+
+- [ ] **Step 2: Replace the Run security checks step**
+
+Find:
+
+```yaml
+      - name: Run security checks
+        if: ${{ inputs.run-security-checks }}
+        run: |
+          echo "🔒 Running pre-publish security checks..."
+
+          # Install security tools
+          pip install safety bandit
+
+          # Check for known vulnerabilities in dependencies
+          echo "📦 Checking dependencies for vulnerabilities..."
+          safety check || echo "⚠️  Safety check found issues - review before publishing"
+
+          # Scan source code for security issues
+          echo "🔍 Scanning source code..."
+          bandit -r ${{ inputs.source-directory }} -ll || echo "⚠️  Bandit found issues - review before publishing"
+```
+
+Replace with:
+
+```yaml
+      - name: Run security checks
+        if: ${{ inputs.run-security-checks }}
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+        run: |
+          echo "Running pre-publish security checks..."
+          uv run pip-audit --strict
+          uv run bandit -r "$SRC_DIR" -c pyproject.toml -ll
+```
+
+- [ ] **Step 3: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-publish-pypi.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/python-publish-pypi.yml
+git commit -m "fix(supply-chain): replace unpinned safety with pip-audit in python-publish-pypi
+
+Remove pip install safety bandit (unpinned, error-suppressed). Replace with
+uv run pip-audit --strict (hard fail on any vulnerability) and
+uv run bandit -r SRC_DIR -c pyproject.toml -ll (respects pyproject.toml config)."
+```
+
+---
+
+## Task 12 (Worktree B): `python-docker.yml` -- Enable-SBOM Default and Provenance Input
+
+**Files:**
+- Modify: `.github/workflows/python-docker.yml:131-135, 285-299`
+
+- [ ] **Step 1: Flip `enable-sbom` default to `true` (lines 131-135)**
+
+Find:
+
+```yaml
+      enable-sbom:
+        description: 'Generate Software Bill of Materials'
+        type: boolean
+        required: false
+        default: false
+```
+
+Replace with:
+
+```yaml
+      enable-sbom:
+        description: 'Generate Software Bill of Materials'
+        type: boolean
+        required: false
+        default: true
+```
+
+- [ ] **Step 2: Add new `enable-provenance` input after `enable-sbom`**
+
+After the `enable-sbom` input block, add:
+
+```yaml
+      enable-provenance:
+        description: 'Generate SLSA provenance attestation for the Docker image'
+        type: boolean
+        required: false
+        default: true
+```
+
+- [ ] **Step 3: Update the build-push-action step to use separate provenance input (line 299)**
+
+Find:
+
+```yaml
+          sbom: ${{ inputs.enable-sbom }}
+          provenance: ${{ inputs.enable-sbom }}
+```
+
+Replace with:
+
+```yaml
+          sbom: ${{ inputs.enable-sbom }}
+          provenance: ${{ inputs.enable-provenance }}
+```
+
+- [ ] **Step 4: Validate**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-docker.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/python-docker.yml
+git commit -m "fix(supply-chain): enable SBOM and provenance by default in python-docker
+
+Flip enable-sbom default from false to true. Add enable-provenance input
+(default: true) separate from enable-sbom so callers can control each
+independently. Callers that previously relied on the false default must add
+enable-sbom: false explicitly."
+```
+
+---
+
+## Task 13: Final Validation of Worktree B
+
+- [ ] **Step 1: Run pre-commit across all files**
+
+From `.worktrees/fix-workflow-input-quoting`:
+
+```bash
+pre-commit run --all-files
+```
+
+Expected: all hooks pass.
+
+- [ ] **Step 2: Run qlty across all modified workflows**
+
+```bash
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-ci.yml \
+  .github/workflows/python-compatibility.yml \
+  .github/workflows/python-docs.yml \
+  .github/workflows/python-release.yml \
+  .github/workflows/python-security-analysis.yml \
+  .github/workflows/python-pr-validation.yml \
+  .github/workflows/python-slsa.yml \
+  .github/workflows/python-publish-pypi.yml \
+  .github/workflows/python-docker.yml
+```
+
+Expected: no errors across all nine files.
+
+- [ ] **Step 3: Confirm no unquoted inputs remain**
+
+```bash
+grep -rn "\${{ inputs\." .github/workflows/python-ci.yml \
+  .github/workflows/python-compatibility.yml \
+  .github/workflows/python-docs.yml \
+  .github/workflows/python-release.yml \
+  .github/workflows/python-security-analysis.yml \
+  .github/workflows/python-pr-validation.yml \
+  .github/workflows/python-publish-pypi.yml \
+  .github/workflows/python-docker.yml | grep -v "^[^:]*:#" | grep "run:" -A5
+```
+
+Review output. Any remaining `${{ inputs.* }}` hits inside `run:` blocks that are not in an `env:` key are injection risks. Fix each before proceeding.
+
+---
+
+## Task 14: Merge Worktrees into Integration Branch
+
+Work directory: `/home/byron/dev/.github` (the main worktree, on `main`)
+
+- [ ] **Step 1: Final validation of Worktree A**
+
+```bash
+cd .worktrees/fix-perf-regression-rce
+pre-commit run --all-files
+qlty check --plugin actionlint --plugin shellcheck \
+  .github/workflows/python-performance-regression.yml
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Merge Worktree A into the integration branch**
+
+```bash
+git checkout fix/workflow-security-remediation
+git merge --no-ff fix/perf-regression-rce \
+  -m "merge: worktree A -- python-performance-regression.yml CRIT fixes"
+```
+
+- [ ] **Step 3: Merge Worktree B into the integration branch**
+
+```bash
+git merge --no-ff fix/workflow-input-quoting \
+  -m "merge: worktree B -- systematic env-var sweep and supply chain fixes"
+```
+
+If merge conflicts occur: they will only appear in files touched by both worktrees. Worktree A touches only `python-performance-regression.yml`; Worktree B does not touch that file. No conflicts are expected.
+
+- [ ] **Step 4: Run final end-to-end validation on integration branch**
+
+```bash
+pre-commit run --all-files
+qlty check --plugin actionlint --plugin shellcheck .github/workflows/
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Confirm success criteria**
+
+```bash
+# No unquoted inputs in any run: block
+grep -rn "\${{ inputs\." .github/workflows/ | grep -v "^[^:]*:#"
+```
+
+Manually review hits. All should appear in `if:`, `with:`, `env:`, or other non-shell contexts. No hits should appear directly inside shell command lines.
+
+```bash
+# synthetic-data-script input removed
+grep -rn "synthetic-data-script" .github/workflows/
+```
+
+Expected: no output.
+
+```bash
+# Docker enable-sbom defaults true
+grep -n "enable-sbom" .github/workflows/python-docker.yml
+```
+
+Expected: `default: true` on the enable-sbom input.
+
+- [ ] **Step 6: Clean up worktrees**
+
+```bash
+git worktree remove .worktrees/fix-perf-regression-rce
+git worktree remove .worktrees/fix-workflow-input-quoting
+```
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push origin fix/workflow-security-remediation
+gh pr create \
+  --base main \
+  --head fix/workflow-security-remediation \
+  --title "fix(security): eliminate input injection vectors and harden supply chain" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- CRIT-01: Remove \`synthetic-data-script\` RCE input from python-performance-regression.yml; callers use \`scripts/generate_test_data.py\` convention
+- CRIT-02: Move all Python heredoc inputs to \`env:\` blocks, read via \`os.environ\`
+- HIGH-05: Move benchmark shell inputs to env vars with quoted references
+- Systematic env-var isolation across python-ci, python-compatibility, python-docs, python-release, python-security-analysis, python-pr-validation
+- Permission scoping: workflow-level over-grants moved to individual jobs
+- Exit-code-5 fix: pytest \`|| echo\` suppression replaced with proper exit code check
+- Supply chain: Docker SBOM/provenance defaults flipped to \`true\`; unpinned safety replaced with pip-audit; SLSA comment examples SHA-pinned
+
+## Breaking Change
+
+\`python-docker.yml\`: \`enable-sbom\` default changed from \`false\` to \`true\`. Callers that intentionally disabled SBOM must add \`enable-sbom: false\` explicitly.
+
+## Test Plan
+
+- [ ] qlty check (actionlint + shellcheck) passes on all 10 modified workflows
+- [ ] pre-commit run --all-files passes
+- [ ] No \`\${{ inputs.* }}\` remains unquoted in any run: shell block
+- [ ] \`synthetic-data-script\` input does not exist in any workflow
+- [ ] python-release.yml artifact upload step has \`if: always()\`
+- [ ] Trigger modified workflows via workflow_dispatch on a downstream test repo
+
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Spec requirement | Task |
+| --- | --- |
+| Remove synthetic-data-script (CRIT-01) | Task 1 |
+| Move all heredoc inputs to env vars (CRIT-02) | Task 2 |
+| benchmark inputs to env vars (HIGH-05) | Task 3 |
+| python-ci.yml: env-var pattern for source-directory, test-directory, python-version, dead-code-confidence | Task 4 steps 2-6 |
+| python-ci.yml: move pull-requests:write, checks:write from workflow level | Task 4 step 1 |
+| python-ci.yml: fix or true swallowing with exit-code-5 pattern | Task 4 steps 7-8 |
+| python-compatibility.yml: env-var pattern + pattern validation | Task 5 |
+| python-docs.yml: move id-token:write to deploy job, remove cache, add harden-runner | Task 6 |
+| python-release.yml: move all permissions to job level, remove issues:write, if:always() on upload | Task 7 |
+| python-security-analysis.yml: boolean heredoc inputs to env vars | Task 8 |
+| python-pr-validation.yml: env-var pattern | Task 9 |
+| python-slsa.yml: SHA-pin examples, SLSA-not-included note | Task 10 |
+| python-publish-pypi.yml: replace safety with pip-audit | Task 11 |
+| python-docker.yml: enable-sbom default true, enable-provenance input | Task 12 |
+| End-to-end validation and PR | Tasks 13-14 |
+
+All spec requirements for Phase 1 are covered. No gaps found.

--- a/docs/superpowers/specs/2026-04-30-workflow-security-architecture-remediation-design.md
+++ b/docs/superpowers/specs/2026-04-30-workflow-security-architecture-remediation-design.md
@@ -1,0 +1,388 @@
+# Workflow Security and Architecture Remediation Design
+
+**Date:** 2026-04-30
+**Status:** Approved
+**Scope:** All 23 reusable workflows in `.github/workflows/`
+**Source:** Comprehensive three-domain audit (security, architecture, supply chain) conducted 2026-04-29
+
+---
+
+## Background
+
+A parallel agent audit of the 23 reusable org-level GitHub Actions workflows identified:
+
+- 3 critical findings (one RCE vector, one code injection vector, one missing SLSA provenance)
+- 6 high findings (permissions over-scoping, shell injection via unquoted inputs)
+- Multiple medium findings (egress policy, artifact integrity, false-assurance security gates)
+- Architecture gaps (duplicated tooling with divergent configs, wrong org references, missing workflows)
+- Supply chain gaps (Docker SBOM/provenance off by default, pip-audit not used consistently)
+
+---
+
+## Delivery Structure
+
+Three sequential PRs. Each depends on the previous merging to `main`.
+
+| PR | Branch | Focus | Breaking |
+|---|---|---|---|
+| 1 | `fix/workflow-security-remediation` | Security fixes + supply chain | Soft (Docker SBOM/provenance defaults flip to `true`) |
+| 2 | `fix/workflow-architecture-cleanup` | Architecture refactor | Yes |
+| 3 | `feat/workflow-new-capabilities` | New workflows | No |
+
+---
+
+## PR 1: Security + Supply Chain
+
+**Branch:** `fix/workflow-security-remediation`
+**Implementation:** Two parallel worktrees merged into the branch before PR.
+
+### Worktree A -- `fix/perf-regression-rce`
+
+Touches only `python-performance-regression.yml`. Resolves CRIT-01 and CRIT-02.
+
+**CRIT-01: Remove `synthetic-data-script` input (arbitrary Python RCE)**
+
+The `synthetic-data-script` input accepted arbitrary Python code from callers and executed it verbatim inside a `python - <<'EOF'` heredoc. This is an RCE vector for any caller that enables `generate-synthetic-data: true`.
+
+Remediation: Remove the input entirely. Replace the heredoc block with:
+
+```yaml
+- name: Generate synthetic test data
+  env:
+    GENERATE_DATA: ${{ inputs.generate-synthetic-data }}
+  run: |
+    if [ "$GENERATE_DATA" = "true" ]; then
+      uv run python scripts/generate_test_data.py
+    fi
+```
+
+Callers place their data-generation script at `scripts/generate_test_data.py` in their repo. Document this convention in the workflow header.
+
+**CRIT-02: Move heredoc inputs to env vars**
+
+All numeric and boolean inputs used inside `python - <<'EOF'` blocks interpolated as raw Python syntax. GitHub does not enforce declared input types, so callers can inject Python expressions.
+
+Remediation pattern -- for every Python heredoc that references `${{ inputs.* }}`:
+
+```yaml
+env:
+  PRIMARY_METRIC: ${{ inputs.primary-metric }}
+  REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
+  IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
+  FAIL_ON_REGRESSION: ${{ inputs.fail-on-regression }}
+run: |
+  uv run python - <<'EOF'
+  import os
+  primary_metric = os.environ["PRIMARY_METRIC"]
+  regression_threshold = float(os.environ["REGRESSION_THRESHOLD"])
+  improvement_threshold = float(os.environ["IMPROVEMENT_THRESHOLD"])
+  fail_on_regression = os.environ["FAIL_ON_REGRESSION"] == "true"
+  ...
+  EOF
+```
+
+Apply to every Python heredoc in the file that currently uses `${{ inputs.* }}` interpolation (lines 185-192, 348, 353-354, 419).
+
+**HIGH-05: Benchmark inputs to env vars**
+
+`benchmark-script`, `benchmark-args`, `warmup-iterations`, `benchmark-iterations` all interpolated unquoted into shell commands. Apply the same env-var pattern and quote all shell references:
+
+```yaml
+env:
+  BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
+  BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
+run: |
+  uv run python "$BENCHMARK_SCRIPT" $BENCHMARK_ARGS
+```
+
+### Worktree B -- `fix/workflow-input-quoting`
+
+Systematic env-var pattern sweep across ~12 other files, plus supply chain fixes. All string inputs used in `run:` blocks must be declared in an `env:` block and referenced with `"$VAR"` quoting.
+
+**Files and specific inputs to fix:**
+
+`python-ci.yml`:
+- `source-directory`, `test-directory` in ruff, basedpyright, vulture, pytest, bandit steps
+- `python-version` in uv python install step
+- `dead-code-confidence` in vulture step (numeric -- pass via env, parse as integer in shell)
+- Permissions: move `pull-requests: write` and `checks: write` from workflow level to job level (only on jobs that actually need them -- none do after Codecov removal lands in PR 2; remove both from workflow level now, add back only if a specific job requires it)
+- Fix `|| true` swallowing in integration and security test steps: replace with exit-code-5 check pattern:
+
+```bash
+uv run pytest -m "integration" ... ; EXIT=$?
+if [ $EXIT -ne 0 ] && [ $EXIT -ne 5 ]; then exit $EXIT; fi
+```
+
+`python-compatibility.yml`:
+- `operating-systems`, `python-versions` in matrix build step
+- `system-deps-ubuntu`, `system-deps-macos`, `system-deps-windows` in system package install steps
+- Add pattern validation before sudo install:
+
+```bash
+PKGS="$SYSTEM_DEPS_UBUNTU"
+if [[ "$PKGS" =~ ^[a-zA-Z0-9_\-\. ]+$ ]]; then
+  sudo apt-get install -y $PKGS
+else
+  echo "::error::Invalid package name characters in system-deps-ubuntu"; exit 1
+fi
+```
+
+`python-docs.yml`:
+- Move `id-token: write` from workflow level to `deploy` job level only
+- Add harden-runner as first step in `deploy` job with `egress-policy: block` and `allowed-endpoints: api.github.com:443`
+- Remove redundant `actions/cache` step (uv's built-in cache via setup-uv is sufficient)
+
+`python-release.yml`:
+- Move `id-token: write`, `attestations: write`, `contents: write`, `pull-requests: write` from workflow level to the specific jobs that need them (`release` job: contents/write, id-token/write, attestations/write; `publish-pypi` job: id-token/write)
+- Remove `issues: write` from workflow level (no job uses it)
+- Set workflow-level permissions to `contents: read`
+- Add `if: always()` to the artifact upload step (line 267)
+
+`python-security-analysis.yml`:
+- Move boolean inputs `fail-on-high`, `fail-on-medium` in Python heredoc to env vars and read via `os.environ`
+
+`python-pr-validation.yml`:
+- Apply env-var pattern to remaining string inputs used in `run:` blocks
+
+**Supply chain fixes (also in Worktree B):**
+
+`python-slsa.yml`:
+- Replace `actions/checkout@v4` in comment examples with `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2`
+- Replace `actions/upload-artifact@v4` in comment examples with `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1`
+- Add prominent note in header: "SLSA provenance is NOT included in `python-release.yml`. Every caller must add the provenance job from this template to their own top-level release workflow."
+
+`python-publish-pypi.yml`:
+- Remove the pre-publish security check block that uses `pip install safety bandit` (unpinned) with `|| echo` error suppression
+- Replace with:
+
+```yaml
+- name: Pre-publish security checks
+  env:
+    SRC_DIR: ${{ inputs.source-directory }}
+  run: |
+    uv run pip-audit --strict
+    uv run bandit -r "$SRC_DIR" -c pyproject.toml -ll
+```
+
+`python-docker.yml`:
+- Change `enable-sbom` default from `false` to `true`
+- Add new `enable-provenance` input (boolean, default: `true`) separate from `enable-sbom`
+- Update `docker/build-push-action` step:
+
+```yaml
+sbom: ${{ inputs.enable-sbom }}
+provenance: ${{ inputs.enable-provenance }}
+```
+
+### PR 1 Merge Sequence
+
+1. Worktree A merges into `fix/workflow-security-remediation` first (smaller, easier to review)
+2. Worktree B merges into `fix/workflow-security-remediation` (resolve any conflicts)
+3. Single PR from `fix/workflow-security-remediation` to `main`
+
+---
+
+## PR 2: Architecture Cleanup
+
+**Branch:** `fix/workflow-architecture-cleanup`
+**Depends on:** PR 1 merged to `main`
+**Implementation:** Single worktree
+
+All breaking changes are documented with migration notes in the affected workflow headers.
+
+### Remove SonarCloud from `python-ci.yml`
+
+Delete the entire `sonarcloud-quality-gate` job (currently lines 579-636). Remove the `enable-sonarcloud`, `sonarcloud-organization`, `sonarcloud-project-key` inputs. Remove the `SONAR_TOKEN` secret declaration. Remove `sonarcloud-quality-gate` from the `ci-gate` job's `needs:` list and result check.
+
+Update the workflow header:
+
+```yaml
+# MIGRATION: SonarCloud integration removed from this workflow.
+# Callers using enable-sonarcloud must switch to calling
+# python-sonarcloud.yml as a separate job:
+#
+#   jobs:
+#     ci:
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+#     sonarcloud:
+#       needs: ci
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-sonarcloud.yml@main
+#       with:
+#         sonar-organization: 'your-org'
+#         sonar-project-key: 'your-key'
+#       secrets:
+#         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+```
+
+### Remove inline Codecov from `python-ci.yml`
+
+Delete all 7 `codecov/codecov-action` steps and the 3 test analytics steps from the `quality-checks` job. Remove `enable-codecov` input. Remove `CODECOV_TOKEN` secret declaration.
+
+Update the workflow header with migration note pointing callers to `python-codecov.yml`.
+
+### Remove `check-secrets` job from `python-ci.yml`
+
+The `check-secrets` job existed solely to gate the SonarCloud and Codecov optional jobs. With both removed, it serves no purpose. Delete the job and remove it from `ci-gate`'s `needs:` list. The `ci-gate` simplifies to checking only `quality-checks`, `llm-governance`, and `matrix-testing`.
+
+### Align bandit configuration in `python-ci.yml`
+
+Add `-c pyproject.toml` to the bandit invocation in `quality-checks`. Replace `uv pip compile pyproject.toml -o requirements.txt && safety check -r requirements.txt` with `uv run pip-audit --strict` (consistent with `python-publish-pypi.yml` after PR 1).
+
+### Fix wrong org references
+
+Three usage comment examples reference `williaby/.github/` instead of `ByronWilliamsCPA/.github/`:
+- `python-fuzzing.yml` line 9
+- `python-performance-regression.yml` line 9
+- `python-qlty-coverage.yml` line 12
+
+Simple find-and-replace in each file.
+
+### Add Scorecard score gate to `python-scorecard.yml`
+
+Add input:
+```yaml
+min-score:
+  description: 'Minimum acceptable score per check (0-10). Checks below this threshold fail the workflow.'
+  type: number
+  required: false
+  default: 4
+```
+
+Add step after SARIF upload:
+
+```yaml
+- name: Evaluate Scorecard Scores
+  env:
+    MIN_SCORE: ${{ inputs.min-score }}
+  run: |
+    python3 - <<'EOF'
+    import json, os, sys
+
+    with open('scorecard-results.sarif') as f:
+        sarif = json.load(f)
+
+    min_score = float(os.environ["MIN_SCORE"])
+    gate_checks = {"Branch-Protection", "Code-Review", "Dangerous-Workflow",
+                   "Token-Permissions", "Pinned-Dependencies"}
+    failures = []
+
+    for run in sarif.get("runs", []):
+        for result in run.get("results", []):
+            rule_id = result.get("ruleId", "")
+            score = result.get("properties", {}).get("score", 10)
+            if rule_id in gate_checks and score < min_score:
+                failures.append(f"{rule_id}: {score}/10 (minimum {min_score})")
+
+    if failures:
+        print("::error::Scorecard score gate failed:")
+        for f in failures:
+            print(f"  - {f}")
+        sys.exit(1)
+    else:
+        print(f"Scorecard score gate passed (all gated checks >= {min_score}/10)")
+    EOF
+```
+
+Note: inputs used inside this heredoc are read via `os.environ` (consistent with the env-var pattern established in PR 1).
+
+### Add missing `timeout-minutes`
+
+- `check-configuration` in `python-sonarcloud.yml`: 5 minutes
+- `check-configuration` in `python-qlty-coverage.yml`: 5 minutes
+- `build-matrix` in `python-compatibility.yml`: 5 minutes
+- `compatibility-summary` in `python-compatibility.yml`: 5 minutes
+
+### Hard-fail `python-pr-validation.yml`
+
+Replace all job content with a single failing job that directs callers to migrate:
+
+```yaml
+jobs:
+  migration-required:
+    name: This workflow is removed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Migration required
+        run: |
+          echo "::error::python-pr-validation.yml has been removed."
+          echo "::error::Migrate to python-ci.yml and python-supplemental-checks.yml."
+          echo "::error::See .github/workflows/python-ci.yml header for usage."
+          exit 1
+```
+
+### Fix `python-supplemental-checks.yml` auto-merge detection
+
+Replace PR-title string matching for major/minor/patch classification with Dependabot's native label approach. Check for labels `major`, `minor`, `patch` set by Dependabot instead of parsing the PR title string. This is not spoofable via PR title manipulation.
+
+---
+
+## PR 3: New Capabilities
+
+**Branch:** `feat/workflow-new-capabilities`
+**Depends on:** PR 2 merged to `main`
+**Implementation:** Single worktree, additive only
+
+### `python-precommit.yml` (new workflow)
+
+Reusable `workflow_call` workflow following the same structure as all existing workflows.
+
+Inputs:
+- `config-path`: string, default `.pre-commit-config.yaml`
+- `python-version`: string, default `3.12`
+- `fail-fast`: boolean, default `true`
+
+Steps: harden-runner (egress: audit), checkout, setup-uv, uv sync, run pre-commit.
+
+All inputs passed via env vars in `run:` blocks.
+
+### `python-standard-stack.yml` (new composite entry point)
+
+A "quickstart" `workflow_call` workflow that chains `python-ci.yml`, `python-security-analysis.yml`, and `python-sbom.yml` using `needs:`. Documents itself as the recommended starting point for new repos.
+
+Exposes only the most common inputs:
+- `python-version` (string, default `3.12`)
+- `source-directory` (string, default `src`)
+- `coverage-threshold` (number, default `80`)
+- `fail-on-high` (boolean, default `true`)
+
+Optional secret passthroughs: `SONAR_TOKEN`, `CODECOV_TOKEN`.
+
+### Commit linting in `python-supplemental-checks.yml`
+
+Add optional job `commit-lint` gated on new boolean input `enable-commit-lint` (default: `false`).
+
+Uses `amannn/action-semantic-pull-request` (SHA-pinned) to validate PR title follows Conventional Commits format. Individual commit message validation (via `commitlint`) is out of scope: it requires a `commitlint.config.js` in every caller repo and is better enforced by pre-commit hooks (which `python-precommit.yml` covers).
+
+---
+
+## What This Does Not Include
+
+- Egress policy upgrades (`audit` to `block`) across all 23 workflows -- high effort, requires endpoint discovery per job, deferred to a standalone "harden egress" spike.
+- Mid-job `git checkout origin/main` refactor in `python-performance-regression.yml` (MED-07) -- requires splitting the comparison into separate jobs, significant redesign, deferred.
+- SBOM attachment to GitHub Releases from `python-sbom.yml` -- requires `python-release.yml` coordination, deferred.
+- `python-codecov.yml` `CODECOV_TOKEN: required: true` → `required: false` -- low priority, deferred to PR 3 or standalone.
+- MED-06 (`check-secrets` boolean exposure) -- removed entirely by PR 2 cleanup, resolves itself.
+
+---
+
+## Success Criteria
+
+**PR 1 complete when:**
+- No `${{ inputs.* }}` appears unquoted in any `run:` shell block across all 23 workflows
+- No `${{ inputs.* }}` appears interpolated directly as Python syntax inside any heredoc
+- `synthetic-data-script` input does not exist
+- All supply chain items (SLSA template, pip-audit, Docker provenance defaults) are updated
+- `python-release.yml` artifact upload step has `if: always()`
+
+**PR 2 complete when:**
+- `python-ci.yml` contains no SonarCloud job, no Codecov steps, no `check-secrets` job
+- Bandit invocation in `python-ci.yml` passes `-c pyproject.toml`
+- All three wrong org references corrected
+- `python-scorecard.yml` exits nonzero when gated checks score below `min-score`
+- `python-pr-validation.yml` exits 1 with migration message on every trigger
+- All missing `timeout-minutes` added
+
+**PR 3 complete when:**
+- `python-precommit.yml` exists, is callable, runs pre-commit hooks end-to-end
+- `python-standard-stack.yml` exists and chains CI + security + SBOM with minimal caller config
+- `python-supplemental-checks.yml` has `enable-commit-lint` input wired to semantic PR title check


### PR DESCRIPTION
## Summary

- CRIT-01: Remove \`synthetic-data-script\` RCE input from python-performance-regression.yml; callers use \`scripts/generate_test_data.py\` convention
- CRIT-02: Move all Python heredoc inputs to \`env:\` blocks, read via \`os.environ\`
- HIGH-05: Move benchmark shell inputs to env vars with quoted references
- Systematic env-var isolation across python-ci, python-compatibility, python-docs, python-release, python-security-analysis, python-pr-validation
- Permission scoping: workflow-level over-grants moved to individual jobs
- Exit-code-5 fix: pytest \`|| echo\` suppression replaced with proper exit code check
- Supply chain: Docker SBOM/provenance defaults flipped to \`true\`; unpinned safety replaced with pip-audit; SLSA comment examples SHA-pinned

## Breaking Change

\`python-docker.yml\`: \`enable-sbom\` default changed from \`false\` to \`true\`. Callers that intentionally disabled SBOM must add \`enable-sbom: false\` explicitly.

## Test Plan

- [ ] qlty check (actionlint + shellcheck) passes on all 10 modified workflows
- [ ] pre-commit run --all-files passes
- [ ] No \`${{ inputs.* }}\` remains unquoted in any run: shell block
- [ ] \`synthetic-data-script\` input does not exist in any workflow
- [ ] python-release.yml artifact upload step has \`if: always()\`
- [ ] Trigger modified workflows via workflow_dispatch on a downstream test repo

Generated with [Claude Code](https://claude.com/claude-code)