### PR TITLE
fix(security): use uv run for pip-audit and bandit in python-publish-pypi.yml

### DIFF
--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -95,8 +95,8 @@ jobs:
           SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "Running pre-publish security checks..."
-          uv run pip-audit --strict
-          uv run bandit -r "$SRC_DIR" -c pyproject.toml -ll
+          uv run --with pip-audit==2.10.0 pip-audit --strict
+          uv run --with 'bandit[toml]==1.9.4' bandit -r "$SRC_DIR" -c pyproject.toml -ll
 
       - name: Build distribution packages
         run: |

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -95,8 +95,8 @@ jobs:
           SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "Running pre-publish security checks..."
-          uvx pip-audit
-          uvx bandit -r "$SRC_DIR" -c pyproject.toml -ll
+          uv run pip-audit --strict
+          uv run bandit -r "$SRC_DIR" -c pyproject.toml -ll
 
       - name: Build distribution packages
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ are no numbered releases.
 
 ### Fixed
 
+- `python-publish-pypi.yml`: replace `uv run pip-audit` / `uv run bandit` with `uv run --with` invocations that pin tool versions (`pip-audit==2.10.0`, `bandit[toml]==1.9.4`); the previous form required both tools to be listed as project dev dependencies in every downstream caller's `uv.lock`, silently failing or auditing an empty environment when they were absent
 - Fix stale `williaby` org reference in usage example comments for `python-fuzzing.yml`, `python-performance-regression.yml`, and `python-qlty-coverage.yml`
 - Add `timeout-minutes: 5` to `build-matrix` and `compatibility-summary` jobs in `python-compatibility.yml`
 - Add `timeout-minutes: 5` to `check-configuration` jobs in `python-sonarcloud.yml` and `python-qlty-coverage.yml`


### PR DESCRIPTION
## Summary

- Replace \`uvx pip-audit\` with \`uv run --with pip-audit==2.10.0 pip-audit --strict\` in the pre-publish security gate
- Replace \`uvx bandit\` with \`uv run --with 'bandit[toml]==1.9.4' bandit\` for consistency
- Pin tool versions explicitly to lock security gate behavior across cache evictions

## Root cause

\`uvx\` is an alias for \`uv tool run --no-project\`, which runs the tool in an isolated throwaway environment with no access to the project's virtual environment or \`uv.lock\`. This means \`uvx pip-audit\` effectively audits an empty environment and will always pass; the security gate provides false confidence and will never catch a vulnerable project dependency.

\`uv run --with\` installs the specified tool into a temporary overlay on top of the project's \`.venv\`, giving pip-audit visibility into all packages that will actually ship to PyPI. The \`--with\` form is used rather than bare \`uv run\` so the workflow works for all downstream callers regardless of whether they list pip-audit and bandit as explicit dev dependencies.

## Why \`--strict\`

\`pip-audit --strict\` fails if dependency collection fails on any single package, rather than silently skipping unresolvable packages. For a publish gate this is the correct posture: an unresolvable dependency is itself a risk signal.

## Prior art

The same fix was applied to \`python-ci.yml\` in commit \`2243166\` ("fix(ci): migrate pip-audit from uvx to uv run for correct dependency scope"). This PR closes the same gap in the publish workflow, which is a higher-stakes gate.

## Static analysis warnings

One SonarQube diagnostic fires on the new lines (S8541). It is a false positive in this context:
- **S8541** (\`--no-build\`): pip-audit is auditing the already-installed project venv, so no new packages are being built. Adding \`--no-build\` would reduce audit coverage by skipping packages that require a build step.

S8544 (unlocked versions) is now addressed by explicit version pinning in the \`--with\` flags (\`pip-audit==2.10.0\`, \`bandit[toml]==1.9.4\`).

## Test plan

- [ ] Trigger \`python-publish-pypi.yml\` via \`workflow_dispatch\` on a downstream repo that has pip-audit and bandit as dev dependencies; confirm the security check step passes and shows project dependency audit output
- [ ] Trigger \`python-publish-pypi.yml\` via \`workflow_dispatch\` on a downstream repo that does NOT have pip-audit and bandit as dev dependencies; confirm the security check step still passes (validates the \`--with\` portability fix)
- [ ] Confirm a downstream repo with a known vulnerable dependency fails the gate

Generated with [Claude Code](https://claude.ai/code)