### PR TITLE
fix(security): P2-10 wire detect-changes into CodeQL job condition

### DIFF
--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -107,9 +107,13 @@ jobs:
               - 'requirements*.txt'
 
   # CodeQL Analysis
+  # Gates on (a) caller opt-in via run-codeql AND (b) at least one security-
+  # relevant file changed in the diff. The detect-changes filter checks Python
+  # sources, workflow files, and dependency manifests; if none changed,
+  # CodeQL is skipped to save CI minutes.
   codeql:
     name: CodeQL Analysis
-    if: ${{ inputs.run-codeql }}
+    if: ${{ inputs.run-codeql && needs.detect-changes.outputs.security_files == 'true' }}
     runs-on: ubuntu-latest
     needs: detect-changes
     timeout-minutes: 20

--- a/docs/audits/2026-05-01-security-audit.md
+++ b/docs/audits/2026-05-01-security-audit.md
@@ -40,7 +40,7 @@
 | P2-07 | MEDIUM | Closed | `python-supplemental-checks.yml` now uses label-based detection (`version-update:semver-{major,minor,patch}` and `semver:*` aliases), replacing the original PR-title regex |
 | P2-08 | MEDIUM | Open | — |
 | P2-09 | LOW | Closed | `python-pr-validation.yml` carries an explicit DEPRECATED header with full migration guide to `python-ci.yml`. Sunset date still TBD but recommendation satisfied |
-| P2-10 | LOW | Open | — |
+| P2-10 | LOW | Fixed | This PR — `python-security-analysis.yml` codeql job now gates on `needs.detect-changes.outputs.security_files == 'true'` in addition to `inputs.run-codeql` |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes finding **P2-10** from `docs/audits/2026-05-01-security-audit.md`.

The `detect-changes` job in `python-security-analysis.yml` computed a `security_files` output but never referenced it. CodeQL ran on every invocation regardless of whether security-relevant files changed — burning CI minutes on no-op analyses while making `detect-changes` effectively dead config.

## Fix

Add `needs.detect-changes.outputs.security_files == 'true'` to the `codeql` job's `if:` condition. CodeQL now runs when **both**:

1. The caller opted in via `inputs.run-codeql`, AND
2. At least one security-relevant file (Python source, workflow file, dependency manifest) changed in the diff

The detect-changes filter scope is unchanged — it still matches `**/*.py`, `.github/workflows/**`, `pyproject.toml`, `poetry.lock`, `uv.lock`, and `requirements*.txt`.

## Behaviour change

| Diff | Before | After |
| --- | --- | --- |
| Touches Python source / workflow / lockfile | CodeQL runs (with `run-codeql: true`) | unchanged — CodeQL runs |
| Docs-only / unrelated change | CodeQL runs (waste) | **CodeQL skipped (saves minutes)** |
| `run-codeql: false` | CodeQL skipped | unchanged |

## Test plan

- [x] `if:` evaluates to true when both conditions met (matches existing behaviour for security-touching diffs)
- [x] `if:` evaluates to false on docs-only diffs (skips CodeQL job)
- [x] `needs: detect-changes` declaration unchanged — dependency graph intact
- [x] Audit status table: P2-10 → Fixed

Generated with [Claude Code](https://claude.com/claude-code)