### PR TITLE
docs(workflows): add documentation for 9 reusable workflows (G007)

### DIFF
--- a/docs/workflows/python-codecov.md
+++ b/docs/workflows/python-codecov.md
@@ -13,6 +13,9 @@ as a separate job after the main CI job uploads a coverage artifact.
 | `flags` | string | no | | Codecov flags (comma-separated) |
 | `name` | string | no | `coverage` | Name for the coverage upload |
 | `fail-ci-if-error` | boolean | no | `false` | Fail the workflow if Codecov upload fails |
+| `verbose` | boolean | no | `false` | Enable verbose output |
+| `workflow-run-id` | string | no | | Workflow run ID to download artifacts from (for `workflow_run` trigger) |
+| `commit-sha` | string | no | | Commit SHA override for `workflow_run` trigger; associates upload with the triggering commit |
 
 ## Secrets
 

--- a/docs/workflows/python-codecov.md
+++ b/docs/workflows/python-codecov.md
@@ -1,0 +1,31 @@
+# python-codecov.yml -- Coverage Upload
+
+Uploads pytest coverage data to Codecov after a test run. Designed to run
+as a separate job after the main CI job uploads a coverage artifact.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `artifact-name` | string | no | `coverage-reports` | Name of the artifact containing coverage reports |
+| `coverage-files` | string | no | `coverage*.xml` | Glob pattern for coverage XML files within artifact |
+| `junit-files` | string | no | `junit-*.xml` | Glob pattern for JUnit XML files for Test Analytics |
+| `flags` | string | no | | Codecov flags (comma-separated) |
+| `name` | string | no | `coverage` | Name for the coverage upload |
+| `fail-ci-if-error` | boolean | no | `false` | Fail the workflow if Codecov upload fails |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `CODECOV_TOKEN` | yes | Codecov upload token from codecov.io |
+
+## Usage
+
+```yaml
+jobs:
+  upload-coverage:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-codecov.yml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+```

--- a/docs/workflows/python-compatibility.md
+++ b/docs/workflows/python-compatibility.md
@@ -1,0 +1,28 @@
+# python-compatibility.yml -- Multi-Version Compatibility Matrix
+
+Runs the test suite across a matrix of Python versions and operating systems
+to verify compatibility. Draft PRs skip the full matrix by default (reducing
+cost by 92%); the full matrix runs on ready PRs.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `python-versions` | string | no | `["3.10","3.11","3.12","3.13"]` | JSON array of Python versions to test |
+| `operating-systems` | string | no | `["ubuntu-latest"]` | JSON array of operating systems |
+| `include-windows` | boolean | no | `false` | Include Windows in the matrix |
+| `include-macos` | boolean | no | `false` | Include macOS in the matrix |
+| `source-directory` | string | no | `src` | Source code directory |
+| `test-command` | string | no | `pytest -v` | Test command (run with `uv run` prefix) |
+| `skip-on-draft` | boolean | no | `true` | Skip expensive matrix on draft PRs |
+| `fail-fast` | boolean | no | `false` | Fail immediately on first matrix failure |
+
+## Usage
+
+```yaml
+jobs:
+  compatibility:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-compatibility.yml@main
+    with:
+      python-versions: '["3.11","3.12","3.13"]'
+```

--- a/docs/workflows/python-compatibility.md
+++ b/docs/workflows/python-compatibility.md
@@ -14,8 +14,10 @@ cost by 92%); the full matrix runs on ready PRs.
 | `include-macos` | boolean | no | `false` | Include macOS in the matrix |
 | `source-directory` | string | no | `src` | Source code directory |
 | `test-command` | string | no | `pytest -v` | Test command (run with `uv run` prefix) |
-| `skip-on-draft` | boolean | no | `true` | Skip expensive matrix on draft PRs |
+| `coverage-report` | boolean | no | `true` | Generate coverage reports |
 | `fail-fast` | boolean | no | `false` | Fail immediately on first matrix failure |
+| `skip-on-draft` | boolean | no | `true` | Skip expensive matrix on draft PRs |
+| `timeout-minutes` | number | no | `30` | Timeout for each matrix job |
 
 ## Usage
 

--- a/docs/workflows/python-container-security.md
+++ b/docs/workflows/python-container-security.md
@@ -11,10 +11,16 @@ for Dockerfile linting and optionally generates a container SBOM.
 | `image-ref` | string | no | | Container image reference to scan (e.g., `ghcr.io/org/repo:sha`). Omit to build from Dockerfile. |
 | `build-image` | boolean | no | `true` | Build image from Dockerfile before scanning |
 | `dockerfile-path` | string | no | `./Dockerfile` | Path to Dockerfile |
-| `severity-threshold` | string | no | `CRITICAL,HIGH` | Minimum severity to report |
+| `build-context` | string | no | `.` | Docker build context path |
+| `image-tag` | string | no | `security-scan:latest` | Tag for built image (used when `build-image` is `true`) |
+| `severity-threshold` | string | no | `CRITICAL,HIGH` | Minimum severity to report (CRITICAL, HIGH, MEDIUM, LOW) |
 | `fail-on-vulnerabilities` | boolean | no | `true` | Fail if vulnerabilities found at threshold |
 | `run-hadolint` | boolean | no | `true` | Run Hadolint Dockerfile linting |
+| `hadolint-failure-threshold` | string | no | `error` | Hadolint severity to treat as failure (error, warning, info, style, ignore, none) |
+| `generate-sbom` | boolean | no | `false` | Generate container SBOM |
 | `upload-sarif` | boolean | no | `true` | Upload SARIF results to GitHub Security tab |
+| `artifact-retention-days` | number | no | `30` | Days to retain security scan artifacts |
+| `enable-dhi-login` | boolean | no | `true` | Enable login to Docker Hardened Images (dhi.io) registry |
 
 ## Secrets
 

--- a/docs/workflows/python-container-security.md
+++ b/docs/workflows/python-container-security.md
@@ -1,0 +1,34 @@
+# python-container-security.yml -- Container Image Security Scan
+
+Scans Docker images for vulnerabilities using Trivy. By default, builds the
+image from the repository Dockerfile before scanning. Also runs Hadolint
+for Dockerfile linting and optionally generates a container SBOM.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `image-ref` | string | no | | Container image reference to scan (e.g., `ghcr.io/org/repo:sha`). Omit to build from Dockerfile. |
+| `build-image` | boolean | no | `true` | Build image from Dockerfile before scanning |
+| `dockerfile-path` | string | no | `./Dockerfile` | Path to Dockerfile |
+| `severity-threshold` | string | no | `CRITICAL,HIGH` | Minimum severity to report |
+| `fail-on-vulnerabilities` | boolean | no | `true` | Fail if vulnerabilities found at threshold |
+| `run-hadolint` | boolean | no | `true` | Run Hadolint Dockerfile linting |
+| `upload-sarif` | boolean | no | `true` | Upload SARIF results to GitHub Security tab |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `DHI_USERNAME` | no | Docker Hardened Images registry username |
+| `DHI_PAT` | no | Docker Hardened Images registry personal access token |
+
+## Usage
+
+```yaml
+jobs:
+  container-scan:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-container-security.yml@main
+    with:
+      severity-threshold: CRITICAL,HIGH
+```

--- a/docs/workflows/python-docker.md
+++ b/docs/workflows/python-docker.md
@@ -1,0 +1,39 @@
+# python-docker.yml -- Docker Build and Push
+
+Builds a Docker image and optionally pushes it to GitHub Container Registry
+(GHCR) or another registry. Includes Trivy vulnerability scanning, SBOM
+generation, SLSA provenance attestation, and PR comments with build info.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `dockerfile` | string | no | `Dockerfile` | Path to Dockerfile |
+| `context` | string | no | `.` | Docker build context |
+| `platforms` | string | no | `linux/amd64` | Target platforms (comma-separated) |
+| `image-name` | string | no | `github.repository` | Image name (without registry prefix) |
+| `push` | boolean | no | `false` | Push image to registry |
+| `tag-latest` | boolean | no | `false` | Tag as latest (for releases and main branch) |
+| `tag-sha` | boolean | no | `true` | Tag with commit SHA |
+| `enable-trivy-scan` | boolean | no | `true` | Enable Trivy vulnerability scanning |
+| `enable-sbom` | boolean | no | `true` | Generate Software Bill of Materials |
+| `enable-provenance` | boolean | no | `true` | Generate SLSA provenance attestation |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `DHI_USERNAME` | no | Docker Hardened Images registry username |
+| `DHI_PAT` | no | Docker Hardened Images registry personal access token |
+
+## Usage
+
+```yaml
+jobs:
+  build:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-docker.yml@main
+    with:
+      image-name: my-app
+      push: ${{ github.ref == 'refs/heads/main' }}
+      tag-latest: ${{ github.ref == 'refs/heads/main' }}
+```

--- a/docs/workflows/python-docker.md
+++ b/docs/workflows/python-docker.md
@@ -10,14 +10,24 @@ generation, SLSA provenance attestation, and PR comments with build info.
 |-------|------|----------|---------|-------------|
 | `dockerfile` | string | no | `Dockerfile` | Path to Dockerfile |
 | `context` | string | no | `.` | Docker build context |
-| `platforms` | string | no | `linux/amd64` | Target platforms (comma-separated) |
-| `image-name` | string | no | `github.repository` | Image name (without registry prefix) |
+| `platforms` | string | no | `linux/amd64,linux/arm64` | Target platforms (comma-separated) |
+| `build-args` | string | no | | Build arguments (newline-separated KEY=VALUE) |
+| `registry` | string | no | `ghcr.io` | Container registry |
+| `image-name` | string | no | `github.repository` | Image name (default: repo slug when empty) |
 | `push` | boolean | no | `false` | Push image to registry |
+| `push-on-fork` | boolean | no | `false` | Allow push from fork PRs (security risk) |
 | `tag-latest` | boolean | no | `false` | Tag as latest (for releases and main branch) |
+| `tag-semver` | boolean | no | `false` | Generate semver tags from release tag |
 | `tag-sha` | boolean | no | `true` | Tag with commit SHA |
+| `tag-pr` | boolean | no | `true` | Tag with PR number (for PR builds) |
+| `additional-tags` | string | no | | Additional tags (newline-separated) |
 | `enable-trivy-scan` | boolean | no | `true` | Enable Trivy vulnerability scanning |
+| `trivy-severity` | string | no | `CRITICAL,HIGH` | Trivy severity threshold (CRITICAL,HIGH,MEDIUM,LOW) |
+| `trivy-fail-on-vuln` | boolean | no | `false` | Fail build if vulnerabilities found |
 | `enable-sbom` | boolean | no | `true` | Generate Software Bill of Materials |
 | `enable-provenance` | boolean | no | `true` | Generate SLSA provenance attestation |
+| `enable-pr-comment` | boolean | no | `true` | Add sticky comment to PR with build info |
+| `enable-dhi-login` | boolean | no | `true` | Enable login to Docker Hardened Images (dhi.io) registry |
 
 ## Secrets
 

--- a/docs/workflows/python-docs.md
+++ b/docs/workflows/python-docs.md
@@ -1,0 +1,24 @@
+# python-docs.yml -- Documentation Build and Deploy
+
+Builds MkDocs documentation and optionally deploys to GitHub Pages.
+Also checks docstring coverage using interrogate.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `python-version` | string | no | `3.12` | Python version for MkDocs build |
+| `docs-directory` | string | no | `docs` | Documentation source directory |
+| `source-directory` | string | no | `src` | Source code directory for docstring extraction |
+| `deploy-to-pages` | boolean | no | `false` | Deploy to GitHub Pages (main branch only) |
+| `docstring-threshold` | number | no | `80` | Minimum docstring coverage percentage |
+
+## Usage
+
+```yaml
+jobs:
+  docs:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-docs.yml@main
+    with:
+      deploy-to-pages: ${{ github.ref == 'refs/heads/main' }}
+```

--- a/docs/workflows/python-mutation.md
+++ b/docs/workflows/python-mutation.md
@@ -15,6 +15,7 @@ This workflow can be long-running; schedule it weekly rather than on every push.
 | `fail-under-threshold` | boolean | no | `false` | Fail workflow if score is below threshold |
 | `post-pr-comment` | boolean | no | `true` | Post mutation results as PR comment |
 | `timeout-minutes` | number | no | `60` | Timeout for mutation testing |
+| `artifact-retention-days` | number | no | `14` | Days to retain mutation reports |
 
 ## Usage
 

--- a/docs/workflows/python-mutation.md
+++ b/docs/workflows/python-mutation.md
@@ -1,0 +1,28 @@
+# python-mutation.yml -- Mutation Testing
+
+Runs mutation testing with mutmut to evaluate test suite quality. Measures
+what percentage of artificial code mutations are caught by the test suite.
+This workflow can be long-running; schedule it weekly rather than on every push.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `python-version` | string | no | `3.12` | Python version |
+| `source-directory` | string | no | `src` | Source code directory to mutate |
+| `test-directory` | string | no | `tests` | Test directory |
+| `mutation-threshold` | number | no | `80` | Minimum mutation score percentage (0-100) |
+| `fail-under-threshold` | boolean | no | `false` | Fail workflow if score is below threshold |
+| `post-pr-comment` | boolean | no | `true` | Post mutation results as PR comment |
+| `timeout-minutes` | number | no | `60` | Timeout for mutation testing |
+
+## Usage
+
+```yaml
+jobs:
+  mutation:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-mutation.yml@main
+    with:
+      mutation-threshold: 70
+      fail-under-threshold: true
+```

--- a/docs/workflows/python-performance-regression.md
+++ b/docs/workflows/python-performance-regression.md
@@ -1,0 +1,39 @@
+# python-performance-regression.yml -- Performance Regression Detection
+
+Benchmarks key code paths and fails if performance regresses beyond a
+configurable threshold. Requires a caller-supplied benchmark script that
+outputs JSON with performance metrics.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `benchmark-script` | string | **yes** | | Path to benchmark script (must output JSON with metrics) |
+| `primary-metric` | string | no | `p95_ms` | Primary metric to track (e.g., `p95_ms`, `throughput`) |
+| `regression-threshold` | number | no | `10.0` | Maximum allowed regression percentage |
+| `improvement-threshold` | number | no | `5.0` | Minimum improvement percentage to highlight |
+| `python-version` | string | no | `3.12` | Python version for benchmarking |
+| `warmup-iterations` | number | no | `10` | Warmup iterations before measurement |
+| `benchmark-iterations` | number | no | `100` | Benchmark iterations for measurement |
+| `fail-on-regression` | boolean | no | `true` | Fail workflow if regression detected |
+| `comment-on-pr` | boolean | no | `true` | Post performance results as PR comment |
+
+## Benchmark script contract
+
+The `benchmark-script` must write a JSON object to stdout with at least one
+numeric metric key matching the `primary-metric` input. Example:
+
+```json
+{"p95_ms": 45.2, "p99_ms": 52.1, "throughput": 1200}
+```
+
+## Usage
+
+```yaml
+jobs:
+  perf:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-performance-regression.yml@main
+    with:
+      benchmark-script: scripts/benchmark.py
+      regression-threshold: 15
+```

--- a/docs/workflows/python-performance-regression.md
+++ b/docs/workflows/python-performance-regression.md
@@ -17,6 +17,12 @@ outputs JSON with performance metrics.
 | `benchmark-iterations` | number | no | `100` | Benchmark iterations for measurement |
 | `fail-on-regression` | boolean | no | `true` | Fail workflow if regression detected |
 | `comment-on-pr` | boolean | no | `true` | Post performance results as PR comment |
+| `benchmark-args` | string | no | | Additional arguments for the benchmark script |
+| `baseline-file` | string | no | | Path to a committed baseline file for comparison |
+| `generate-synthetic-data` | boolean | no | `false` | Generate synthetic test data via `scripts/generate_test_data.py` |
+| `test-data-directory` | string | no | `/tmp/perf_test_data` | Directory for generated test data |
+| `extra-dependencies` | string | no | `dev` | Additional uv sync extras (e.g., `dev ml`) |
+| `timeout-minutes` | number | no | `30` | Job timeout in minutes |
 
 ## Benchmark script contract
 

--- a/docs/workflows/python-standard-stack.md
+++ b/docs/workflows/python-standard-stack.md
@@ -1,0 +1,53 @@
+# python-standard-stack.yml -- Standard Python CI Quickstart
+
+The `python-standard-stack.yml` reusable workflow is the recommended starting point
+for new Python projects in ByronWilliamsCPA. It bundles the most common CI checks
+into a single workflow call.
+
+## What it runs
+
+- Ruff lint and format check
+- BasedPyright type checking
+- pytest with coverage measurement
+- Bandit security scan
+- pip-audit dependency vulnerability scan
+
+## Minimal usage
+
+Create `.github/workflows/ci.yml` in your project:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-standard-stack.yml@main
+    with:
+      python-version: "3.12"
+    secrets: inherit
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `python-version` | string | no | `3.12` | Python version to use |
+| `source-directory` | string | no | `src` | Source code directory |
+| `coverage-threshold` | number | no | `80` | Minimum line coverage percentage |
+| `fail-on-high` | boolean | no | `true` | Fail on HIGH or CRITICAL security findings |
+
+## Extending the stack
+
+After `python-standard-stack.yml` passes, chain additional workflows for:
+- Container builds: `python-docker.yml`
+- Coverage upload: `python-codecov.yml`
+- SBOM generation: `python-sbom.yml`
+- Release: `python-release.yml`
+
+See [docs/workflows/](.) for individual workflow documentation.

--- a/docs/workflows/python-supplemental-checks.md
+++ b/docs/workflows/python-supplemental-checks.md
@@ -18,13 +18,20 @@ Each check is disabled by default; enable only what your project needs.
 | Input | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `enable-link-check` | boolean | no | `false` | Enable documentation link checking |
-| `link-check-paths` | string | no | `./docs/**/*.md` | Paths to check |
+| `link-check-paths` | string | no | `./docs/**/*.md ./README.md ./CONTRIBUTING.md` | Paths to check for broken links (space-separated) |
+| `link-check-fail` | boolean | no | `false` | Fail workflow on broken links |
+| `link-check-exclude-patterns` | string | no | GitHub/Linear URL patterns | Regex patterns to exclude from link checking (comma-separated) |
 | `enable-changelog-check` | boolean | no | `false` | Require CHANGELOG update on PRs |
-| `changelog-skip-labels` | string | no | `skip-changelog` | PR labels that skip the requirement |
-| `enable-automerge` | boolean | no | `false` | Enable auto-merge for bots |
-| `automerge-allowed-update-types` | string | no | `patch,minor` | Update types to auto-merge |
-| `enable-commit-lint` | boolean | no | `false` | Validate PR title format |
+| `changelog-path` | string | no | `CHANGELOG.md` | Path to CHANGELOG file |
+| `changelog-skip-labels` | string | no | `skip-changelog,dependencies,documentation` | PR labels that skip the changelog requirement (comma-separated) |
+| `enable-cruft-check` | boolean | no | `false` | Enable cruft template synchronization check |
+| `cruft-fail-on-diff` | boolean | no | `true` | Fail if project is out of sync with template |
 | `python-version` | string | no | `3.12` | Python version for cruft check |
+| `enable-automerge` | boolean | no | `false` | Enable auto-merge for Dependabot/Renovate PRs |
+| `automerge-allowed-actors` | string | no | `dependabot[bot],renovate[bot]` | Bot usernames allowed for auto-merge (comma-separated) |
+| `automerge-allowed-update-types` | string | no | `patch,minor` | Update types to auto-merge (comma-separated: patch,minor,major) |
+| `automerge-merge-method` | string | no | `squash` | Merge method for auto-merge (merge, squash, rebase) |
+| `enable-commit-lint` | boolean | no | `false` | Validate PR title format (Conventional Commits) |
 
 ## Usage
 

--- a/docs/workflows/python-supplemental-checks.md
+++ b/docs/workflows/python-supplemental-checks.md
@@ -1,0 +1,39 @@
+# python-supplemental-checks.yml -- Supplemental Quality Checks
+
+A collection of optional quality checks not included in the standard CI stack.
+Each check is disabled by default; enable only what your project needs.
+
+## Available checks
+
+| Check | Enable input | Description |
+|-------|-------------|-------------|
+| Link checking | `enable-link-check` | Checks documentation for broken URLs |
+| Changelog enforcement | `enable-changelog-check` | Requires CHANGELOG update on PRs |
+| Cruft sync | `enable-cruft-check` | Verifies project is in sync with template |
+| Auto-merge | `enable-automerge` | Auto-merges Dependabot/Renovate PRs |
+| Commit lint | `enable-commit-lint` | Validates Conventional Commits format |
+
+## Key inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable-link-check` | boolean | `false` | Enable documentation link checking |
+| `link-check-paths` | string | `./docs/**/*.md` | Paths to check |
+| `enable-changelog-check` | boolean | `false` | Require CHANGELOG update on PRs |
+| `changelog-skip-labels` | string | `skip-changelog` | PR labels that skip the requirement |
+| `enable-automerge` | boolean | `false` | Enable auto-merge for bots |
+| `automerge-allowed-update-types` | string | `patch,minor` | Update types to auto-merge |
+| `enable-commit-lint` | boolean | `false` | Validate PR title format |
+| `python-version` | string | `3.12` | Python version for cruft check |
+
+## Usage
+
+```yaml
+jobs:
+  supplemental:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-supplemental-checks.yml@main
+    with:
+      enable-link-check: true
+      enable-changelog-check: true
+      changelog-skip-labels: skip-changelog,dependencies
+```

--- a/docs/workflows/python-supplemental-checks.md
+++ b/docs/workflows/python-supplemental-checks.md
@@ -13,18 +13,18 @@ Each check is disabled by default; enable only what your project needs.
 | Auto-merge | `enable-automerge` | Auto-merges Dependabot/Renovate PRs |
 | Commit lint | `enable-commit-lint` | Validates Conventional Commits format |
 
-## Key inputs
+## Inputs
 
-| Input | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enable-link-check` | boolean | `false` | Enable documentation link checking |
-| `link-check-paths` | string | `./docs/**/*.md` | Paths to check |
-| `enable-changelog-check` | boolean | `false` | Require CHANGELOG update on PRs |
-| `changelog-skip-labels` | string | `skip-changelog` | PR labels that skip the requirement |
-| `enable-automerge` | boolean | `false` | Enable auto-merge for bots |
-| `automerge-allowed-update-types` | string | `patch,minor` | Update types to auto-merge |
-| `enable-commit-lint` | boolean | `false` | Validate PR title format |
-| `python-version` | string | `3.12` | Python version for cruft check |
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enable-link-check` | boolean | no | `false` | Enable documentation link checking |
+| `link-check-paths` | string | no | `./docs/**/*.md` | Paths to check |
+| `enable-changelog-check` | boolean | no | `false` | Require CHANGELOG update on PRs |
+| `changelog-skip-labels` | string | no | `skip-changelog` | PR labels that skip the requirement |
+| `enable-automerge` | boolean | no | `false` | Enable auto-merge for bots |
+| `automerge-allowed-update-types` | string | no | `patch,minor` | Update types to auto-merge |
+| `enable-commit-lint` | boolean | no | `false` | Validate PR title format |
+| `python-version` | string | no | `3.12` | Python version for cruft check |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Creates \`docs/workflows/\` with one Markdown file per undocumented reusable workflow (G007)
- Documents all inputs, secrets, and usage examples for: \`python-codecov.yml\`, \`python-compatibility.yml\`, \`python-container-security.yml\`, \`python-docker.yml\`, \`python-docs.yml\`, \`python-mutation.yml\`, \`python-performance-regression.yml\`, \`python-standard-stack.yml\`, and \`python-supplemental-checks.yml\`
- Inputs tables verified against actual workflow YAML files via Python parsing (not the implementation plan, which had inaccuracies)

## Checks resolved

- **G007**: 9 reusable workflows had no caller-facing documentation

## Test plan

- [ ] Verify \`docs/workflows/\` directory appears in the repo with 9 \`.md\` files
- [ ] Spot-check any workflow's inputs table against the actual \`.github/workflows/*.yml\` file
- [ ] Confirm no broken links or placeholder text in any doc

Generated with [Claude Code](https://claude.com/claude-code)