### PR TITLE
chore(audits): defer P2-06 egress-policy migration with documented plan

### DIFF
--- a/docs/audits/2026-05-01-security-audit.md
+++ b/docs/audits/2026-05-01-security-audit.md
@@ -36,7 +36,7 @@
 | P2-03 | HIGH | Closed | Current `python-publish-pypi.yml` step uses `pip-audit --strict` and `bandit -ll` with no `\|\| echo` swallow — both hard-fail on findings |
 | P2-04 | HIGH | Closed | PR #46 (`cbb86ee`) reduced workflow-level `permissions:` in `python-release.yml` to `contents: read`; per-job permissions scoped narrowly |
 | P2-05 | MEDIUM | Fixed | This PR — `python-release.yml` adds required `skip-tests-reason` input and validates it is non-empty when `run-tests: false`; release job fails fast on accidental bypass |
-| P2-06 | MEDIUM | Open | — |
+| P2-06 | MEDIUM | Deferred | This PR documents the migration plan. Per-workflow `allowed-endpoints` lists must be derived from real audit-mode CI logs before block-mode is safe to enable; no code change in this PR. See "Future Work — P2-06 Migration Plan" below |
 | P2-07 | MEDIUM | Closed | `python-supplemental-checks.yml` now uses label-based detection (`version-update:semver-{major,minor,patch}` and `semver:*` aliases), replacing the original PR-title regex |
 | P2-08 | MEDIUM | Open | — |
 | P2-09 | LOW | Closed | `python-pr-validation.yml` carries an explicit DEPRECATED header with full migration guide to `python-ci.yml`. Sunset date still TBD but recommendation satisfied |
@@ -316,3 +316,61 @@ The `detect-changes` job output (`security_files`) is computed but never referen
 | P4 | P1-04 · Dependabot unused ecosystems | Trivial |
 | P4 | P1-05 · Self-test CI workflow | Low |
 | P4 | P2-10 · CodeQL change-gating | Trivial |
+
+---
+
+## Future Work — P2-06 Migration Plan
+
+P2-06 (egress-policy `audit` → `block`) is **Deferred** rather than Fixed because correct implementation requires per-workflow `allowed-endpoints` lists that can only be derived safely from real CI traffic. Guessing the lists risks breaking workflow runs for every downstream consumer, which contradicts the audit's defence-in-depth goal.
+
+The migration sequence below describes the work required and the data inputs each step needs.
+
+### Step 1 — Harvest endpoint data from existing audit-mode runs
+
+`step-security/harden-runner` in `audit` mode logs every outbound network request to GitHub Step Summary and to the harden-runner dashboard (when configured). For each reusable workflow:
+
+1. Trigger a representative run (preferably from a downstream caller's repo to capture realistic traffic, not just the self-test path).
+2. Download the harden-runner outbound-traffic report from the run's summary.
+3. Record the unique `host:port` pairs observed.
+
+A minimum of 3–5 successful runs per workflow is recommended to capture cache-miss paths, transient endpoints (e.g., codecov uploader auto-update probes), and PR vs push divergence.
+
+### Step 2 — Categorise endpoints into baseline + per-workflow
+
+Build two tiers:
+
+- **Baseline** (every workflow): GitHub APIs, `raw.githubusercontent.com`, GHCR, harden-runner's own telemetry endpoint, runner-image package mirrors.
+- **Per-workflow add-ons**: PyPI + `files.pythonhosted.org` for `python-publish-pypi.yml`; `codecov.io` + `keybase.io` for `python-codecov.yml`; `sonarcloud.io` + binary download CDN for `python-sonarcloud.yml`; etc.
+
+Document the categorisation in `docs/security/egress-allowlist.md` (new file).
+
+### Step 3 — Migrate one workflow at a time
+
+For each workflow, in order from lowest-risk to highest-risk:
+
+1. Switch its `egress-policy: audit` to `egress-policy: block` and add the derived `allowed-endpoints:` list.
+2. Trigger a run. If it fails because of a missing endpoint, add the endpoint with a code comment recording the exact failure and link to the run that surfaced it.
+3. Repeat until the workflow runs cleanly. Lock in.
+
+Suggested order:
+
+1. `python-scorecard.yml` (only talks to github.com + ossf scorecard)
+2. `python-reuse.yml` (only github.com + reuse-tool's PyPI install)
+3. `python-ci.yml` (PyPI + github.com — well-trodden path)
+4. `python-security-analysis.yml` (PyPI + GitHub security APIs)
+5. `python-codecov.yml` (codecov.io added)
+6. `python-publish-pypi.yml` (PyPI write + Sigstore + OIDC)
+7. `python-release.yml` (largest endpoint set; do last)
+
+### Step 4 — Update workflow-templates and downstream guidance
+
+Once all reusable workflows are in block mode with documented allowed-endpoints, update the `workflow-templates/*.yml` patterns and add a "Network policy" section to USAGE_EXAMPLES.md so downstream callers understand the contract.
+
+### Effort estimate
+
+- Step 1 (harvest): ~30 min per workflow × ~22 workflows = ~10–11 hours
+- Step 2 (categorise): ~2–3 hours
+- Step 3 (migrate + test): ~30 min per workflow + iteration time = ~15–20 hours
+- Step 4 (docs): ~2 hours
+
+Total: roughly 30–40 hours of focused work. Best done as a dedicated initiative rather than slipping into normal feature work.


### PR DESCRIPTION
## Summary

Reclassifies finding **P2-06** (egress-policy `audit` → `block` across ~22 workflows) from **Open** to **Deferred** in `docs/audits/2026-05-01-security-audit.md`, and adds a four-step migration plan to the document.

## Why deferred and not fixed

Correct implementation requires per-workflow `allowed-endpoints` lists. Those lists can only be derived safely from observed CI traffic in audit mode — guessing them breaks workflow runs for every downstream consumer the moment a missing endpoint is hit. This contradicts the audit's defence-in-depth goal.

The audit-mode harden-runner setup already logs the data needed for this work; we simply do not have ad-hoc access to those logs from this session, and starting block-mode migration without them would create more incidents than it prevents.

## What this PR adds

A new "Future Work — P2-06 Migration Plan" section in the audit document describing:

1. **Harvest endpoint data** from existing audit-mode runs (per-workflow, 3-5 runs each)
2. **Categorise endpoints** into a shared baseline + per-workflow add-ons; record in a new `docs/security/egress-allowlist.md`
3. **Migrate one workflow at a time** in suggested order (lowest-risk first: scorecard → reuse → ci → security-analysis → codecov → publish-pypi → release)
4. **Update workflow-templates and downstream guidance** once all reusable workflows are in block mode

Effort estimate: ~30-40 hours of focused work, best handled as a dedicated initiative rather than slipped into normal feature work.

## What this PR does NOT change

- No workflow files modified
- No `egress-policy: audit` → `block` switches
- No new `allowed-endpoints:` declarations

The harden-runner audit-mode logs on every existing workflow continue to provide the data needed for the eventual migration.

## Status table change

| Finding | Old | New |
| --- | --- | --- |
| P2-06 | Open | **Deferred** with migration plan reference |

## Test plan

- [x] Audit doc edits limited to the P2-06 row + new "Future Work" section
- [x] No workflow files touched
- [x] Migration plan covers harvest → categorise → migrate → docs

Generated with [Claude Code](https://claude.com/claude-code)