### PR TITLE
feat(ci): add SonarCloud analysis for shell scripts and workflow templates

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -203,8 +203,6 @@ jobs:
         env:
           SYSTEM_DEPS_UBUNTU: ${{ inputs.system-deps-ubuntu }}
         run: |
-          # shellcheck disable=SC1033,SC1050,SC1072,SC1073,SC1140
-          # Bracket-class regex [a-zA-Z0-9_\-\. ] confuses shellcheck's parser; bash syntax is valid.
           PKGS="$SYSTEM_DEPS_UBUNTU"
           pkg_pattern='^[a-zA-Z0-9_. -]+$'
           if [[ "$PKGS" =~ $pkg_pattern ]]; then
@@ -222,8 +220,6 @@ jobs:
         env:
           SYSTEM_DEPS_MACOS: ${{ inputs.system-deps-macos }}
         run: |
-          # shellcheck disable=SC1033,SC1050,SC1072,SC1073,SC1140
-          # Bracket-class regex [a-zA-Z0-9_\-\. ] confuses shellcheck's parser; bash syntax is valid.
           PKGS="$SYSTEM_DEPS_MACOS"
           pkg_pattern='^[a-zA-Z0-9_. -]+$'
           if [[ "$PKGS" =~ $pkg_pattern ]]; then

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -203,6 +203,8 @@ jobs:
         env:
           SYSTEM_DEPS_UBUNTU: ${{ inputs.system-deps-ubuntu }}
         run: |
+          # shellcheck disable=SC1033,SC1050,SC1072,SC1073,SC1140
+          # Bracket-class regex [a-zA-Z0-9_\-\. ] confuses shellcheck's parser; bash syntax is valid.
           PKGS="$SYSTEM_DEPS_UBUNTU"
           pkg_pattern='^[a-zA-Z0-9_. -]+$'
           if [[ "$PKGS" =~ $pkg_pattern ]]; then
@@ -220,6 +222,8 @@ jobs:
         env:
           SYSTEM_DEPS_MACOS: ${{ inputs.system-deps-macos }}
         run: |
+          # shellcheck disable=SC1033,SC1050,SC1072,SC1073,SC1140
+          # Bracket-class regex [a-zA-Z0-9_\-\. ] confuses shellcheck's parser; bash syntax is valid.
           PKGS="$SYSTEM_DEPS_MACOS"
           pkg_pattern='^[a-zA-Z0-9_. -]+$'
           if [[ "$PKGS" =~ $pkg_pattern ]]; then

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,9 +3,6 @@
 # Analyzes shell scripts, YAML workflow templates, and configuration files.
 # SonarCloud auto-detects languages; no Python configuration required.
 #
-# Prerequisites:
-#   - Project registered at https://sonarcloud.io (see sonar-project.properties)
-#   - SONAR_TOKEN secret configured in repository settings
 name: SonarCloud Analysis
 
 on:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,48 @@
+# SonarCloud Analysis for ByronWilliamsCPA/.github
+#
+# Analyzes shell scripts, YAML workflow templates, and configuration files.
+# SonarCloud auto-detects languages; no Python configuration required.
+#
+# Prerequisites:
+#   - Project registered at https://sonarcloud.io (see sonar-project.properties)
+#   - SONAR_TOKEN secret configured in repository settings
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: sonarcloud-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432  # v8.0.0  # nosemgrep: detected-sonarqube-docs-api-key
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+# SonarCloud Project Configuration for ByronWilliamsCPA/.github
+#
+# SETUP REQUIRED before running:
+#   1. Visit https://sonarcloud.io and sign in with GitHub
+#   2. Import ByronWilliamsCPA/.github as a new project
+#   3. Generate a token at https://sonarcloud.io/account/security
+#   4. Add SONAR_TOKEN to repo secrets (Settings > Secrets > Actions)
+
+sonar.projectKey=ByronWilliamsCPA_.github
+sonar.organization=byronwilliamscpa
+
+sonar.projectName=GitHub Organization Shared Workflows
+
+# Scan workflow templates, shell scripts, and configuration
+sonar.sources=.
+
+# Exclude documentation, generated files, and dependencies
+sonar.exclusions=docs/**,examples/**,**/*.md,LICENSES/**,checksums.txt,**/*.txt,profile/**
+
+# Source encoding
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,4 @@
 # SonarCloud Project Configuration for ByronWilliamsCPA/.github
-#
-# SETUP REQUIRED before running:
-#   1. Visit https://sonarcloud.io and sign in with GitHub
-#   2. Import ByronWilliamsCPA/.github as a new project
-#   3. Generate a token at https://sonarcloud.io/account/security
-#   4. Add SONAR_TOKEN to repo secrets (Settings > Secrets > Actions)
 
 sonar.projectKey=ByronWilliamsCPA_.github
 sonar.organization=byronwilliamscpa


### PR DESCRIPTION
## Summary

- Adds `sonar-project.properties` with project key `ByronWilliamsCPA_.github`
- Adds `.github/workflows/sonarcloud.yml` that runs on push to main and pull requests
- Uses `sonarqube-scan-action@v8.0.0` (consistent with other callers in this repo)
- `sonar.sources=.` scans shell scripts, YAML workflow templates, and configuration files; SonarCloud auto-detects languages

## Why

Both `ByronWilliamsCPA/.claude` and `ByronWilliamsCPA/.github` are org-level control-plane repos that should have SonarCloud coverage. The project is already registered at sonarcloud.io and `SONAR_TOKEN` is available as an org-level secret.

## Test plan

- [x] `pre-commit run` passes on both new files
- [x] Project `ByronWilliamsCPA_.github` registered at sonarcloud.io
- [x] `SONAR_TOKEN` available as org-level secret

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated code quality scanning via SonarCloud for continuous analysis on pushes and pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/.github/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->