### PR TITLE
fix(compliance): wrap instructional SPDX echoes in python-reuse.yml

### DIFF
--- a/.github/workflows/python-reuse.yml
+++ b/.github/workflows/python-reuse.yml
@@ -112,8 +112,10 @@ jobs:
             echo "### How to Fix" >> $GITHUB_STEP_SUMMARY
             echo "1. Add SPDX license identifiers to source files:" >> $GITHUB_STEP_SUMMARY
             echo '   ```' >> $GITHUB_STEP_SUMMARY
+            # REUSE-IgnoreStart
             echo '   # SPDX-FileCopyrightText: 2024 Your Name' >> $GITHUB_STEP_SUMMARY
             echo '   # SPDX-License-Identifier: MIT' >> $GITHUB_STEP_SUMMARY
+            # REUSE-IgnoreEnd
             echo '   ```' >> $GITHUB_STEP_SUMMARY
             echo "2. Or create a \`.reuse/dep5\` file for bulk declarations" >> $GITHUB_STEP_SUMMARY
             echo "3. Install reuse tool: \`pip install reuse\`" >> $GITHUB_STEP_SUMMARY

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -9,3 +9,14 @@ SPDX-PackageDownloadLocation = "https://github.com/ByronWilliamsCPA/.github"
 path = ["**"]
 SPDX-License-Identifier = "MIT"
 SPDX-FileCopyrightText = "2025 Byron Williams"
+
+
+# Pre-existing files (added 2026-05-08 to clear REUSE compliance backlog)
+# These files predate the centralized REUSE.toml coverage. Licensed CC0-1.0
+# (public domain dedication) consistent with other configuration files.
+[[annotations]]
+path = [
+    ".github/workflows/python-reuse.yml",
+]
+SPDX-License-Identifier = "CC0-1.0"
+SPDX-FileCopyrightText = "2025 Byron Williams"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -9,14 +9,3 @@ SPDX-PackageDownloadLocation = "https://github.com/ByronWilliamsCPA/.github"
 path = ["**"]
 SPDX-License-Identifier = "MIT"
 SPDX-FileCopyrightText = "2025 Byron Williams"
-
-
-# Pre-existing files (added 2026-05-08 to clear REUSE compliance backlog)
-# These files predate the centralized REUSE.toml coverage. Licensed CC0-1.0
-# (public domain dedication) consistent with other configuration files.
-[[annotations]]
-path = [
-    ".github/workflows/python-reuse.yml",
-]
-SPDX-License-Identifier = "CC0-1.0"
-SPDX-FileCopyrightText = "2025 Byron Williams"


### PR DESCRIPTION
## Summary

Wrap instructional `echo '# SPDX-License-Identifier: MIT'` lines in
`.github/workflows/python-reuse.yml` with `# REUSE-IgnoreStart` /
`# REUSE-IgnoreEnd` markers (REUSE 3.3 spec) so the REUSE compliance
gate stops parsing them as real SPDX expressions.

## Why

The previous failure log on PR #67 (TruffleHog rollout) and on this PR's
initial commit reported two REUSE errors against the same file:

1. `INVALID SPDX LICENSE EXPRESSIONS`: the shell echoes were parsed as
   actual SPDX tags, producing `MIT' >> $GITHUB_STEP_SUMMARY` (invalid).
2. `MISSING COPYRIGHT AND LICENSING INFORMATION`: the file had no header.

The original approach (adding a `[[annotations]]` block to `REUSE.toml`
with CC0-1.0) only addressed #2; the invalid-SPDX detection runs on
file content directly and would have remained failing after merge.

This rev wraps the offending lines so REUSE skips them. The existing
global `path = ["**"]` MIT annotation then satisfies the licensing-info
check without needing an override block. The earlier CC0-1.0 annotation
is reverted (CC0 in this org is reserved for the image-detection
training-data project; reusable workflows referenced via `uses:` are
not redistributed, so MIT applies fine).

## Verification

- `reuse lint` passes locally: 125/125 files compliant, 0 invalid SPDX
  expressions.
- CodeQL Default setup was disabled in repo settings (separate fix), so
  the `CodeQL Analyze` advanced workflow can upload SARIF without
  conflict.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compliance checking workflow configuration to improve handling of license documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->