### PR TITLE
fix(ci): remove include-scope from dependabot commit-message config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
       - "ByronWilliamsCPA"
     commit-message:
       prefix: "ci(actions):"
-      include: "scope"
     pull-request-branch-name:
       separator: "/"
     allow:


### PR DESCRIPTION
## Summary

- Removes `include: "scope"` from `.github/dependabot.yml` so dependabot generates PR titles in the format `ci(actions): bump X` instead of `ci(actions):(deps): bump X`
- The double-scope format was failing the conventional commit regex in `pr-validation.yml` (which expects a single `(\([^()]+\))?` group)
- Also applies pre-commit trailing-whitespace and EOF-newline fixes to several files that were previously uncleaned

## Root Cause

`commit-message.include: "scope"` instructs dependabot to append its own auto-detected scope as a second parenthesized group. Combined with the `ci(actions):` prefix, this produced `ci(actions):(deps):` -- two scope groups -- which the regex `^(feat|fix|...|ci)(\([^()]+\))?!?: .+` cannot match.

## Test plan

- [ ] PR title format check passes on this PR
- [ ] Verify next dependabot PR title uses `ci(actions): bump X` format (no `(deps)`)
- [ ] Existing failing PRs #82, #83, #84, #85 resolved separately by title rename in Phase 3

Generated with [Claude Code](https://claude.com/claude-code)