### PR TITLE
fix(ci): add tracking reference to nosemgrep suppression in sonarcloud.yml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432  # v8.0.0  # nosemgrep: detected-sonarqube-docs-api-key
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432  # v8.0.0  # nosemgrep: detected-sonarqube-docs-api-key  # FP -- see #37
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `# FP -- see #37` to the `detected-sonarqube-docs-api-key` nosemgrep suppression on `sonarcloud.yml:41`
- This is the only remaining gap identified in #37; `python-sonarcloud.yml` already had the tracking reference on both affected lines

## Why

CLAUDE.md requires all suppressions to cite a tracking issue. The suppression is a confirmed false positive: the matched value is a SHA-pinned `uses:` line, not a SonarQube API key.

Closes #37

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality scanning configuration to address scanning accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/.github/pull/95)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->