### PR TITLE
fix(scorecard): bump python-scorecard.yml to post-OIDC-fix SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,4 +26,4 @@ jobs:
       security-events: write
       contents: read
       actions: read
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@cd0f5c28e964cdf62b54173e681105782d0831a2  # main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@f05c26a424a708a73fc445a0ebb5b3ce476c1793  # main


### PR DESCRIPTION
## Summary

- Bumps `python-scorecard.yml` pin to `f05c26a424a708a73fc445a0ebb5b3ce476c1793` (the current clean HEAD of `ByronWilliamsCPA/.github`)
- This SHA hard-codes `publish_results: false` in the reusable workflow, preventing the OIDC token `repository` claim from targeting the `.github` host repo instead of the calling repo

## Root cause

When `python-scorecard.yml` runs as a reusable callee, the OIDC token's `repository` claim resolves to `ByronWilliamsCPA/.github` (where the workflow lives), not the calling repository. The old workflow passed `publish_results: ${{ inputs.publish-results }}` through to `ossf/scorecard-action`, which used that claim to publish to the wrong repo and error. Fixed in `ByronWilliamsCPA/.github` PR #80.

Generated with [Claude Code](https://claude.com/claude-code)