### PR TITLE
fix(ci): read [tool.pip-audit].ignore-vuln from pyproject.toml

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -320,10 +320,17 @@ jobs:
           FAIL_ON_FINDINGS: ${{ inputs.fail-on-security-findings }}
         run: |
           echo "::group::pip-audit Dependency Scan"
+          # Read [tool.pip-audit].ignore-vuln from pyproject.toml if present.
+          # Each listed ID is passed as --ignore-vuln to pip-audit, paired with
+          # a dated entry in docs/known-vulnerabilities.md per project policy.
+          IGNORE_ARGS=""
+          if [ -f "pyproject.toml" ]; then
+            IGNORE_ARGS=$(python3 -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); ids=d.get('tool',{}).get('pip-audit',{}).get('ignore-vuln',[]); print(' '.join('--ignore-vuln '+i for i in ids))" 2>/dev/null || true)
+          fi
           if [ "$FAIL_ON_FINDINGS" = "true" ]; then
-            uv run pip-audit
+            uv run pip-audit $IGNORE_ARGS
           else
-            uv run pip-audit || echo "::warning::Vulnerable dependencies detected (fail-on-security-findings=false; not failing CI)"
+            uv run pip-audit $IGNORE_ARGS || echo "::warning::Vulnerable dependencies detected (fail-on-security-findings=false; not failing CI)"
           fi
           echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

- Adds support for reading `[tool.pip-audit].ignore-vuln` from `pyproject.toml` in the pip-audit step of `python-ci.yml`
- Each listed CVE ID is passed as `--ignore-vuln` to pip-audit at runtime
- Projects must pair each ignore entry with a dated entry in `docs/known-vulnerabilities.md` per CLAUDE.md policy

## Motivation

Transitive dependencies sometimes have CVEs with no available upstream fix (e.g., `py` PYSEC-2022-42969, unmaintained package). Without a per-project ignore mechanism, the security gate is either permanently failing or permanently disabled. This change allows targeted per-CVE allowlisting without turning off the gate entirely.

## Test plan

- [ ] Verify YAML is valid (check-yaml pre-commit hook passes)
- [ ] Python one-liner correctly parses the ignore list from pyproject.toml
- [ ] CI passes in downstream repo with `[tool.pip-audit]` configured

Generated with [Claude Code](https://claude.com/claude-code)