### PR TITLE
feat(compliance): add foundation docs and CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,7 +32,7 @@ See: [docs/response-aware-development.md](https://github.com/ByronWilliamsCPA/.g
 ## Writing Rules
 
 Never use em-dashes in any output (documentation, YAML run steps, commit messages).
-Replace with comma, semicolon, or colon.
+The `no-em-dash` pre-commit hook enforces this. Replace with comma, semicolon, or colon.
 
 ## Git Workflow
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,47 @@
+# .github Repository -- Claude Code Instructions
+
+> Scope: this file applies when Claude Code is working in the ByronWilliamsCPA/.github repo.
+
+## Repository Purpose
+
+This is the GitHub org-level community health file repo and reusable workflow library
+for ByronWilliamsCPA. It contains:
+
+- Community health files (SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, etc.)
+- Reusable GitHub Actions workflows (`.github/workflows/python-*.yml`)
+- Org-level profile (`profile/README.md`)
+
+There is no Python package, no test suite, and no build system in this repo.
+
+## Model Selection
+
+| Task | Model |
+|------|-------|
+| Workflow YAML editing, doc fixes | Sonnet 4.6 (default) |
+| Architecture decisions, ADRs | Opus 4.7 |
+| File scanning, grep, read-only | Haiku 4.5 |
+
+## Response-Aware Development (RAD)
+
+Tag assumptions with `#CRITICAL`, `#ASSUME`, `#EDGE`, and `#VERIFY` in comments
+when editing workflow YAML. Mandatory for: permission scopes, secret references,
+OIDC token behavior, and reusable workflow caller/callee permission inheritance.
+
+See: [docs/response-aware-development.md](https://github.com/ByronWilliamsCPA/.github/blob/main/docs/response-aware-development.md)
+
+## Writing Rules
+
+Never use em-dashes in any output (documentation, YAML run steps, commit messages).
+Replace with comma, semicolon, or colon.
+
+## Git Workflow
+
+Branch naming: `claude/<description>-<id>` (e.g., `claude/compliance-quick-wins-0`).
+Always run `pre-commit run --all-files` before committing.
+Create worktrees at `.worktrees/<branch-slug>`.
+
+## Cross-References
+
+- Agents: [AGENTS.md](../AGENTS.md)
+- Known vulnerabilities: [docs/known-vulnerabilities.md](../docs/known-vulnerabilities.md)
+- Architecture decisions: [docs/architecture/adr-000-index.md](../docs/architecture/adr-000-index.md)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,7 +27,7 @@ Tag assumptions with `#CRITICAL`, `#ASSUME`, `#EDGE`, and `#VERIFY` in comments
 when editing workflow YAML. Mandatory for: permission scopes, secret references,
 OIDC token behavior, and reusable workflow caller/callee permission inheritance.
 
-See: [docs/response-aware-development.md](https://github.com/ByronWilliamsCPA/.github/blob/main/docs/response-aware-development.md)
+See the global `~/.claude/CLAUDE.md` for full RAD tagging syntax and examples.
 
 ## Writing Rules
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,16 @@
   "permissions": {
     "allow": [
       "Bash(git:*)",
-      "Bash(gh:*)",
+      "Bash(gh pr *)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue list*)",
+      "Bash(gh run view*)",
+      "Bash(gh run list*)",
+      "Bash(gh api repos/*/*)",
       "Bash(pre-commit:*)",
       "Bash(yamllint:*)",
-      "Bash(python3:*)",
+      "Bash(python3 -m*)",
+      "Bash(python3 *.py*)",
       "Bash(grep:*)",
       "Bash(find:*)",
       "Bash(ls:*)",
@@ -14,9 +20,22 @@
       "Edit(*)"
     ],
     "deny": [
-      "Bash(rm -rf *)",
+      "Bash(gh secret*)",
+      "Bash(gh auth*)",
+      "Bash(gh org*)",
+      "Bash(gh workflow run*)",
+      "Bash(gh repo delete*)",
+      "Bash(gh repo transfer*)",
+      "Bash(gh repo rename*)",
+      "Bash(gh release create*)",
+      "Bash(gh release delete*)",
+      "Bash(gh api -X DELETE*)",
+      "Bash(gh api --method DELETE*)",
+      "Bash(gh api -X PATCH*)",
+      "Bash(gh api --method PATCH*)",
       "Bash(git push --force*)",
-      "Bash(git reset --hard*)"
+      "Bash(git reset --hard*)",
+      "Bash(rm -rf*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(pre-commit:*)",
+      "Bash(yamllint:*)",
+      "Bash(python3:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Read(*)",
+      "Write(*)",
+      "Edit(*)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,10 @@ tmp/
 tmp_cleanup/
 actionlint
 
-# AI assistant state (ephemeral session content ignored; intentional config files are explicitly unignored below)
-.claude/
-!.claude/CLAUDE.md
-!.claude/settings.json
+# AI assistant state (track CLAUDE.md and settings.json; ignore only transient cache subdirs)
+.claude/cache/
+.claude/session/
+.claude/conversations/
 
 # Git worktrees
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,11 @@ actionlint
 .claude/cache/
 .claude/session/
 .claude/conversations/
+.claude/memories/
+.claude/logs/
+.claude/todos/
+.claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Git worktrees
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,10 @@ tmp/
 tmp_cleanup/
 actionlint
 
-# AI assistant state
+# AI assistant state (ephemeral session content ignored; intentional config files are explicitly unignored below)
 .claude/
+!.claude/CLAUDE.md
+!.claude/settings.json
 
 # Git worktrees
 .worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Catalog
+
+Subagents available for work in this repository.
+
+## Specialized Agents
+
+| Agent | Purpose | When to use |
+|-------|---------|-------------|
+| `devops-deployment-agent` | CI/CD audit and remediation | Workflow YAML changes, CI check failures |
+| `repo-foundations-auditor` | Foundation file compliance | FOUND-* check remediation |
+| `pre-commit-auditor` | Pre-commit hook compliance | PC-* check remediation |
+| `claude-docs-auditor` | CLAUDE.md and settings compliance | CLAUDE-* check remediation |
+| `ossf-compliance-auditor` | OpenSSF Scorecard and badge | OSSF-* check remediation |
+| `general-compliance-auditor` | Freeform gap analysis | G-* general findings |
+| `writing-style-editor` | Em-dash and AI pattern detection | Doc quality, CLAUDE-007 |
+
+## Model Assignment
+
+| Agent type | Model |
+|-----------|-------|
+| Read-only exploration (`Explore`) | Haiku 4.5 |
+| Planning (`Plan`) | Inherit from caller |
+| All others | Sonnet 4.6 (default) |
+| Deep reasoning tasks | Opus 4.7 (specify in prompt) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ are no numbered releases.
 - Prose cleanup across 18 documentation files to remove AI-pattern language and improve plain-language clarity
 - `python-scorecard.yml`: add `Warn on deprecated publish-results input` step that emits a `::warning::` annotation when a caller passes `publish-results: true`; surfaces the deprecation in CI logs so callers know to remove the now-ignored input
 - `.github/workflows/pr-validation.yml`: add `Dependency & Standards Validation` job to satisfy the required branch protection check context that no workflow in this repo was previously reporting; gates on the same title-check and body-check results as `PR Validation Gate`
+- `.claude/CLAUDE.md`: project-scoped Claude Code instructions with Model Selection table, RAD tagging rules, no-em-dash writing rule, and git workflow conventions (CLAUDE-001 through CLAUDE-006)
+- `.claude/settings.json`: explicit allow/deny permission block scoping Claude Code operations to safe repo commands (CLAUDE-002)
+- `AGENTS.md`: agent catalog and model assignment table for subagents operating in this repo (CLAUDE-003)
+- `GEMINI.md`: Gemini CLI context stub with repo summary, writing rules, and branch naming convention (CLAUDE-004)
+- `docs/known-vulnerabilities.md`: empty CVE baseline satisfying the OpenSSF FOUND-007 foundation check; no known vulnerabilities as of 2026-05-14
+- `docs/architecture/adr-000-index.md`, `docs/architecture/adr-001-scorecard-publish-results.md`: ADR infrastructure and first decision record documenting the `publish-results: false` constraint in the reusable scorecard workflow and the plan for a direct `self-scorecard` job (FOUND-008)
+- `.gitignore`: narrow `.claude/` exclusion from directory-level to specific transient subdirs so `.claude/CLAUDE.md` and `.claude/settings.json` are tracked by git
 
 ### Fixed
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,19 @@
+# Gemini CLI Instructions -- ByronWilliamsCPA/.github
+
+## Repository Context
+
+This repo contains GitHub org-level community health files and reusable GitHub Actions
+workflows. There is no Python package or test suite.
+
+## Tool Mapping
+
+Gemini CLI tool names differ from Claude Code. See tool mapping in:
+`~/.claude/skills/brainstorming/references/` for equivalents.
+
+## Writing Rules
+
+Never use em-dashes in any output. Replace with comma, semicolon, or colon.
+
+## Branch Naming
+
+`claude/<description>-<id>` for all Claude/Gemini branches.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,8 +7,8 @@ workflows. There is no Python package or test suite.
 
 ## Tool Mapping
 
-Gemini CLI tool names differ from Claude Code. See tool mapping in:
-`~/.claude/skills/brainstorming/references/` for equivalents.
+Gemini CLI uses its own built-in tools (Read, Write, Edit, Bash, etc.). Consult
+the Gemini CLI documentation for tool names; they differ from Claude Code equivalents.
 
 ## Writing Rules
 

--- a/docs/architecture/adr-000-index.md
+++ b/docs/architecture/adr-000-index.md
@@ -2,9 +2,9 @@
 
 Index of ADRs for the ByronWilliamsCPA/.github reusable workflow library.
 
-| ADR | Title | Status | Date |
-|-----|-------|--------|------|
-| [ADR-001](adr-001-scorecard-publish-results.md) | Scorecard publish_results: false in reusable workflow | Accepted | 2026-05-14 |
+| ADR                                             | Title                                                              | Status   | Date       |
+|-------------------------------------------------|--------------------------------------------------------------------|----------|------------|
+| [ADR-001](adr-001-scorecard-publish-results.md) | Scorecard publish-results deprecated; action param hardcoded false | Proposed | 2026-05-14 |
 
 ## ADR Format
 

--- a/docs/architecture/adr-000-index.md
+++ b/docs/architecture/adr-000-index.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+Index of ADRs for the ByronWilliamsCPA/.github reusable workflow library.
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-001](adr-001-scorecard-publish-results.md) | Scorecard publish_results: false in reusable workflow | Accepted | 2026-05-14 |
+
+## ADR Format
+
+Each ADR covers: Context, Decision, Consequences.
+Use status: Proposed / Accepted / Deprecated / Superseded.

--- a/docs/architecture/adr-001-scorecard-publish-results.md
+++ b/docs/architecture/adr-001-scorecard-publish-results.md
@@ -1,18 +1,17 @@
 # ADR-001: Scorecard publish_results: false in Reusable Workflow
 
-**Status:** Accepted
+**Status:** Proposed
 **Date:** 2026-05-14
 
 ## Context
 
 The `python-scorecard.yml` reusable workflow hard-codes `publish_results: false`.
 When a reusable workflow calls `ossf/scorecard-action`, the OIDC token `repository`
-claim resolves to the calling repo (e.g., `ByronWilliamsCPA/some-python-project`),
-which is correct. However, Scorecard's API lookup uses this claim to attribute results.
-When the reusable workflow itself is tested in the `.github` repo via `self-test.yml`,
-the OIDC token resolves to `ByronWilliamsCPA/.github`, which does match the repo we
-want to score. The constraint is `publish_results: true` in the reusable workflow would
-expose results for every calling repo under a single API entry.
+claim resolves to the `.github` repo (where the workflow file lives), not the calling
+repository. The scorecard-action uses that claim to publish results to
+securityscorecards.dev. With the wrong repo claim, publication fails and the job
+errors. The reusable workflow keeps `publish_results: false` to prevent this; SARIF
+upload to the calling repo's Security tab continues to work correctly.
 
 ## Decision
 
@@ -21,6 +20,8 @@ Add a direct, non-reusable `self-scorecard` job to `scorecard.yml` in this repo
 that uses `publish_results: true`. This job runs the scorecard action directly
 (not via the reusable), so the OIDC token `repository` claim correctly resolves to
 `ByronWilliamsCPA/.github`.
+
+**Implementation deferred to Task 5 (OSSF/Scorecard PR).**
 
 ## Consequences
 

--- a/docs/architecture/adr-001-scorecard-publish-results.md
+++ b/docs/architecture/adr-001-scorecard-publish-results.md
@@ -1,4 +1,4 @@
-# ADR-001: Scorecard publish_results: false in Reusable Workflow
+# ADR-001: Scorecard publish-results Deprecated; publish_results Hardcoded False
 
 **Status:** Proposed
 **Date:** 2026-05-14
@@ -27,5 +27,5 @@ that uses `publish_results: true`. This job runs the scorecard action directly
 
 - Downstream repos using `python-scorecard.yml` do not publish results (by design;
   they opt in by adding their own scorecard workflow).
-- The `.github` repo itself publishes results via the direct job.
+- The `.github` repo itself will publish results via the direct job (pending Task 5).
 - The reusable workflow remains unchanged for callers.

--- a/docs/architecture/adr-001-scorecard-publish-results.md
+++ b/docs/architecture/adr-001-scorecard-publish-results.md
@@ -1,0 +1,30 @@
+# ADR-001: Scorecard publish_results: false in Reusable Workflow
+
+**Status:** Accepted
+**Date:** 2026-05-14
+
+## Context
+
+The `python-scorecard.yml` reusable workflow hard-codes `publish_results: false`.
+When a reusable workflow calls `ossf/scorecard-action`, the OIDC token `repository`
+claim resolves to the calling repo (e.g., `ByronWilliamsCPA/some-python-project`),
+which is correct. However, Scorecard's API lookup uses this claim to attribute results.
+When the reusable workflow itself is tested in the `.github` repo via `self-test.yml`,
+the OIDC token resolves to `ByronWilliamsCPA/.github`, which does match the repo we
+want to score. The constraint is `publish_results: true` in the reusable workflow would
+expose results for every calling repo under a single API entry.
+
+## Decision
+
+Keep `publish_results: false` in `python-scorecard.yml` (the reusable workflow).
+Add a direct, non-reusable `self-scorecard` job to `scorecard.yml` in this repo
+that uses `publish_results: true`. This job runs the scorecard action directly
+(not via the reusable), so the OIDC token `repository` claim correctly resolves to
+`ByronWilliamsCPA/.github`.
+
+## Consequences
+
+- Downstream repos using `python-scorecard.yml` do not publish results (by design;
+  they opt in by adding their own scorecard workflow).
+- The `.github` repo itself publishes results via the direct job.
+- The reusable workflow remains unchanged for callers.

--- a/docs/known-vulnerabilities.md
+++ b/docs/known-vulnerabilities.md
@@ -1,0 +1,19 @@
+# Known Vulnerabilities
+
+Tracked unresolved CVEs per the OpenSSF release gate policy.
+No entry ages past 60 days without reassessment.
+Review quarterly or when `pip-audit` / `trivy` surface new findings.
+
+**Note:** This repo has no Python package and no container images. This file exists
+to satisfy the FOUND-007 foundation check and will contain entries if transitive
+dependencies are flagged by the workflow toolchain.
+
+| CVE | Package | Severity | Introduced | Reassess By | Status | Notes |
+|-----|---------|----------|-----------|-------------|--------|-------|
+| -- | -- | -- | -- | -- | -- | No known vulnerabilities as of 2026-05-14 |
+
+## Template
+
+```
+| CVE-YYYY-NNNNN | package-name | Critical/High/Medium/Low | YYYY-MM-DD | YYYY-MM-DD | Open/Monitoring | Link to upstream issue or fix ETA |
+```


### PR DESCRIPTION
## Summary

- Creates `.claude/CLAUDE.md` with Model Selection section, RAD cross-reference, and writing rules (CLAUDE-001 through CLAUDE-006)
- Creates `.claude/settings.json` with explicit allow/deny permission blocks (CLAUDE-002)
- Creates `AGENTS.md` with agent catalog and model assignment table (CLAUDE-003)
- Creates `GEMINI.md` with repo context stub (CLAUDE-004)
- Creates `docs/known-vulnerabilities.md` with empty baseline (FOUND-007)
- Creates `docs/architecture/` with ADR index and ADR-001 documenting the scorecard publish_results decision (FOUND-008)

## Test plan

- [ ] `grep -c "Model Selection" .claude/CLAUDE.md` returns 1
- [ ] `grep -c "response-aware-development" .claude/CLAUDE.md` returns 1
- [ ] `python3 -c "import json; json.load(open('.claude/settings.json'))"` exits 0
- [ ] `ls AGENTS.md GEMINI.md docs/known-vulnerabilities.md docs/architecture/adr-000-index.md` all succeed

Generated with [Claude Code](https://claude.com/claude-code)