### PR TITLE
chore(gitignore): ignore .claude/ AI assistant state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ tmp/
 tmp_cleanup/
 actionlint
 
+# AI assistant state
+.claude/
+
 # Git worktrees
 .worktrees/
 


### PR DESCRIPTION
## Summary

- Add `.claude/` to `.gitignore` under a new `# AI assistant state` section

## Why

The `.claude/` directory is created by Claude Code and contains local session
state (e.g. `scheduled_tasks.lock`). It has no business being in version
control and was showing up as an untracked file in every `git status`.

## Test plan

- [x] `git status` no longer shows `.claude/` as untracked

Generated with [Claude Code](https://claude.com/claude-code)