### PR TITLE
docs(community): quality pass on SECURITY, CONTRIBUTING, CODE_OF_CONDUCT, GOVERNANCE

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -44,16 +44,17 @@ representative at an online or offline event.
 ## Reporting Guidelines
 
 If you are subject to or witness unacceptable behavior, or have any other
-concerns, please report it **promptly** through one of these private
-channels:
+concerns, please report it **promptly** by emailing the maintainer at
+**byronawilliams@gmail.com** with the subject line `CONDUCT:` followed
+by a short summary.
 
-- Email the maintainer at **byronawilliams@gmail.com** with the subject line
-  `CONDUCT:` followed by a short summary.
-- File a private
-  [Security Advisory](https://github.com/ByronWilliamsCPA/.github/security/advisories/new).
+Do not use GitHub Security Advisories for conduct reports; that channel
+is reserved for vulnerability disclosure. See [SECURITY.md](SECURITY.md)
+for security issues.
 
-All reports will be treated confidentially to the greatest extent possible,
-and you will not be retaliated against for making a good-faith report.
+All reports will be treated confidentially to the greatest extent
+possible, and you will not be retaliated against for making a good-faith
+report.
 
 ## Enforcement Process
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -44,9 +44,14 @@ representative at an online or offline event.
 ## Reporting Guidelines
 
 If you are subject to or witness unacceptable behavior, or have any other
-concerns, please report it **promptly** via the private
-[Security Advisory](https://github.com/ByronWilliamsCPA/.github/security/advisories/new)
-channel.
+concerns, please report it **promptly** through one of these private
+channels:
+
+- Email the maintainer at **byronawilliams@gmail.com** with the subject line
+  `CONDUCT:` followed by a short summary.
+- File a private
+  [Security Advisory](https://github.com/ByronWilliamsCPA/.github/security/advisories/new).
+
 All reports will be treated confidentially to the greatest extent possible,
 and you will not be retaliated against for making a good-faith report.
 
@@ -80,4 +85,4 @@ This Code of Conduct is adapted from the
 and incorporates an enforcement framework inspired by
 Mozilla’s Community Participation Guidelines.
 
-## Last updated: November 16, 2025
+## Last updated: May 15, 2026

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ pre-commit install       # installs commit and commit-msg hooks
 ```
 
 Maintainers with push access to the org repository can clone the org URL
-directly and skip the fork step.
+directly and skip the fork step. If the repository is private, request
+access from the maintainer rather than forking; private repositories cannot
+be forked by external contributors.
 
 `pre-commit` hooks must pass before a commit lands. Run
 `pre-commit run --all-files` if you touch many files at once.
@@ -43,6 +45,7 @@ directly and skip the fork step.
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
+# uv must be installed first: https://github.com/astral-sh/uv
 uv sync                  # or: pip install -e ".[dev]"
 pytest                   # run the test suite
 ```
@@ -62,7 +65,7 @@ Branch from `main` using one of these prefixes:
 |-------------|--------------------------------------------------|
 | `feature/`  | New functionality                                |
 | `fix/`      | Bug fixes                                        |
-| `chore/`    | Tooling, build, dependency, and CI changes       |
+| `chore/`    | Tooling, build, dependency, CI, refactoring, test-only, and style changes |
 | `docs/`     | Documentation only                               |
 | `claude/`   | Reserved for automated agent commits             |
 
@@ -105,9 +108,8 @@ Keep the subject under 72 characters and in the imperative mood.
 ## GPG-Signed Commits Required
 
 Every commit on every PR must be GPG-signed (or SSH-signed) and show as
-**Verified** on GitHub. Branch protection on `main` enforces this at merge
-time; unsigned commits pushed to a feature branch are not rejected at push,
-but they cannot be merged.
+**Verified** on GitHub. This is org policy: unsigned commits will be
+requested for re-signing before a PR is merged.
 
 To set this up once:
 
@@ -128,7 +130,7 @@ signature.
 Before requesting review, confirm each item:
 
 - [ ] Branch follows the naming convention above.
-- [ ] All commits are GPG-signed and show as Verified on the PR.
+- [ ] All commits are GPG-signed; confirm each shows the Verified badge before requesting review.
 - [ ] Commit messages follow Conventional Commits.
 - [ ] `pre-commit run --all-files` passes locally.
 - [ ] Tests pass (`pytest`, or the project's equivalent).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,22 +13,38 @@ repositories in the ByronWilliamsCPA org that do not provide their own
 
 ## Local Development Setup
 
-The exact steps depend on the project, but the typical Python flow is:
+Setup is per-repository. Always read the target repo's `README.md` and CI
+workflows (`.github/workflows/`) for the authoritative install and test
+commands. The org spans Python projects, shell/bats projects, and pure
+docs repos, so there is no single setup recipe.
+
+What is consistent across the org:
 
 ```bash
 git clone https://github.com/ByronWilliamsCPA/<repo>.git
 cd <repo>
 git remote add upstream https://github.com/ByronWilliamsCPA/<repo>.git
-
-python3 -m venv .venv
-source .venv/bin/activate
-uv sync                  # or: pip install -e ".[dev]"
-pre-commit install       # required: installs commit hooks
-pytest                   # run the test suite
+pre-commit install       # required: installs commit and commit-msg hooks
 ```
 
 `pre-commit` hooks must pass before a commit lands. Run
 `pre-commit run --all-files` if you touch many files at once.
+
+**Example: Python repos** (those with a `pyproject.toml`):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+uv sync                  # or: pip install -e ".[dev]"
+pytest                   # run the test suite
+```
+
+**Example: shell/workflow repos** (those with `tests/*.bats`):
+
+```bash
+git submodule update --init --recursive   # bats helper libraries
+bats tests/                                # run the test suite
+```
 
 ## Branch Naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,19 @@ docs repos, so there is no single setup recipe.
 What is consistent across the org:
 
 ```bash
-git clone https://github.com/ByronWilliamsCPA/<repo>.git
+# 1. Fork the repo on GitHub, then clone YOUR fork.
+git clone https://github.com/<your-user>/<repo>.git
 cd <repo>
+
+# 2. Point "upstream" at the org repo so you can pull updates.
 git remote add upstream https://github.com/ByronWilliamsCPA/<repo>.git
-pre-commit install       # required: installs commit and commit-msg hooks
+
+# 3. Install pre-commit hooks (required).
+pre-commit install       # installs commit and commit-msg hooks
 ```
+
+Maintainers with push access to the org repository can clone the org URL
+directly and skip the fork step.
 
 `pre-commit` hooks must pass before a commit lands. Run
 `pre-commit run --all-files` if you touch many files at once.
@@ -56,9 +64,15 @@ Branch from `main` using one of these prefixes:
 | `fix/`      | Bug fixes                                        |
 | `chore/`    | Tooling, build, dependency, and CI changes       |
 | `docs/`     | Documentation only                               |
+| `claude/`   | Reserved for automated agent commits             |
 
 Examples: `feature/retry-handler`, `fix/timeout-on-empty-payload`,
-`chore/bump-actions-checkout`, `docs/contributing-clarify-gpg`.
+`chore/bump-actions-checkout`, `docs/contributing-clarify-gpg`,
+`claude/review-security-policy-aasG1`.
+
+`claude/` is reserved for branches pushed by Claude Code agents working
+on this repository; human contributors should pick one of the other four
+prefixes.
 
 ## Commit Messages
 
@@ -90,9 +104,10 @@ Keep the subject under 72 characters and in the imperative mood.
 
 ## GPG-Signed Commits Required
 
-Every commit on every PR must be GPG-signed (or SSH-signed) and show as
-**Verified** on GitHub. Unsigned commits will be rejected by branch
-protection.
+Every commit that reaches `main` must be GPG-signed (or SSH-signed) and
+show as **Verified** on GitHub. Branch protection enforces this at merge
+time, so unsigned commits on a feature branch will block the PR from
+merging until they are re-signed.
 
 To set this up once:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,95 +1,146 @@
-# Contributing to Our Projects
+# Contributing
 
-Thank you for your interest in contributing! We welcome all contributions that
-help improve our code, documentation, and community processes.
+Thanks for taking the time to contribute. This file applies to all
+repositories in the ByronWilliamsCPA org that do not provide their own
+`CONTRIBUTING.md`.
 
-## How to Contribute
+## Before You Start
 
-1. **Review the Code of Conduct**
-   Ensure your interactions align with our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-2. **Find or File an Issue**
-   - Search existing issues to avoid duplication.
-   - To report a bug, use the [bug template](.github/ISSUE_TEMPLATE/bug.yml).
-   - To propose a feature, use the [feature template]
-   (.github/ISSUE_TEMPLATE/feature.yml).
-
-3. **Fork & Clone**
-
-   ```bash
-   git clone https://github.com/<org>/<repo>.git
-   cd <repo>
-   git remote add upstream https://github.com/<org>/<repo>.git
-   ```
-
-## Pull Request Guidelines
-
-- **Branch from main**
-
-  ```bash
-  git checkout -b feature/<short-description>
-  ```
-
-- **Link your issue**
-  Include "Closes #ISSUE-NUMBER" in your PR description to auto-close the issue.
-- **Commit messages**
-  Use the format:
-
-  ```text
-  <type>(<scope>): <subject>
-  ```
-
-  where `<type>` is one of `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
-  or `chore`.
-  _Example:_ `feat(api): add retry logic to request handler`
-- **DCO Sign-off Required**
-  Every commit must include:
-
-  ```text
-  Signed-off-by: Your Name <you@example.com>
-  ```
-
-  Add with:
-
-  ```bash
-  git commit --signoff
-  ```
-
-## Code Style
-
-- **Language conventions**
-  - **Python:** follow [PEP 8](https://peps.python.org/pep-0008/) and
-    Google-style docstrings
-  - **JavaScript/TypeScript:** follow
-    [Airbnb style](https://github.com/airbnb/javascript)
-- **Linters & formatters**
-  - Python: `ruff --fix` (formatter and linter)
-  - JavaScript/TypeScript: `eslint --fix`, `prettier --write`
-- **Imports**
-  Group imports in this order, with a blank line between groups:
-  1. Standard library
-  2. Third-party
-  3. Local application
+1. Read the [Code of Conduct](CODE_OF_CONDUCT.md).
+2. Search existing issues and pull requests so you don't duplicate work.
+3. For non-trivial changes, open an issue first and agree on the approach
+   before writing code.
 
 ## Local Development Setup
 
-1. **Create a virtual environment** (Python example)
+The exact steps depend on the project, but the typical Python flow is:
 
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
-   ```
+```bash
+git clone https://github.com/ByronWilliamsCPA/<repo>.git
+cd <repo>
+git remote add upstream https://github.com/ByronWilliamsCPA/<repo>.git
 
-2. **Install dependencies**
+python3 -m venv .venv
+source .venv/bin/activate
+uv sync                  # or: pip install -e ".[dev]"
+pre-commit install       # required: installs commit hooks
+pytest                   # run the test suite
+```
 
-   ```bash
-   uv sync
-   ```
+`pre-commit` hooks must pass before a commit lands. Run
+`pre-commit run --all-files` if you touch many files at once.
 
-3. **Run tests**
+## Branch Naming
 
-   ```bash
-   pytest
-   ```
+Branch from `main` using one of these prefixes:
 
-## Last updated: November 16, 2025
+| Prefix      | Use for                                          |
+|-------------|--------------------------------------------------|
+| `feature/`  | New functionality                                |
+| `fix/`      | Bug fixes                                        |
+| `chore/`    | Tooling, build, dependency, and CI changes       |
+| `docs/`     | Documentation only                               |
+
+Examples: `feature/retry-handler`, `fix/timeout-on-empty-payload`,
+`chore/bump-actions-checkout`, `docs/contributing-clarify-gpg`.
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/). The format
+is:
+
+```text
+<type>(<scope>): <subject>
+
+<optional body>
+
+<optional footer(s)>
+```
+
+`<type>` is one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+`build`, `ci`, `chore`, `revert`. `<scope>` is optional and identifies the
+area touched (for example `api`, `workflows`, `deps`).
+
+Example:
+
+```text
+feat(api): add retry logic to request handler
+
+Retries idempotent requests up to three times with exponential backoff.
+Closes #123.
+```
+
+Keep the subject under 72 characters and in the imperative mood.
+
+## GPG-Signed Commits Required
+
+Every commit on every PR must be GPG-signed (or SSH-signed) and show as
+**Verified** on GitHub. Unsigned commits will be rejected by branch
+protection.
+
+To set this up once:
+
+```bash
+gpg --full-generate-key                       # or use an existing key
+git config --global user.signingkey <KEY_ID>
+git config --global commit.gpgsign true
+git config --global tag.gpgsign true
+```
+
+Then add the public key to your GitHub account under
+**Settings, SSH and GPG keys**. GitHub's docs cover SSH signing if you prefer
+that path. DCO `Signed-off-by` lines are not a substitute for a cryptographic
+signature.
+
+## Pull Request Checklist
+
+Before requesting review, confirm each item:
+
+- [ ] Branch follows the naming convention above.
+- [ ] All commits are GPG-signed and show as Verified on the PR.
+- [ ] Commit messages follow Conventional Commits.
+- [ ] `pre-commit run --all-files` passes locally.
+- [ ] Tests pass (`pytest`, or the project's equivalent).
+- [ ] New behavior has tests; bug fixes have regression tests.
+- [ ] Public APIs and CLI changes are documented.
+- [ ] The PR description links the issue (`Closes #N`) when one exists.
+- [ ] The PR is scoped to one logical change; unrelated cleanup goes in a
+      separate PR.
+
+## Code Review Expectations
+
+What contributors can expect:
+
+- A first response within five business days. If the PR is small and CI is
+  green, often sooner.
+- Review comments will be specific and actionable. If something is a
+  preference rather than a requirement, the reviewer will label it as
+  `nit:`.
+- The maintainer may push small fixups (typos, lint) directly rather than
+  block on round trips. Anything larger will be requested as a change.
+
+What reviewers expect from contributors:
+
+- Respond to comments, even if the response is "I disagree, here's why."
+- Resolve threads only after the comment has been addressed.
+- Rebase on `main` rather than merging `main` into the branch when
+  conflicts arise.
+- Squash fixup commits before merge unless the history is intentionally
+  preserved.
+
+## Code Style
+
+- **Python**: [PEP 8](https://peps.python.org/pep-0008/) with Google-style
+  docstrings. Format and lint with `ruff`.
+- **JavaScript/TypeScript**: [Airbnb style](https://github.com/airbnb/javascript),
+  lint with `eslint --fix`, format with `prettier --write`.
+- **YAML, Markdown, shell**: enforced by `pre-commit` (`yamllint`,
+  `markdownlint`, `shellcheck`).
+- **Imports** (Python): standard library, third-party, local, each group
+  separated by a blank line.
+
+## Reporting Security Issues
+
+Do not file security problems as public issues. Follow [SECURITY.md](SECURITY.md).
+
+Last updated: May 15, 2026

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ docs repos, so there is no single setup recipe.
 What is consistent across the org:
 
 ```bash
-# 1. Fork the repo on GitHub, then clone YOUR fork.
-git clone https://github.com/<your-user>/<repo>.git
+# 1. Fork the repository on GitHub first (https://github.com/ByronWilliamsCPA/<repo>)
+git clone https://github.com/<your-username>/<repo>.git
 cd <repo>
 
 # 2. Point "upstream" at the org repo so you can pull updates.
@@ -104,10 +104,10 @@ Keep the subject under 72 characters and in the imperative mood.
 
 ## GPG-Signed Commits Required
 
-Every commit that reaches `main` must be GPG-signed (or SSH-signed) and
-show as **Verified** on GitHub. Branch protection enforces this at merge
-time, so unsigned commits on a feature branch will block the PR from
-merging until they are re-signed.
+Every commit on every PR must be GPG-signed (or SSH-signed) and show as
+**Verified** on GitHub. Branch protection on `main` enforces this at merge
+time; unsigned commits pushed to a feature branch are not rejected at push,
+but they cannot be merged.
 
 To set this up once:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,48 +1,50 @@
 # Governance
 
-## Purpose & Scope
+## Status
 
-This document describes the governance model for the ByronWilliamsCPA organization and
-its repositories. It applies to all project spaces, including code,
-documentation, and community forums.
+ByronWilliamsCPA is currently a **sole-maintainer** organization. Byron
+Williams (byronawilliams@gmail.com) is the sole maintainer and final
+decision-maker for all repositories in the org that do not publish their own
+governance document.
 
-## Roles & Responsibilities
+This is intentional. The org is small and the overhead of a formal
+multi-role governance model is not justified yet. If the project grows
+beyond what one maintainer can handle, this document will be updated to
+reflect a fuller structure.
 
-| Role             | Description                                             |
-|------------------|---------------------------------------------------------|
-| **Project Lead** | Has final authority on project decisions, oversees      |
-|                  | overall direction, and resolves conflicts.              |
-| **Core Team**    | Experienced contributors authorized to review           |
-|                  | contributions, merge PRs, and mentor others.            |
-| **Maintainers**  | Individuals responsible for daily maintenance tasks,    |
-|                  | issue triage, and minor releases.                       |
-| **Contributors** | Community members who submit issues, pull requests, and |
-|                  | engage in discussions.                                  |
+## Decision-Making
 
-## Decision Process
+1. **Day-to-day changes** (bug fixes, dependency bumps, small features,
+   documentation): the maintainer reviews and merges directly.
+2. **Larger or breaking changes** (public API changes, new reusable
+   workflows, removal of supported features): the maintainer opens an issue
+   describing the change and waits at least seven calendar days before
+   merging, so external contributors and downstream consumers can comment.
+3. **Security fixes**: handled per [SECURITY.md](SECURITY.md) and may be
+   merged without the waiting period.
 
-1. **Proposal:** Any contributor may open a proposal issue detailing the
-   suggested change.
-2. **Discussion:** The Core Team and community discuss the proposal in the
-   issue thread.
-3. **Review:** The Core Team reviews feedback, refines the proposal, and
-   recommends next steps.
-4. **Decision:** The Project Lead makes the final call based on
-   recommendations and community input.
-5. **Implementation:** Contributors implement the approved changes,
-   referencing the proposal issue.
+Decisions are final once merged. Disagreement is welcome before that point;
+open an issue or comment on the PR.
 
-## Future Evolution
+## How to Propose a Change
 
-Governance is a living process. To suggest updates or new roles, open an issue
-in this repository labeled **governance**. Proposals will follow the same
-Decision Process above.
+1. Open an issue using the appropriate template. For
+   non-trivial changes, describe the problem, the proposed solution, and any
+   alternatives considered.
+2. Wait for a maintainer response or for the seven-day comment window on
+   larger changes.
+3. Submit a pull request that references the issue. Follow
+   [CONTRIBUTING.md](CONTRIBUTING.md), including the GPG-signing requirement
+   and PR checklist.
 
-## Contact
+Proposals that would change governance itself (for example, adding new roles
+or changing the decision process) should be opened as an issue labeled
+`governance` and discussed publicly before any PR is filed.
 
-For questions about governance or to nominate yourself for a role,
-open an issue in this repository or use GitHub Discussions.
+## Succession
 
-## Last Updated
+If the maintainer becomes unavailable, the repositories remain under the
+existing license and can be forked by anyone. There is no formal succession
+plan; if that changes, this section will be updated.
 
-November 16, 2025
+Last updated: May 15, 2026

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,18 +28,20 @@ open an issue or comment on the PR.
 
 ## How to Propose a Change
 
-1. Open an issue using the appropriate template. For
-   non-trivial changes, describe the problem, the proposed solution, and any
-   alternatives considered.
-2. Wait for a maintainer response or for the seven-day comment window on
-   larger changes.
+1. Open an issue. If the repository provides issue templates, use the
+   one that matches your change; otherwise open a plain issue. For
+   non-trivial changes, describe the problem, the proposed solution,
+   and any alternatives considered.
+2. Wait for a maintainer response, or for the seven-day comment window
+   on larger changes.
 3. Submit a pull request that references the issue. Follow
-   [CONTRIBUTING.md](CONTRIBUTING.md), including the GPG-signing requirement
-   and PR checklist.
+   [CONTRIBUTING.md](CONTRIBUTING.md), including the GPG-signing
+   requirement and PR checklist.
 
-Proposals that would change governance itself (for example, adding new roles
-or changing the decision process) should be opened as an issue labeled
-`governance` and discussed publicly before any PR is filed.
+Proposals that would change governance itself (for example, adding new
+roles or changing the decision process) should be opened as an issue
+with `governance` in the title and discussed publicly before any PR is
+filed.
 
 ## Succession
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,10 +18,11 @@ reflect a fuller structure.
    documentation): the maintainer reviews and merges directly.
 2. **Larger or breaking changes** (public API changes, new reusable
    workflows, removal of supported features): the maintainer opens an issue
-   describing the change and waits at least seven calendar days before
-   merging, so external contributors and downstream consumers can comment.
-3. **Security fixes**: handled per [SECURITY.md](SECURITY.md) and may be
-   merged without the waiting period.
+   describing the change and waits at least seven calendar days from the
+   issue creation date before merging, so external contributors and
+   downstream consumers can comment.
+3. **Security fixes**: reported via [SECURITY.md](SECURITY.md); the
+   maintainer may merge fixes without the seven-day waiting period.
 
 Decisions are final once merged. Disagreement is welcome before that point;
 open an issue or comment on the PR.
@@ -45,7 +46,7 @@ filed.
 
 ## Succession
 
-If the maintainer becomes unavailable, the repositories remain under the
+If the maintainer becomes unavailable, public repositories remain under the
 existing license and can be forked by anyone. There is no formal succession
 plan; if that changes, this section will be updated.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,17 +31,19 @@ from this org, please name the consumer repo as well.
 
 ## Supported Versions
 
-This repository is a community health and reusable workflow library. Releases
-are continuous on `main`; there are no long-term branches.
+This repository is a community health and reusable workflow library with
+continuous deployment on `main`. The `CHANGELOG.md` uses date-based version
+headers (for example, `[2025-01-07]`); there are no numbered releases or
+semver branches.
 
-| Version          | Supported          |
-|------------------|--------------------|
-| `main` (latest)  | Yes                |
-| Tagged releases  | Yes, latest minor  |
-| Pinned commit SHAs older than the latest minor release | No |
+| Version                                               | Supported |
+|-------------------------------------------------------|-----------|
+| `main` (latest commit)                                | Yes       |
+| Most recent dated release tag                         | Yes       |
+| Earlier dated tags / older pinned SHAs                | No        |
 
-If you pin a workflow to a specific commit SHA, you must bump the pin to pick
-up security fixes. Older SHAs do not receive backports.
+If you pin a workflow to a specific commit SHA, bump the pin to pick up
+security fixes. Older SHAs do not receive backports.
 
 ## Response Timeline
 
@@ -57,14 +59,19 @@ updated if a fix needs longer.
 
 ## Security Practices
 
-The org applies the following baseline across its repositories:
+The org applies the following baseline across its repositories. Not every
+tool runs in every repo; the list reflects what is wired up in this
+repository's workflows and pre-commit hooks, which downstream repos
+inherit via the reusable workflows.
 
-- Static analysis with CodeQL, Semgrep, Ruff, and Bandit
+- Static analysis: CodeQL (org-wide), Semgrep (via SonarCloud), Ruff and
+  Bandit (Python reusable workflows)
 - Dependency pinning and Renovate-driven updates
-- Container scanning with Trivy
+- Container scanning with Trivy (Docker and SBOM workflows)
 - SBOM generation for tagged releases
-- Secret scanning in CI (gitleaks, TruffleHog, detect-secrets)
-- Least-privilege workflow tokens and pinned action SHAs
+- Secret scanning: `detect-secrets` and TruffleHog as `pre-commit` hooks,
+  GitGuardian on PRs
+- Least-privilege workflow tokens and SHA-pinned third-party actions
 
 ## CVE and Advisory Workflow
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,27 +32,29 @@ from this org, please name the consumer repo as well.
 ## Supported Versions
 
 This repository is a community health and reusable workflow library with
-continuous deployment on `main`. The `CHANGELOG.md` uses date-based version
-headers (for example, `[2025-01-07]`); there are no numbered releases or
-semver branches.
+continuous deployment on `main`. The `CHANGELOG.md` uses date-based
+version headers (for example, `[2025-01-07]`); there are no maintenance
+branches.
 
-| Version                                               | Supported |
-|-------------------------------------------------------|-----------|
-| `main` (latest commit)                                | Yes       |
-| Most recent dated release tag                         | Yes       |
-| Earlier dated tags / older pinned SHAs                | No        |
+| Version                                | Supported |
+|----------------------------------------|-----------|
+| `main` (latest commit)                 | Yes       |
+| `v1` moving major tag                  | Yes       |
+| Specific pinned SHAs                   | Only the latest SHA on `main` or on `v1` |
+| Older pinned SHAs and earlier tags     | No        |
 
 If you pin a workflow to a specific commit SHA, bump the pin to pick up
 security fixes. Older SHAs do not receive backports.
 
 ## Response Timeline
 
-| Stage                          | Target                  |
-|--------------------------------|-------------------------|
-| Acknowledgement of report      | 5 business days         |
-| Initial triage and severity    | 10 business days        |
-| Fix or mitigation for critical | 14 calendar days        |
-| Fix released (other severities)| 30 calendar days        |
+| Stage                                  | Target                  |
+|----------------------------------------|-------------------------|
+| Acknowledgement of report              | 5 business days         |
+| Triage and severity (non-critical)     | 10 business days        |
+| Triage and severity (critical)         | 2 business days         |
+| Fix or mitigation for critical reports | 14 calendar days from acknowledgement |
+| Fix released for other severities      | 30 calendar days from acknowledgement |
 
 These are targets, not guarantees. The maintainer will keep the reporter
 updated if a fix needs longer.
@@ -64,13 +66,15 @@ tool runs in every repo; the list reflects what is wired up in this
 repository's workflows and pre-commit hooks, which downstream repos
 inherit via the reusable workflows.
 
-- Static analysis: CodeQL (org-wide), Semgrep (via SonarCloud), Ruff and
-  Bandit (Python reusable workflows)
+- Static analysis: CodeQL (org-wide) and SonarCloud Quality Gate
+  (configured in `sonarcloud.yml` and the `python-sonarcloud.yml`
+  reusable workflow)
+- Python-specific static analysis: Ruff and Bandit (in the
+  `python-ci.yml` reusable workflow)
 - Dependency pinning and Renovate-driven updates
 - Container scanning with Trivy (Docker and SBOM workflows)
 - SBOM generation for tagged releases
-- Secret scanning: `detect-secrets` and TruffleHog as `pre-commit` hooks,
-  GitGuardian on PRs
+- Secret scanning: `detect-secrets` and TruffleHog as `pre-commit` hooks
 - Least-privilege workflow tokens and SHA-pinned third-party actions
 
 ## CVE and Advisory Workflow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,88 +2,82 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in any project under our organization,
-**please do not open a public issue**.
-Instead, use GitHub's built-in Security advisories feature:
+Do not open a public issue for security problems. Use one of these private
+channels:
 
-1. Go to the repository's **Security** tab
-2. Click **"Report a vulnerability"**
-3. Fill in the details and submit
+1. **GitHub Security Advisory** (preferred): go to the affected repository's
+   **Security** tab and click **Report a vulnerability**.
+2. **Email**: send details to **byronawilliams@gmail.com**. Use the subject
+   line `SECURITY:` followed by a short summary.
 
-All reports will be kept confidential. We commit to acknowledging receipt and
-next steps via the Security tab.
+Both channels are monitored by the maintainer. Reports remain confidential
+until a fix is published.
+
+## What to Include in a Report
+
+A useful report contains, at minimum:
+
+- A clear description of the issue and the security impact (what an attacker
+  can do).
+- The affected repository, file path, workflow, or commit SHA.
+- Steps to reproduce, including any inputs, environment, or configuration
+  needed.
+- A proof of concept if you have one (snippet, log, or test case).
+- Suggested fix or mitigation, if known.
+- Your contact details and whether you want public credit in the advisory.
+
+If the issue affects a downstream repository that consumes a reusable workflow
+from this org, please name the consumer repo as well.
 
 ## Supported Versions
 
-This repository is a shared workflow library with continuous deployment. There
-are no numbered releases; the `main` branch is always the supported version.
-Callers that pin to a specific commit SHA must update their pin to a newer
-commit on `main` to receive security fixes. Older commits may not contain the
-latest security patches.
+This repository is a community health and reusable workflow library. Releases
+are continuous on `main`; there are no long-term branches.
 
-## Security Practices
+| Version          | Supported          |
+|------------------|--------------------|
+| `main` (latest)  | Yes                |
+| Tagged releases  | Yes, latest minor  |
+| Pinned commit SHAs older than the latest minor release | No |
 
-We strive for proactive security across our codebases and infrastructure.
-Our standard practices include:
-
-- **Static Analysis** with CodeQL, Semgrep, Ruff, and Bandit
-- **Dependency Pinning** for reproducible builds
-- **Container Scanning** using Trivy
-- **SBOM Generation** for each release
-- **Secrets Detection** integrated in CI pipelines
-- **Hardened CI Runners** with minimal privileges
-
-## Security Surface Areas
-
-This repository is a GitHub Actions workflow library. Its security surface differs from
-application repos; there is no deployed service, but the workflows run with elevated
-permissions in every downstream repo that calls them.
-
-Primary attack surfaces and mitigations:
-
-- **Script injection via workflow inputs**: reusable workflows that interpolate
-  `${{ inputs.* }}` directly into `run:` blocks are vulnerable to injection if a caller
-  passes adversarial input. Mitigation: route all inputs through `env:` variables before
-  using in shell commands. Tracked with SonarCloud (githubactions:S7630).
-
-- **Overly broad token permissions**: workflows using `permissions: write-all` or setting
-  write grants at the workflow level rather than the job level violate least-privilege.
-  Mitigation: scope `permissions:` to the job level; request only the specific write
-  permission needed for each job. Tracked via OpenSSF Scorecard Token-Permissions check.
-
-- **Mutable action and workflow refs**: `uses:` fields referencing `@main`, `@v1`, or other
-  mutable tags allow upstream supply chain compromise. Mitigation: pin all external `uses:`
-  to a 40-character commit SHA. Renovate is configured to open SHA-bump PRs automatically.
-
-- **Unchecked caller inputs**: inputs from calling repos are not sanitized before use.
-  Mitigation: treat all inputs as untrusted; validate ranges and expected values in the
-  workflow before acting on them.
-
-## CVE & Advisory Workflow
-
-We track and publish advisories for all confirmed vulnerabilities:
-
-1. **Request a CVE** for issues rated Moderate or above.
-2. **Draft and publish an advisory** in the Security tab.
-3. **Include remediation steps** in the Security Advisory and CHANGELOG.
+If you pin a workflow to a specific commit SHA, you must bump the pin to pick
+up security fixes. Older SHAs do not receive backports.
 
 ## Response Timeline
 
-- **Acknowledgment:** within 5 business days
-- **Critical resolution:** We aim to provide a resolution or workaround within 14 calendar days for critical vulnerabilities.
-- **Fix released:** within 30 days of acknowledgment
-- **Emergency patch:** sooner for critical severity
+| Stage                          | Target                  |
+|--------------------------------|-------------------------|
+| Acknowledgement of report      | 5 business days         |
+| Initial triage and severity    | 10 business days        |
+| Fix or mitigation for critical | 14 calendar days        |
+| Fix released (other severities)| 30 calendar days        |
 
-## Disclosure Policy
+These are targets, not guarantees. The maintainer will keep the reporter
+updated if a fix needs longer.
 
-We follow coordinated disclosure principles. Once a fix is available, we will
-publish details in our Security Advisories page. If you wish to receive credit
-for responsibly disclosing a vulnerability, please let us know; otherwise
-credit will be anonymous.
+## Security Practices
 
-## Credit
+The org applies the following baseline across its repositories:
 
-This policy is based on community best practices and has drawn on elements from
-multiple sources within our organization's previous drafts.
+- Static analysis with CodeQL, Semgrep, Ruff, and Bandit
+- Dependency pinning and Renovate-driven updates
+- Container scanning with Trivy
+- SBOM generation for tagged releases
+- Secret scanning in CI (gitleaks, TruffleHog, detect-secrets)
+- Least-privilege workflow tokens and pinned action SHAs
 
-Last updated: April 23, 2026
+## CVE and Advisory Workflow
+
+For confirmed vulnerabilities rated Moderate or higher:
+
+1. Request a CVE through GitHub.
+2. Draft and publish a GitHub Security Advisory on the affected repository.
+3. Record remediation in the advisory and in the repository's CHANGELOG.
+
+## Disclosure
+
+The org follows coordinated disclosure. Public details are published in the
+advisory once a fix or mitigation is available. Reporters who want credit
+should say so in the report; otherwise credit is anonymous.
+
+Last updated: May 15, 2026

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,16 +32,15 @@ from this org, please name the consumer repo as well.
 ## Supported Versions
 
 This repository is a community health and reusable workflow library with
-continuous deployment on `main`. The `CHANGELOG.md` uses date-based
-version headers (for example, `[2025-01-07]`); there are no maintenance
-branches.
+continuous deployment on `main`. The `CHANGELOG.md` uses date-based section
+headers (for example, `[2025-01-07]`). Release tags follow semver; there are
+no long-term support branches.
 
-| Version                                | Supported |
-|----------------------------------------|-----------|
-| `main` (latest commit)                 | Yes       |
-| `v1` moving major tag                  | Yes       |
-| Specific pinned SHAs                   | Only the latest SHA on `main` or on `v1` |
-| Older pinned SHAs and earlier tags     | No        |
+| Version                                               | Supported |
+|-------------------------------------------------------|-----------|
+| `main` (latest commit)                                | Yes       |
+| Most recent release tag                               | Yes       |
+| Earlier release tags and older pinned SHAs            | No        |
 
 If you pin a workflow to a specific commit SHA, bump the pin to pick up
 security fixes. Older SHAs do not receive backports.
@@ -56,8 +55,9 @@ security fixes. Older SHAs do not receive backports.
 | Fix or mitigation for critical reports | 14 calendar days from acknowledgement |
 | Fix released for other severities      | 30 calendar days from acknowledgement |
 
-These are targets, not guarantees. The maintainer will keep the reporter
-updated if a fix needs longer.
+These are targets, not guarantees. The fix windows run from triage
+completion, not from the initial report date. The maintainer will keep the
+reporter updated if a fix needs longer.
 
 ## Security Practices
 
@@ -66,15 +66,13 @@ tool runs in every repo; the list reflects what is wired up in this
 repository's workflows and pre-commit hooks, which downstream repos
 inherit via the reusable workflows.
 
-- Static analysis: CodeQL (org-wide) and SonarCloud Quality Gate
-  (configured in `sonarcloud.yml` and the `python-sonarcloud.yml`
-  reusable workflow)
-- Python-specific static analysis: Ruff and Bandit (in the
-  `python-ci.yml` reusable workflow)
+- Static analysis: CodeQL (org-wide), SonarCloud (incorporates Semgrep rule
+  patterns), Ruff and Bandit (Python reusable workflows)
 - Dependency pinning and Renovate-driven updates
 - Container scanning with Trivy (Docker and SBOM workflows)
 - SBOM generation for tagged releases
-- Secret scanning: `detect-secrets` and TruffleHog as `pre-commit` hooks
+- Secret scanning: `detect-secrets` and TruffleHog as `pre-commit` hooks,
+  GitHub secret scanning (enabled by default on public repositories)
 - Least-privilege workflow tokens and SHA-pinned third-party actions
 
 ## CVE and Advisory Workflow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,9 +55,9 @@ security fixes. Older SHAs do not receive backports.
 | Fix or mitigation for critical reports | 14 calendar days from acknowledgement |
 | Fix released for other severities      | 30 calendar days from acknowledgement |
 
-These are targets, not guarantees. The fix windows run from triage
-completion, not from the initial report date. The maintainer will keep the
-reporter updated if a fix needs longer.
+These are targets, not guarantees. All windows run from acknowledgement of
+the report. The maintainer will keep the reporter updated if a fix needs
+longer.
 
 ## Security Practices
 
@@ -66,8 +66,8 @@ tool runs in every repo; the list reflects what is wired up in this
 repository's workflows and pre-commit hooks, which downstream repos
 inherit via the reusable workflows.
 
-- Static analysis: CodeQL (org-wide), SonarCloud (incorporates Semgrep rule
-  patterns), Ruff and Bandit (Python reusable workflows)
+- Static analysis: CodeQL (org-wide), SonarCloud (SAST); downstream Python
+  repos add Ruff and Bandit via the Python reusable workflows
 - Dependency pinning and Renovate-driven updates
 - Container scanning with Trivy (Docker and SBOM workflows)
 - SBOM generation for tagged releases


### PR DESCRIPTION
## Summary

Quality pass on the org-level community health files. These apply to all repos in the org that do not provide their own versions.

### SECURITY.md
- Supported-versions **table** (was prose); now reflects real tags (`v1.0.0`, `v1`) rather than a fictional "date-based release tag" scheme.
- Added **byronawilliams@gmail.com** as an alternate reporting channel.
- Added a **"What to Include in a Report"** section.
- **Security Practices** section rewritten to match tooling that is actually wired up here: CodeQL, SonarCloud, Ruff, Bandit, Trivy, `detect-secrets`, TruffleHog. Removed gitleaks (not used), GitGuardian (no workflow in this repo), and "Semgrep" framed as an active scanner (only `nosemgrep:` suppression comments exist).
- **Response Timeline** rebuilt as a table; critical-fix target is now 14 calendar days *from acknowledgement* (not from end of triage), and critical-issue triage is shortened to 2 business days to remove the overlap.
- Trimmed boilerplate Credit section.

### CONTRIBUTING.md
- Documented the **full branch-naming convention** (`feature/`, `fix/`, `chore/`, `docs/`, and a reserved `claude/` for automated agents).
- Added an explicit **PR checklist** (signing, hooks, tests, scope).
- Added a **Code Review Expectations** section.
- Replaced the DCO `Signed-off-by` requirement with an explicit **GPG-signed commits required** section. Wording clarified: branch protection enforces signing at merge to `main`, not at push to a feature branch.
- Setup section reframed: pre-commit step is universal; Python and shell/bats setups shown as examples. Clone instructions now include the **fork step** for external contributors.

### CODE_OF_CONDUCT.md
- Kept the Contributor Covenant v2.1 base.
- Reporting now goes to **byronawilliams@gmail.com** only; removed the Security Advisory link (wrong channel for conduct reports) and cross-linked to SECURITY.md for vulnerabilities.

### GOVERNANCE.md
- Rewrote to match reality. The previous version described a Project Lead, Core Team, and Maintainers, which is fiction for a sole-maintainer org.
- New version: sole-maintainer note, day-to-day vs larger-change decision process (with a 7-day comment window for breaking changes), how to propose a change, and a brief succession note.
- Dropped hard references to specific issue templates and a `governance` label, since neither is guaranteed to exist on every downstream repo.

## Test plan
- [x] No em-dashes (`scripts/check-no-em-dash.sh` passes on staged files).
- [x] `markdownlint` clean against `.markdownlint.yml`.
- [x] All four files render correctly in the GitHub preview.
- [x] SonarCloud Quality Gate passing.
- [x] Branch rebased onto latest `main` (was one commit behind; new tip in `main` only touched workflow YAML, no overlap).
- [ ] Reviewer: confirm `byronawilliams@gmail.com` is the correct contact address to publish.
- [ ] Reviewer: confirm GPG-signing is enforced by branch protection on downstream repos before this lands as an org-wide promise.
