### PR TITLE
fix(security): P2-05 close run-tests skip bypass in python-release.yml

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -23,6 +23,13 @@
 #   - PyPI publishing with OIDC trusted publishing
 #   - Sigstore artifact signing
 #   - SBOM generation
+#
+# Skipping pre-release tests:
+#   The `run-tests: false` input opts out of the pre-release test gate. To
+#   prevent accidental bypass, callers using `run-tests: false` MUST also
+#   supply a non-empty `skip-tests-reason` input documenting why the tests
+#   are safe to skip (e.g., "tests run in upstream pipeline X"). The release
+#   job will fail fast if `run-tests: false` is used without a reason.
 # ============================================================================
 
 name: Python Release (Reusable)
@@ -75,6 +82,11 @@ on:
         required: false
         type: boolean
         default: true
+      skip-tests-reason:
+        description: 'Reason for skipping pre-release tests (REQUIRED when run-tests is false; e.g., "tests run in upstream pipeline X")'
+        required: false
+        type: string
+        default: ''
       generate-sbom:
         description: 'Generate Software Bill of Materials'
         required: false
@@ -179,6 +191,18 @@ jobs:
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: audit
+
+      - name: Validate skip-tests opt-out
+        if: ${{ !inputs.run-tests }}
+        env:
+          SKIP_TESTS_REASON: ${{ inputs.skip-tests-reason }}
+        run: |
+          if [ -z "$SKIP_TESTS_REASON" ]; then
+            echo "::error::run-tests is false but skip-tests-reason is empty."
+            echo "::error::Pre-release tests are a required quality gate. To opt out intentionally, supply a non-empty skip-tests-reason input documenting why (e.g., 'tests run in upstream pipeline X')."
+            exit 1
+          fi
+          echo "Pre-release tests skipped intentionally. Reason: $SKIP_TESTS_REASON"
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/docs/audits/2026-05-01-security-audit.md
+++ b/docs/audits/2026-05-01-security-audit.md
@@ -35,7 +35,7 @@
 | P2-02 | HIGH | Closed | PR #46 (`cbb86ee`) routed all caller inputs through `env:` blocks across `python-ci.yml`, `python-performance-regression.yml`, `python-security-analysis.yml` |
 | P2-03 | HIGH | Closed | Current `python-publish-pypi.yml` step uses `pip-audit --strict` and `bandit -ll` with no `\|\| echo` swallow — both hard-fail on findings |
 | P2-04 | HIGH | Closed | PR #46 (`cbb86ee`) reduced workflow-level `permissions:` in `python-release.yml` to `contents: read`; per-job permissions scoped narrowly |
-| P2-05 | MEDIUM | Open | — |
+| P2-05 | MEDIUM | Fixed | This PR — `python-release.yml` adds required `skip-tests-reason` input and validates it is non-empty when `run-tests: false`; release job fails fast on accidental bypass |
 | P2-06 | MEDIUM | Open | — |
 | P2-07 | MEDIUM | Closed | `python-supplemental-checks.yml` now uses label-based detection (`version-update:semver-{major,minor,patch}` and `semver:*` aliases), replacing the original PR-title regex |
 | P2-08 | MEDIUM | Open | — |


### PR DESCRIPTION
## Summary

Closes finding **P2-05** from `docs/audits/2026-05-01-security-audit.md`.

The release job's gating condition treated `needs.test.result == 'skipped'` (when `run-tests: false`) identically to `'success'`. A caller could silently bypass the pre-release quality gate by flipping a single boolean.

## Fix

- Add new `skip-tests-reason` input (string, default empty)
- Add **Validate skip-tests opt-out** step at the start of the `release` job. Runs only when `run-tests: false`. Fails fast with clear `::error::` annotations when `skip-tests-reason` is empty.
- Update workflow header comment documenting the new contract.
- Update audit status table: P2-05 → Fixed.

## Behaviour change

| Caller setting | Before | After |
| --- | --- | --- |
| `run-tests: true` (default) | Tests run, gate enforced | unchanged |
| `run-tests: false`, no reason | Release proceeds silently | **Release fails fast with explanatory error** |
| `run-tests: false` + `skip-tests-reason: "..."` | Release proceeds silently | Release proceeds, reason logged |

## Test plan

- [x] Existing default path (`run-tests: true`) untouched — test job runs as before
- [x] Validate step env-var routing follows existing pattern (other inputs already use `env:` blocks)
- [x] Audit status table updated in same commit

## Notes

This is a behaviour-changing security fix but **not a breaking change for current callers**: any caller currently using `run-tests: false` was already in an unsafe configuration. They will now receive a clear error and a path to opt-in (provide a documented reason).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow validation to require explicit documentation when intentionally skipping pre-release tests, preventing accidental test bypass.
  * Updated security audit documentation to reflect resolution of findings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/.github/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->