### PR TITLE
feat(security): add pre-commit config with TruffleHog secret scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Pre-commit hooks: file checks and secret scanning.
+# See pre-commit-authoring skill for hook authoring guidance.
+
+default_install_hook_types: [pre-commit]
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: c4a0b883114b00d8d76b479c820ce7950211c99b  # v4.5.0
+    hooks:
+      - id: trailing-whitespace
+        stages: [pre-commit]
+      - id: end-of-file-fixer
+        stages: [pre-commit]
+      - id: check-added-large-files
+        stages: [pre-commit]
+      - id: check-merge-conflict
+        stages: [pre-commit]
+      - id: detect-private-key
+        stages: [pre-commit]
+
+  # ============================================================================
+  # Secret Detection - TruffleHog
+  # ============================================================================
+  - repo: local
+    hooks:
+      - id: trufflehog
+        name: TruffleHog Secret Scanner
+        description: Detect secrets in your data before committing
+        # Scan staged files only. The git-history mode (--since-commit HEAD) also
+        # traverses fetched remote branches in the local object store, producing
+        # false positives from unmerged branches. Staged-file scanning is the
+        # correct scope for a pre-commit hook; git history scanning belongs in CI.
+        entry: bash -c 'command -v trufflehog >/dev/null 2>&1 && (git diff --cached -z --diff-filter=d --name-only 2>/dev/null | xargs -0 -r trufflehog filesystem --fail --no-update --results=verified,unknown) || echo "TruffleHog not installed - skipping secret scan"'
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary

Add a baseline `.pre-commit-config.yaml` with file-quality hooks
(trailing-whitespace, end-of-file, large-file, merge-conflict, private-key)
and a TruffleHog secret-scanning hook scoped to staged files.

Run `pre-commit install` after pulling to activate the hooks locally.

See `.claude/rules/pre-commit.md` invariant `PC-HOOK-STAGED-SCOPE` for the
scope principle.

## Why

Resolves observation #4 from `~/.claude/skill-observations/log.md`.
Part of a fleet-wide TruffleHog rollout following the methodology in the
`pre-commit-authoring` skill and the `PC-HOOK-STAGED-SCOPE` invariant in
`.claude/rules/pre-commit.md`.

Generated with [Claude Code](https://claude.ai/code)