### PR TITLE
fix(ci): remove --no-build from uv sync in all reusable workflows

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras --frozen --no-build
+          uv sync --all-extras --frozen
 
       - name: Run Ruff formatter check
         env:
@@ -533,7 +533,7 @@ jobs:
         run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen --no-build
+        run: uv sync --all-extras --frozen
 
       - name: Run tests
         env:

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -255,7 +255,7 @@ jobs:
         shell: pwsh
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen --no-build
+        run: uv sync --all-extras --frozen
 
       - name: Run tests
         id: tests

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -80,7 +80,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen --no-build
+        run: uv sync --all-extras --frozen
 
       - name: Check docstring coverage
         env:

--- a/.github/workflows/python-fips-compatibility.yml
+++ b/.github/workflows/python-fips-compatibility.yml
@@ -359,7 +359,7 @@ jobs:
         run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen --no-build
+        run: uv sync --all-extras --frozen
 
       - name: Test crypto imports in simulated FIPS mode
         run: |

--- a/.github/workflows/python-mutation.yml
+++ b/.github/workflows/python-mutation.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras --frozen --no-build
+          uv sync --all-extras --frozen
           uv pip install --no-build 'mutmut==2.5.1'
 
       - name: Run mutation testing

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -179,9 +179,9 @@ jobs:
             while IFS= read -r dep; do
               [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
             done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen --no-build
+            uv sync "${EXTRA_ARGS[@]}" --frozen
           else
-            uv sync --frozen --no-build
+            uv sync --frozen
           fi
 
       - name: Generate Synthetic Test Data
@@ -309,9 +309,9 @@ jobs:
             while IFS= read -r dep; do
               [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
             done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen --no-build
+            uv sync "${EXTRA_ARGS[@]}" --frozen
           else
-            uv sync --frozen --no-build
+            uv sync --frozen
           fi
 
           # Check if script supports --output argument

--- a/.github/workflows/python-precommit.yml
+++ b/.github/workflows/python-precommit.yml
@@ -67,7 +67,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --frozen --no-build
+        run: uv sync --frozen
 
       - name: Run pre-commit hooks
         env:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -143,7 +143,7 @@ jobs:
         run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen --no-build
+        run: uv sync --all-extras --frozen
 
       - name: Run tests
         env:
@@ -222,7 +222,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen --no-build
+        run: uv sync --all-extras --frozen
 
       - name: Build package
         run: |

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -111,7 +111,7 @@ jobs:
         run: uv pip install --no-build 'cyclonedx-bom==7.3.0'
 
       - name: Install dependencies
-        run: uv sync --frozen --no-build
+        run: uv sync --frozen
 
       - name: Generate runtime SBOM (production dependencies)
         run: |

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -140,7 +140,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --no-dev --frozen --no-build
+        run: uv sync --no-dev --frozen
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
@@ -223,7 +223,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen --no-build
+        run: uv sync --all-extras --frozen
 
       - name: Bandit Static Analysis
         if: ${{ inputs.run-bandit }}

--- a/.github/workflows/python-sonarcloud.yml
+++ b/.github/workflows/python-sonarcloud.yml
@@ -231,15 +231,15 @@ jobs:
           EXTRA_DEPENDENCIES: ${{ inputs.extra-dependencies }}
         run: |
           if [ "$EXTRA_DEPENDENCIES" == "all" ]; then
-            uv sync --all-extras --frozen --no-build
+            uv sync --all-extras --frozen
           elif [ -n "$EXTRA_DEPENDENCIES" ]; then
             EXTRA_ARGS=()
             while IFS= read -r dep; do
               [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
             done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen --no-build
+            uv sync "${EXTRA_ARGS[@]}" --frozen
           else
-            uv sync --frozen --no-build
+            uv sync --frozen
           fi
 
       - name: Run tests with coverage


### PR DESCRIPTION
## Summary

Removes \`--no-build\` from every \`uv sync\` call across 11 reusable workflow files. The flag breaks editable installs of local packages, causing immediate CI Gate and Code Quality Checks failures in all consuming repos.

## Why

Commit \`45213cb\` ("remediate 207 SonarCloud issues") added \`--no-build\` to all \`uv sync\` calls as a blanket security measure. This is incompatible with editable installs of local packages (\`editable+.\`), which every Python project using \`uv sync\` will have.

The exact error in consuming repos:

\`\`\`
error: Distribution \`<pkg>==<ver> @ editable+.\` can't be installed
because it is marked as --no-build but has no binary distribution
\`\`\`

The security intent of \`--no-build\` is already satisfied by \`--frozen\`, which pins every package to the lockfile. \`--no-build\` adds no additional security over \`--frozen\` for projects with a checked-in \`uv.lock\`.

## Changes

Removes \`--no-build\` from \`uv sync\` in 11 workflow files. Retains \`--no-build\` on \`uv pip install\` (external packages with wheels) and \`uv run\` (running from already-installed env).

## Impact

- Unblocks CI Gate and Code Quality Checks in all consuming repos
- Security posture unchanged: \`--frozen\` continues to enforce lockfile pinning

Generated with [Claude Code](https://claude.ai/code)