### PR TITLE
feat(ossf): add self-scorecard job with publish_results: true

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+# Codecov configuration for ByronWilliamsCPA/.github
+# This repo has no Python package; coverage data is uploaded by downstream callers
+# of python-codecov.yml.
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 90%
+        threshold: 2%
+
+comment:
+  layout: reach,diff,flags,files
+  behavior: default
+  require_changes: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,7 @@
-# OpenSSF Scorecard for Claude Code Configuration
+# OpenSSF Scorecard for ByronWilliamsCPA/.github
 # Delegates to the org-level reusable Scorecard workflow.
 #
-# Dashboard: https://securityscorecards.dev/viewer/?uri=github.com/ByronWilliamsCPA/.claude
+# Dashboard: https://securityscorecards.dev/viewer/?uri=github.com/ByronWilliamsCPA/.github
 # Documentation: https://github.com/ossf/scorecard
 name: OpenSSF Scorecard
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,3 +26,41 @@ jobs:
       contents: read
       actions: read
     uses: ByronWilliamsCPA/.github/.github/workflows/python-scorecard.yml@e5d5926a5add719155ff8dc151c85413cd501a86  # main
+
+  self-scorecard:
+    name: OpenSSF Scorecard (this repo)
+    runs-on: ubuntu-latest
+    # #ASSUME: This job runs in the context of ByronWilliamsCPA/.github directly.
+    # The OIDC token repository claim resolves to ByronWilliamsCPA/.github, which
+    # is the correct value for publish_results: true. See docs/architecture/adr-001.
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99  # v2.19.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          publish_results: true
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,9 @@ jobs:
     # #ASSUME: This job runs in the context of ByronWilliamsCPA/.github directly.
     # The OIDC token repository claim resolves to ByronWilliamsCPA/.github, which
     # is the correct value for publish_results: true. See docs/architecture/adr-001.
+    # #VERIFY: After first successful run, confirm the "Run Scorecard analysis" step
+    # log shows repository=ByronWilliamsCPA/.github in the OIDC token claims, and
+    # that results appear at securityscorecards.dev/viewer/?uri=github.com/ByronWilliamsCPA/.github
     timeout-minutes: 15
     permissions:
       security-events: write
@@ -40,6 +43,15 @@ jobs:
       contents: read
       actions: read
     steps:
+      - name: Verify SCORECARD_TOKEN is set
+        env:
+          TOKEN_SET: ${{ secrets.SCORECARD_TOKEN != '' }}
+        run: |
+          if [ "$TOKEN_SET" != "true" ]; then
+            echo "::error::SCORECARD_TOKEN secret is not set. publish_results: true requires this token."
+            exit 1
+          fi
+
       - name: Harden runner
         uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99  # v2.19.2
         with:
@@ -64,3 +76,10 @@ jobs:
         with:
           sarif_file: results.sarif
           category: scorecard
+
+      - name: Scorecard summary
+        if: always()
+        run: |
+          echo "## OpenSSF Scorecard (this repo)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Dashboard: https://securityscorecards.dev/viewer/?uri=github.com/ByronWilliamsCPA/.github" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ are no numbered releases.
 - `.markdownlint.yml`: markdownlint config disabling 14 rules with pre-existing violations; MD060 (table-column-style) suppresses violations across USAGE_EXAMPLES.md, AGENTS.md, and docs/workflows/
 - `scripts/check-no-em-dash.sh`: byte-sequence grep hook that blocks em-dash (U+2014) characters in staged text files; uses `language: script` with `types: [text]` to skip binary files
 - `.secrets.baseline`: detect-secrets baseline with 5 SHA-pin false positives in `.pre-commit-config.yaml`
+- `scorecard.yml`: add `self-scorecard` direct job with `publish_results: true` and `id-token: write`; runs `ossf/scorecard-action` without the reusable wrapper so the OIDC token `repository` claim resolves to `ByronWilliamsCPA/.github` (see ADR-001); includes SCORECARD_TOKEN guard, harden-runner, and job summary step
+- `.codecov.yml`: Codecov configuration for `ByronWilliamsCPA/.github` with 80% project and 90% patch coverage targets
 
 ### Changed
 

--- a/docs/architecture/adr-001-scorecard-publish-results.md
+++ b/docs/architecture/adr-001-scorecard-publish-results.md
@@ -1,6 +1,6 @@
 # ADR-001: Scorecard publish-results Deprecated; publish_results Hardcoded False
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-14
 
 ## Context
@@ -21,11 +21,9 @@ that uses `publish_results: true`. This job runs the scorecard action directly
 (not via the reusable), so the OIDC token `repository` claim correctly resolves to
 `ByronWilliamsCPA/.github`.
 
-**Implementation deferred to Task 5 (OSSF/Scorecard PR).**
-
 ## Consequences
 
 - Downstream repos using `python-scorecard.yml` do not publish results (by design;
   they opt in by adding their own scorecard workflow).
-- The `.github` repo itself will publish results via the direct job (pending Task 5).
+- The `.github` repo itself publishes results via the direct `self-scorecard` job in `scorecard.yml`.
 - The reusable workflow remains unchanged for callers.


### PR DESCRIPTION
## Summary

- Adds \`self-scorecard\` job to \`scorecard.yml\` that uses \`ossf/scorecard-action\` directly
  (not via the reusable \`python-scorecard.yml\`) so \`publish_results: true\` works correctly.
  The OIDC token \`repository\` claim resolves to \`ByronWilliamsCPA/.github\` in this context.
  See \`docs/architecture/adr-001-scorecard-publish-results.md\` for full rationale (OSSF-007).
- Creates \`.codecov.yml\` with 80% project and 90% patch coverage targets (OSSF-002).
- OSSF-006 (token permissions on \`security-analysis.yml\`): already satisfied by
  the explicit job-level grants from the CI-033 compliance work in PR #101. Changing
  \`permissions: {}\` to \`read-all\` would violate CI-033; the current setup is more
  restrictive and meets OSSF-006's intent.

**Depends on:** #101 (CI hardening) -- merged 2026-05-15.

## Review fixes (post-review commit a92e190)

- Added \`#VERIFY\` instruction paired with \`#ASSUME\` tag in \`scorecard.yml\` (RAD compliance)
- Added SCORECARD_TOKEN guard step that fails fast when the secret is absent
- Added \`if: always()\` summary step with dashboard URL
- Updated ADR-001 status from Proposed to Accepted
- Added CHANGELOG entries for self-scorecard job and \`.codecov.yml\`

## Test plan

- [ ] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"\` exits 0
- [ ] \`grep "publish_results: true" .github/workflows/scorecard.yml\` returns the self-scorecard job line
- [ ] \`python3 -c "import yaml; yaml.safe_load(open('.codecov.yml'))"\` exits 0
- [ ] All action refs in self-scorecard job are 40-char hex SHA-pinned
- [ ] After merge: verify Scorecard results appear in the Security tab under Code Scanning
- [ ] After merge: verify results appear at securityscorecards.dev/viewer/?uri=github.com/ByronWilliamsCPA/.github

Generated with [Claude Code](https://claude.com/claude-code)