### PR TITLE
fix(security): P1-03 migrate @main pins to @v1 and document pinning strategy

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     ci:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
 #       with:
 #         python-version: '3.12'
 #         coverage-threshold: 80

--- a/.github/workflows/python-codecov.yml
+++ b/.github/workflows/python-codecov.yml
@@ -18,7 +18,7 @@
 #   # Then call this workflow:
 #   upload-coverage:
 #     needs: test
-#     uses: ByronWilliamsCPA/.github/.github/workflows/python-codecov.yml@main
+#     uses: ByronWilliamsCPA/.github/.github/workflows/python-codecov.yml@v1
 #     with:
 #       artifact-name: 'coverage-reports'
 #     secrets:

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     compatibility:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@v1
 #       with:
 #         python-versions: '["3.10", "3.11", "3.12", "3.13"]'
 #         operating-systems: '["ubuntu-latest", "macos-latest", "windows-latest"]'
@@ -28,7 +28,7 @@
 # System Dependencies Example (for packages like python-magic):
 #   jobs:
 #     compatibility:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@v1
 #       with:
 #         system-deps-macos: 'libmagic'
 #         system-deps-ubuntu: 'libmagic-dev'

--- a/.github/workflows/python-container-security.yml
+++ b/.github/workflows/python-container-security.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     container-security:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-container-security.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-container-security.yml@v1
 #       with:
 #         image-ref: 'myapp:latest'
 #         dockerfile-path: './Dockerfile'

--- a/.github/workflows/python-docker.yml
+++ b/.github/workflows/python-docker.yml
@@ -7,7 +7,7 @@
 #   # For PR builds (build + optional push):
 #   jobs:
 #     docker:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-docker.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-docker.yml@v1
 #       with:
 #         push: true
 #         platforms: 'linux/amd64,linux/arm64'
@@ -15,7 +15,7 @@
 #   # For release builds:
 #   jobs:
 #     docker:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-docker.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-docker.yml@v1
 #       with:
 #         push: true
 #         tag-latest: true

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -4,7 +4,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     docs:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-docs.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-docs.yml@v1
 #       with:
 #         deploy-to-pages: true
 #       permissions:

--- a/.github/workflows/python-fips-compatibility.yml
+++ b/.github/workflows/python-fips-compatibility.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     fips-check:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-fips-compatibility.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-fips-compatibility.yml@v1
 #       with:
 #         strict-mode: false
 #         include-tests: true

--- a/.github/workflows/python-fuzzing.yml
+++ b/.github/workflows/python-fuzzing.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     fuzzing:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-fuzzing.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-fuzzing.yml@v1
 #       with:
 #         fuzz-seconds: 1200
 #         sanitizer: 'address'

--- a/.github/workflows/python-mutation.yml
+++ b/.github/workflows/python-mutation.yml
@@ -20,7 +20,7 @@
 #       - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM
 #   jobs:
 #     mutation:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@v1
 #       with:
 #         source-directory: 'src'
 #         mutation-threshold: 80

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     performance:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-performance-regression.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-performance-regression.yml@v1
 #       with:
 #         benchmark-script: 'scripts/benchmarks/run_benchmark.py'
 #         regression-threshold: 10.0

--- a/.github/workflows/python-pr-validation.yml
+++ b/.github/workflows/python-pr-validation.yml
@@ -31,12 +31,12 @@
 # Before (deprecated):
 #   jobs:
 #     pr-validation:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-pr-validation.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-pr-validation.yml@v1
 #
 # After (recommended):
 #   jobs:
 #     ci:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
 #       with:
 #         python-version: '3.12'
 #         coverage-threshold: 80

--- a/.github/workflows/python-precommit.yml
+++ b/.github/workflows/python-precommit.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     pre-commit:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-precommit.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-precommit.yml@v1
 #       with:
 #         python-version: '3.12'
 #         fail-fast: true

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -14,7 +14,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     publish:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
 #       with:
 #         package-name: 'my-package'
 #       permissions:

--- a/.github/workflows/python-qlty-coverage.yml
+++ b/.github/workflows/python-qlty-coverage.yml
@@ -8,7 +8,7 @@
 #     qlty-coverage:
 #       needs: [ci]  # Run after CI workflow completes
 #       if: success()
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-coverage.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-coverage.yml@v1
 #       secrets:
 #         QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
 #       with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     release:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-release.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-release.yml@v1
 #       with:
 #         python-version: '3.12'
 #         semantic-release: true

--- a/.github/workflows/python-reuse.yml
+++ b/.github/workflows/python-reuse.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     reuse:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-reuse.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-reuse.yml@v1
 #       with:
 #         generate-spdx: true
 #

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     sbom:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-sbom.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-sbom.yml@v1
 #       with:
 #         python-version: '3.12'
 #         fail-on-vulnerabilities: true

--- a/.github/workflows/python-scorecard.yml
+++ b/.github/workflows/python-scorecard.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     scorecard:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@v1
 #       permissions:
 #         security-events: write
 #         contents: read

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -4,7 +4,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     security:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-security-analysis.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-security-analysis.yml@v1
 #       with:
 #         source-directory: 'src'
 #         fail-on-high: true

--- a/.github/workflows/python-sonarcloud.yml
+++ b/.github/workflows/python-sonarcloud.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     sonarcloud:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-sonarcloud.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-sonarcloud.yml@v1
 #       permissions:
 #         contents: read
 #         pull-requests: write   # REQUIRED for PR decoration -- see Known Limitations

--- a/.github/workflows/python-standard-stack.yml
+++ b/.github/workflows/python-standard-stack.yml
@@ -8,7 +8,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     standard-stack:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-standard-stack.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-standard-stack.yml@v1
 #       permissions:
 #         contents: read
 #         pull-requests: write

--- a/.github/workflows/python-supplemental-checks.yml
+++ b/.github/workflows/python-supplemental-checks.yml
@@ -6,7 +6,7 @@
 # Usage from downstream repos:
 #   jobs:
 #     supplemental:
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-supplemental-checks.yml@main
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-supplemental-checks.yml@v1
 #       with:
 #         enable-link-check: true
 #         enable-changelog-check: true

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.11", "3.12"]'
     secrets:
@@ -146,7 +146,7 @@ overridden by a repo-specific copy).
 **To use the reusable workflows in your Python project**, reference them directly by name -- no fork or clone needed:
 
 ```yaml
-uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
 ```
 
 See [USAGE_EXAMPLES.md](USAGE_EXAMPLES.md) for full examples and all available input parameters. See the [Prerequisites](#prerequisites) section above for what your repo must provide.

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -16,7 +16,7 @@ on:
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```
@@ -42,7 +42,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.11", "3.12"]'
     secrets:
@@ -60,7 +60,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       coverage-threshold: 90
     secrets:
@@ -78,7 +78,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       source-directory: 'app'
       test-directory: 'tests/unit'
@@ -97,7 +97,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       run-mypy: false
     secrets:
@@ -115,7 +115,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       run-ruff: false
       run-mypy: false
@@ -136,7 +136,7 @@ on:
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.10", "3.11", "3.12"]'
       source-directory: 'src/myapp'
@@ -163,7 +163,7 @@ on: [push, pull_request]
 jobs:
   # Testing and quality
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.11", "3.12"]'
       coverage-threshold: 85
@@ -172,12 +172,12 @@ jobs:
 
   # Security scanning
   security:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-security-analysis.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-security-analysis.yml@v1
     if: github.event_name == 'pull_request'
 
   # Documentation
   docs:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-docs.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-docs.yml@v1
     if: github.ref == 'refs/heads/main'
 ```
 
@@ -196,7 +196,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     permissions:
       id-token: write  # Required for OIDC
       contents: read
@@ -213,42 +213,61 @@ jobs:
 
 ## Version Pinning
 
-### Use Specific Version (Recommended for Production)
+This repository publishes two kinds of tags so callers can choose the right
+trade-off between stability and security:
 
-Pin to a specific tag:
+- **`@v1`** — moving major-version tag, re-pointed when a backward-compatible
+  change lands on `main`. Recommended default for most production callers.
+- **`@v1.0.0`** — immutable patch tag for exact-version pinning.
+- **`@<sha>`** — full 40-character commit SHA. Most secure (immune to tag
+  rewrites), highest maintenance burden (must be rotated manually).
+
+`@main` is **not** recommended for any caller. A push to `main` takes effect
+in every consumer instantly, with no review and no rollback path. Use it only
+for short-lived workflow development on a fork or a feature branch in this
+repo.
+
+### Use Moving Major Tag (Recommended for Most Callers)
+
+Pin to the moving `@v1` tag for a balance of stability and continuous fixes:
+
+```yaml
+jobs:
+  ci:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
+    #                                                         ^^ Tracks v1.x.x backwards-compatible updates
+```
+
+### Use Specific Version (Pin Once, Update Deliberately)
+
+Pin to an immutable patch tag:
 
 ```yaml
 jobs:
   ci:
     uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1.0.0
-    #                                                         ^^^^^^ Pin to tag
+    #                                                         ^^^^^^ Pin to exact patch version
 ```
 
 ### Use Commit SHA (Most Secure)
 
-Pin to exact commit:
+Pin to a full commit SHA. Renovate/Dependabot can auto-bump these:
 
 ```yaml
 jobs:
   ci:
     uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@abc123def456...
-    #                                                         ^^^^^^ Specific commit
+    #                                                         ^^^^^^ Full 40-char SHA
 ```
 
-### Use Branch (Always Latest - Risky)
+**Choosing a strategy:**
 
-Use main branch (always gets latest changes):
-
-```yaml
-jobs:
-  ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
-    #                                                         ^^^^ Always latest
-```
-
-**Recommendation**:
-- **Development**: Use `@main` to get latest features
-- **Production**: Use `@v1` or specific tag for stability
+| Caller profile | Recommended pin |
+| --- | --- |
+| Standard production project | `@v1` |
+| Compliance-sensitive / regulated | `@v1.0.0` or `@<sha>` |
+| Maximum supply-chain hardening | `@<sha>` (auto-managed by Renovate) |
+| Active workflow development on this repo | `@<feature-branch>` (temporary) |
 
 ---
 
@@ -266,7 +285,7 @@ on:
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.11", "3.12"]'
       source-directory: 'app'
@@ -278,7 +297,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   security:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-security-analysis.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-security-analysis.yml@v1
     needs: ci
 ```
 
@@ -291,7 +310,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       # Test on multiple Python versions for CLI compatibility
       python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
@@ -312,7 +331,7 @@ on:
 
 jobs:
   test:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.10", "3.11", "3.12"]'
       coverage-threshold: 95  # High coverage for library
@@ -321,7 +340,7 @@ jobs:
   publish:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     permissions:
       id-token: write
 ```
@@ -340,7 +359,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11, 3.12]  # ❌ Don't do matrix in calling workflow
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.11", "3.12"]'
 ```
@@ -350,7 +369,7 @@ jobs:
 ```yaml
 jobs:
   test:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-versions: '["3.11", "3.12"]'  # ✅ Pass array, workflow handles matrix
 ```
@@ -365,7 +384,7 @@ jobs:
 jobs:
   ci:
     if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
 ```
 
 ### Skip CI on Documentation Changes
@@ -379,7 +398,7 @@ on:
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
 ```
 
 ---
@@ -393,7 +412,7 @@ Workflow runs appear in **your repo's Actions tab**, not the `.github` repo.
 ### Common Issues
 
 **Issue**: "Workflow not found"
-**Fix**: Check path is exactly: `ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main`
+**Fix**: Check path is exactly: `ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1`
 
 **Issue**: "permissions denied"
 **Fix**: Add `permissions:` block in calling workflow if needed
@@ -466,7 +485,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```

--- a/docs/audits/2026-05-01-security-audit.md
+++ b/docs/audits/2026-05-01-security-audit.md
@@ -28,7 +28,7 @@
 | --- | --- | --- | --- |
 | P1-01 | MEDIUM | Deferred | Pending decision on secondary owner identity |
 | P1-02 | MEDIUM | Open | — |
-| P1-03 | MEDIUM | Open | — |
+| P1-03 | MEDIUM | Fixed | This PR — bulk replaces `.yml@main` with `.yml@v1` across 42 user-facing docs, workflow header comments, and templates; adds version-pinning strategy section to USAGE_EXAMPLES.md. Maintainer to push `v1.0.0` and `v1` tags after all 8 fix PRs merge |
 | P1-04 | LOW | Closed | Resolved by file separation: `.github/dependabot.yml` (active for this repo) lists only `github-actions`; root `dependabot.yml` is a template propagated to downstream repos by `sync_org_files.sh` and intentionally covers all common ecosystems |
 | P1-05 | LOW | Open | — |
 | P2-01 | CRITICAL | Closed | PR #46 (`cbb86ee`) removed `synthetic-data-script` input; current code calls hardcoded `scripts/generate_test_data.py` |

--- a/docs/migration/image-detection-pypi-migration.md
+++ b/docs/migration/image-detection-pypi-migration.md
@@ -88,7 +88,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'image-preprocessing-detector'
       use-testpypi: ${{ inputs.use_testpypi || false }}

--- a/docs/migration/pypi-publishing-migration.md
+++ b/docs/migration/pypi-publishing-migration.md
@@ -63,7 +63,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'image-preprocessing-detector'  # Your package name
       use-testpypi: ${{ inputs.use_testpypi || false }}
@@ -111,7 +111,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'your-package-name'  # ← CHANGE THIS
       use-testpypi: ${{ inputs.use_testpypi || false }}
@@ -175,7 +175,7 @@ None - all inputs have sensible defaults!
 ```yaml
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'my-package'
       python-version: '3.11'  # ← Use Python 3.11
@@ -189,7 +189,7 @@ jobs:
 ```yaml
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'my-package'
       run-security-checks: false  # ← Skip security scans
@@ -203,7 +203,7 @@ jobs:
 ```yaml
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'my-package'
       source-directory: 'lib'  # ← Scan lib/ instead of src/
@@ -311,7 +311,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'image-preprocessing-detector'
       use-testpypi: ${{ inputs.use_testpypi || false }}

--- a/docs/workflows/NEW_WORKFLOWS_SUMMARY.md
+++ b/docs/workflows/NEW_WORKFLOWS_SUMMARY.md
@@ -28,10 +28,10 @@ This document summarizes the four new reusable workflows added to the organizati
 ```yaml
 jobs:
   security-static:
-    uses: williaby/.github/.github/workflows/python-security-analysis.yml@main
+    uses: williaby/.github/.github/workflows/python-security-analysis.yml@v1
 
   security-fuzzing:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-seconds: 600
 ```
@@ -53,18 +53,18 @@ jobs:
 # Option 1: Comprehensive (SonarCloud)
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 # Option 2: Lightweight (Qlty)
 jobs:
   ci:
-    uses: williaby/.github/.github/workflows/python-ci.yml@main
+    uses: williaby/.github/.github/workflows/python-ci.yml@v1
 
   qlty:
     needs: ci
-    uses: williaby/.github/.github/workflows/python-qlty-coverage.yml@main
+    uses: williaby/.github/.github/workflows/python-qlty-coverage.yml@v1
     secrets:
       QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
 ```
@@ -81,18 +81,18 @@ on: [push, pull_request]
 jobs:
   # Static analysis
   security-scan:
-    uses: williaby/.github/.github/workflows/python-security-analysis.yml@main
+    uses: williaby/.github/.github/workflows/python-security-analysis.yml@v1
 
   # Dynamic fuzzing (weekly)
   fuzzing:
     if: github.event_name == 'schedule'
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-seconds: 1200
 
   # Code quality
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 ```
@@ -110,7 +110,7 @@ on:
 
 jobs:
   performance:
-    uses: williaby/.github/.github/workflows/python-performance-regression.yml@main
+    uses: williaby/.github/.github/workflows/python-performance-regression.yml@v1
     with:
       benchmark-script: 'scripts/benchmark.py'
       regression-threshold: 5.0  # Strict 5% threshold
@@ -126,11 +126,11 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: williaby/.github/.github/workflows/python-ci.yml@main
+    uses: williaby/.github/.github/workflows/python-ci.yml@v1
 
   sonarcloud:
     needs: ci
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -138,7 +138,7 @@ jobs:
 
   performance:
     needs: ci
-    uses: williaby/.github/.github/workflows/python-performance-regression.yml@main
+    uses: williaby/.github/.github/workflows/python-performance-regression.yml@v1
     with:
       benchmark-script: 'scripts/benchmark.py'
       fail-on-regression: true

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -30,7 +30,7 @@ on:
 
 jobs:
   my-job:
-    uses: ByronWilliamsCPA/.github/.github/workflows/WORKFLOW-NAME.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/WORKFLOW-NAME.yml@v1
     with:
       # Workflow-specific inputs
       input-name: 'value'
@@ -50,7 +50,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'my-package'
     permissions:
@@ -70,7 +70,7 @@ See [examples/publish-pypi-caller.yml](../../examples/publish-pypi-caller.yml) f
 2. **Consistency** - Same behavior across all projects
 3. **Security** - Built-in security scanning and best practices
 4. **Reduced Boilerplate** - Less code in each repository
-5. **Version Pinning** - Use `@main` for latest or pin to specific tags
+5. **Version Pinning** - Pin to `@v1` (moving major tag, recommended), `@v1.0.0` (immutable), or `@<sha>` (most secure). See `USAGE_EXAMPLES.md` for details. Avoid `@main` for production callers.
 
 ## Workflow Development
 
@@ -80,7 +80,7 @@ See [examples/publish-pypi-caller.yml](../../examples/publish-pypi-caller.yml) f
 2. **Define inputs** using `inputs:` section
 3. **Document usage** in this directory
 4. **Create example** in `examples/` directory
-5. **Test thoroughly** before promoting to `@main`
+5. **Test thoroughly** before promoting to `@v1` (moving major tag) or cutting a new immutable `@v1.x.x` tag
 
 ### Workflow Naming Convention
 

--- a/docs/workflows/python-fips-compatibility.md
+++ b/docs/workflows/python-fips-compatibility.md
@@ -39,7 +39,7 @@ permissions:
 
 jobs:
   fips-check:
-    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@v1
     permissions:
       contents: read
       pull-requests: write
@@ -50,7 +50,7 @@ jobs:
 ```yaml
 jobs:
   fips-check:
-    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@v1
     with:
       # Treat warnings as errors (default: false)
       strict-mode: true
@@ -96,7 +96,7 @@ on:
 
 jobs:
   fips-check:
-    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@v1
     with:
       strict-mode: ${{ github.event.inputs.strict_mode || false }}
       enable-runtime-test: ${{ github.event_name == 'schedule' }}

--- a/docs/workflows/python-fuzzing.md
+++ b/docs/workflows/python-fuzzing.md
@@ -67,7 +67,7 @@ on:
 
 jobs:
   fuzzing:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-seconds: 1200  # 20 minutes
       sanitizer: 'address'
@@ -146,7 +146,7 @@ on:
 
 jobs:
   fuzzing:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-seconds: 1200  # Extended 20-minute run
       sanitizer: 'address'
@@ -166,7 +166,7 @@ on:
 
 jobs:
   fuzzing:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-seconds: 600  # Shorter 10-minute run
       sanitizer: 'address'
@@ -184,13 +184,13 @@ on:
 
 jobs:
   address-sanitizer:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-seconds: 900
       sanitizer: 'address'
 
   undefined-sanitizer:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-seconds: 900
       sanitizer: 'undefined'
@@ -201,7 +201,7 @@ jobs:
 ```yaml
 jobs:
   fuzzing:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       fuzz-target-directory: 'tests/security/fuzz'
       fuzz-seconds: 1200
@@ -212,7 +212,7 @@ jobs:
 ```yaml
 jobs:
   fuzzing-build-test:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       dry-run: true  # Only build, don't execute
 ```
@@ -487,12 +487,12 @@ Test across Python versions:
 ```yaml
 jobs:
   fuzzing-py311:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       python-version: '3.11'
 
   fuzzing-py312:
-    uses: williaby/.github/.github/workflows/python-fuzzing.yml@main
+    uses: williaby/.github/.github/workflows/python-fuzzing.yml@v1
     with:
       python-version: '3.12'
 ```

--- a/docs/workflows/python-publish-pypi.md
+++ b/docs/workflows/python-publish-pypi.md
@@ -30,7 +30,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'my-package'
     permissions:
@@ -55,7 +55,7 @@ on:
 
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'my-package'
       use-testpypi: ${{ inputs.use_testpypi || false }}
@@ -69,7 +69,7 @@ jobs:
 ```yaml
 jobs:
   publish:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-publish-pypi.yml@v1
     with:
       package-name: 'my-package'
       python-version: '3.11'

--- a/docs/workflows/python-sonarcloud.md
+++ b/docs/workflows/python-sonarcloud.md
@@ -36,7 +36,7 @@ on:
 
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -96,7 +96,7 @@ on:
 
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -109,7 +109,7 @@ jobs:
 ```yaml
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -124,7 +124,7 @@ jobs:
 ```yaml
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -138,7 +138,7 @@ jobs:
 ```yaml
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -152,7 +152,7 @@ jobs:
 ```yaml
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -167,7 +167,7 @@ jobs:
 ```yaml
 jobs:
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -325,11 +325,11 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: williaby/.github/.github/workflows/python-ci.yml@main
+    uses: williaby/.github/.github/workflows/python-ci.yml@v1
 
   sonarcloud:
     needs: ci
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -342,10 +342,10 @@ jobs:
 ```yaml
 jobs:
   security:
-    uses: williaby/.github/.github/workflows/python-security-analysis.yml@main
+    uses: williaby/.github/.github/workflows/python-security-analysis.yml@v1
 
   sonarcloud:
-    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@main
+    uses: williaby/.github/.github/workflows/python-sonarcloud.yml@v1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:

--- a/docs/workflows/workflow-optimizations.md
+++ b/docs/workflows/workflow-optimizations.md
@@ -43,7 +43,7 @@ Implement tiered testing strategy:
 ```yaml
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-version: '3.12'  # Primary version for quality checks
 ```
@@ -53,7 +53,7 @@ jobs:
 ```yaml
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-version: '3.12'
       enable-matrix-testing: true
@@ -66,7 +66,7 @@ jobs:
 ```yaml
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-version: '3.13'
       enable-matrix-testing: true
@@ -124,7 +124,7 @@ Skip matrix testing on draft PRs by default:
 ```yaml
 jobs:
   compatibility:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@v1
     with:
       python-versions: '["3.11", "3.12", "3.13"]'
       operating-systems: '["ubuntu-latest", "macos-latest", "windows-latest"]'
@@ -136,7 +136,7 @@ jobs:
 ```yaml
 jobs:
   compatibility:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@v1
     with:
       python-versions: '["3.11", "3.12", "3.13"]'
       skip-on-draft: false  # Always run matrix, even on drafts
@@ -215,7 +215,7 @@ on:
 
 jobs:
   mutation:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@v1
     with:
       source-directory: 'src'
       mutation-threshold: 80
@@ -234,7 +234,7 @@ on:
 
 jobs:
   mutation:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@v1
     with:
       mutation-threshold: 85
       fail-under-threshold: true  # Block release on low scores
@@ -249,7 +249,7 @@ on:
 
 jobs:
   mutation:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@v1
     # This will display performance warning in workflow summary
 ```
 
@@ -292,7 +292,7 @@ Recommendation: Run mutation testing on schedule (weekly/monthly) instead.
 ```yaml
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-version: '3.12'
 ```
@@ -302,7 +302,7 @@ jobs:
 ```yaml
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-version: '3.12'
       enable-matrix-testing: true  # Enable tiered testing
@@ -315,7 +315,7 @@ jobs:
 ```yaml
 jobs:
   compatibility:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@v1
 ```
 
 **After:**
@@ -323,7 +323,7 @@ jobs:
 ```yaml
 jobs:
   compatibility:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@v1
     with:
       skip-on-draft: true  # Add this to save costs
 ```
@@ -337,7 +337,7 @@ on: [pull_request, push]
 
 jobs:
   mutation:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@v1
 ```
 
 **After:**
@@ -349,7 +349,7 @@ on:
 
 jobs:
   mutation:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@v1
 ```
 
 ---

--- a/workflow-templates/python-compatibility.yml
+++ b/workflow-templates/python-compatibility.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   compatibility:
     name: Compatibility Matrix
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@v1
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       operating-systems: '["ubuntu-latest"]'

--- a/workflow-templates/python-container-security.yml
+++ b/workflow-templates/python-container-security.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   container-security:
     name: Container Security Scan
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-container-security.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-container-security.yml@v1
     with:
       dockerfile-path: './Dockerfile'
       build-image: true

--- a/workflow-templates/python-fips-compatibility.yml
+++ b/workflow-templates/python-fips-compatibility.yml
@@ -52,7 +52,7 @@ permissions:
 jobs:
   fips-check:
     name: FIPS Compliance Check
-    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@main
+    uses: ByronWilliamsCPA/.github/workflows/python-fips-compatibility.yml@v1
     with:
       strict-mode: ${{ github.event.inputs.strict_mode || false }}
       include-tests: true

--- a/workflow-templates/python-mutation.yml
+++ b/workflow-templates/python-mutation.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   mutation:
     name: Mutation Testing
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@v1
     with:
       source-directory: 'src'
       test-directory: 'tests'

--- a/workflow-templates/python-pr-validation.yml
+++ b/workflow-templates/python-pr-validation.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   pr-validation:
     name: PR Validation
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-pr-validation.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-pr-validation.yml@v1
     with:
       python-version: '3.12'
       source-directory: 'src'

--- a/workflow-templates/python-reuse.yml
+++ b/workflow-templates/python-reuse.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   reuse:
     name: REUSE Compliance Check
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-reuse.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-reuse.yml@v1
     with:
       generate-spdx: true
       fail-on-missing: true

--- a/workflow-templates/python-sbom.yml
+++ b/workflow-templates/python-sbom.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   sbom:
     name: SBOM Generation & Scan
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-sbom.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-sbom.yml@v1
     with:
       python-version: '3.12'
       fail-on-vulnerabilities: true

--- a/workflow-templates/python-scorecard.yml
+++ b/workflow-templates/python-scorecard.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   scorecard:
     name: Scorecard Analysis
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@v1
     with:
       publish-results: true
       upload-sarif: true

--- a/workflow-templates/python-slsa.yml
+++ b/workflow-templates/python-slsa.yml
@@ -70,7 +70,7 @@ jobs:
   provenance:
     name: Generate Provenance
     needs: build
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-slsa.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-slsa.yml@v1
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
       upload-assets: true


### PR DESCRIPTION
## Summary

Closes finding **P1-03** from `docs/audits/2026-05-01-security-audit.md`.

Every reusable workflow example documented `@main` as the pinning target. A push to this repo's `main` branch took effect in **every** consumer CI run instantly — no consumer-side review, no rollback. A single malicious or broken commit affected every org project simultaneously.

## Fix

### Bulk replacement (42 files)

`.yml@main` → `.yml@v1` across:

- User-facing docs: `README.md`, `USAGE_EXAMPLES.md`, `docs/workflows/*`, `docs/migration/*`
- Workflow header comments: 22 files in `.github/workflows/`
- Caller templates: 9 files in `workflow-templates/`

The replacement is intentionally narrow (`.yml@main`, not bare `@main`) so URLs (`blob/main/`, `tree/main/`, `raw.githubusercontent.com/.../main`) and explanatory prose stay untouched.

### New Version Pinning guidance

`USAGE_EXAMPLES.md` "Version Pinning" section rewritten to recommend three pinning options with a chooser table:

| Caller profile | Recommended pin |
| --- | --- |
| Standard production project | `@v1` (moving major) |
| Compliance-sensitive / regulated | `@v1.0.0` (immutable) or `@<sha>` |
| Maximum supply-chain hardening | `@<sha>` (full 40-char SHA, Renovate-managed) |
| Active workflow development on this repo | `@<feature-branch>` (temporary) |

Explicitly recommends against `@main` for production. The misleading prior advice ("Development: Use @main to get latest features") is removed.

`docs/workflows/README.md` development guidance also updated away from `@main`.

## Tag publication

This PR **does not push tags**. The `v1.0.0` (immutable) and `v1` (moving major) tags will be pushed by the maintainer after **all 8 audit fix PRs** land on main, so `v1` represents a fully-hardened state. Until then, any callers who already pin to `@v1` will fail with "ref not found" — but no current caller pins to `@v1` (they pin to `@main`).

The transition order is:

1. Land all 8 fix PRs on main (P2-05, P2-08, P2-10, P1-02, P1-05, P2-06, plus this PR and the audit reconciliation already merged)
2. Maintainer pushes `v1.0.0` and `v1` tags from main HEAD
3. Existing downstream callers continue working with `@main` (still valid ref); they migrate to `@v1` at their own pace using the new docs

## Test plan

- [x] No remaining `.yml@main` references in scope
- [x] All replacements use `@v1` (verified with grep post-edit)
- [x] Version Pinning section in USAGE_EXAMPLES.md is internally consistent (every example, every recommendation)
- [x] Audit status table: P1-03 → Fixed

## Notes

This is a docs-only PR. No workflow execution paths change. Existing callers using `@main` continue to work. The behaviour change is downstream: callers updating their workflows from these examples will pin to `@v1` instead of `@main`.

Generated with [Claude Code](https://claude.com/claude-code)