### PR TITLE
feat(workflows): add no-build opt-out input to all reusable workflows

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -105,6 +105,12 @@ on:
         type: boolean
         default: true
 
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
+
 permissions: {}
 
 jobs:
@@ -117,6 +123,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 15
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
 
     outputs:
       coverage-artifact: coverage-reports
@@ -144,7 +152,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras --frozen
+          uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Run Ruff formatter check
         env:
@@ -152,8 +160,8 @@ jobs:
           TEST_DIR: ${{ inputs.test-directory }}
         run: |
           echo "::group::Ruff Formatting"
-          uv run --frozen --no-build ruff format --check "$SRC_DIR"/ "$TEST_DIR"/ || {
-            echo "::error::Code formatting issues detected. Run: uv run --frozen --no-build ruff format ${SRC_DIR}/ ${TEST_DIR}/"
+          uv run --frozen $NO_BUILD_FLAG ruff format --check "$SRC_DIR"/ "$TEST_DIR"/ || {
+            echo "::error::Code formatting issues detected. Run: uv run --frozen $NO_BUILD_FLAG ruff format ${SRC_DIR}/ ${TEST_DIR}/"
             exit 1
           }
           echo "::endgroup::"
@@ -164,7 +172,7 @@ jobs:
           TEST_DIR: ${{ inputs.test-directory }}
         run: |
           echo "::group::Ruff Linting"
-          uv run --frozen --no-build ruff check "$SRC_DIR"/ "$TEST_DIR"/ --output-format=github
+          uv run --frozen $NO_BUILD_FLAG ruff check "$SRC_DIR"/ "$TEST_DIR"/ --output-format=github
           echo "::endgroup::"
 
       - name: Run BasedPyright type checker
@@ -172,7 +180,7 @@ jobs:
           SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::BasedPyright Type Checking"
-          uv run --frozen --no-build basedpyright "$SRC_DIR"/ || {
+          uv run --frozen $NO_BUILD_FLAG basedpyright "$SRC_DIR"/ || {
             echo "::warning::Type checking found issues"
           }
           echo "::endgroup::"
@@ -193,7 +201,7 @@ jobs:
           echo "Scanning for dead code (min confidence: $DEAD_CODE_CONFIDENCE%)..."
 
           # Capture output for reporting
-          VULTURE_OUTPUT=$(uv run --frozen --no-build vulture "$SRC_DIR"/ --min-confidence "$DEAD_CODE_CONFIDENCE" 2>&1) || true
+          VULTURE_OUTPUT=$(uv run --frozen $NO_BUILD_FLAG vulture "$SRC_DIR"/ --min-confidence "$DEAD_CODE_CONFIDENCE" 2>&1) || true
 
           if [ -n "$VULTURE_OUTPUT" ]; then
             echo "$VULTURE_OUTPUT"
@@ -234,7 +242,7 @@ jobs:
           SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "::group::Unit Test Execution"
-          uv run --frozen --no-build pytest \
+          uv run --frozen $NO_BUILD_FLAG pytest \
             -m "unit or not (integration or security or slow)" \
             --cov="$SRC_DIR" \
             --cov-report=xml:coverage-unit.xml \
@@ -252,7 +260,7 @@ jobs:
         run: |
           echo "::group::Integration Test Execution"
           set +e
-          uv run --frozen --no-build pytest \
+          uv run --frozen $NO_BUILD_FLAG pytest \
             -m "integration" \
             --cov="$SRC_DIR" \
             --cov-report=xml:coverage-integration.xml \
@@ -274,7 +282,7 @@ jobs:
         run: |
           echo "::group::Security Test Execution"
           set +e
-          uv run --frozen --no-build pytest \
+          uv run --frozen $NO_BUILD_FLAG pytest \
             -m "security" \
             --cov="$SRC_DIR" \
             --cov-report=xml:coverage-security.xml \
@@ -294,10 +302,10 @@ jobs:
           COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
         run: |
           echo "::group::Combined Coverage"
-          uv run --frozen --no-build coverage combine --keep || true
-          uv run --frozen --no-build coverage xml -o coverage.xml
-          uv run --frozen --no-build coverage html
-          uv run --frozen --no-build coverage report --fail-under="$COVERAGE_THRESHOLD"
+          uv run --frozen $NO_BUILD_FLAG coverage combine --keep || true
+          uv run --frozen $NO_BUILD_FLAG coverage xml -o coverage.xml
+          uv run --frozen $NO_BUILD_FLAG coverage html
+          uv run --frozen $NO_BUILD_FLAG coverage report --fail-under="$COVERAGE_THRESHOLD"
           echo "::endgroup::"
 
       - name: Security scan with Bandit
@@ -308,9 +316,9 @@ jobs:
           echo "::group::Bandit Security Scan"
           # -lll filters to HIGH severity only; non-zero exit on findings.
           if [ "$FAIL_ON_FINDINGS" = "true" ]; then
-            uv run --frozen --no-build bandit -r "$SRC_DIR"/ -c pyproject.toml -lll -f json -o bandit-report.json
+            uv run --frozen $NO_BUILD_FLAG bandit -r "$SRC_DIR"/ -c pyproject.toml -lll -f json -o bandit-report.json
           else
-            uv run --frozen --no-build bandit -r "$SRC_DIR"/ -c pyproject.toml -lll -f json -o bandit-report.json || {
+            uv run --frozen $NO_BUILD_FLAG bandit -r "$SRC_DIR"/ -c pyproject.toml -lll -f json -o bandit-report.json || {
               echo "::warning::HIGH-severity security issues detected (fail-on-security-findings=false; not failing CI)"
               cat bandit-report.json
             }
@@ -330,9 +338,9 @@ jobs:
             IGNORE_ARGS=$(python3 -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); ids=d.get('tool',{}).get('pip-audit',{}).get('ignore-vuln',[]); print(' '.join('--ignore-vuln '+i for i in ids))" 2>/dev/null || true)
           fi
           if [ "$FAIL_ON_FINDINGS" = "true" ]; then
-            uv run --frozen --no-build pip-audit $IGNORE_ARGS
+            uv run --frozen $NO_BUILD_FLAG pip-audit $IGNORE_ARGS
           else
-            uv run --frozen --no-build pip-audit $IGNORE_ARGS || echo "::warning::Vulnerable dependencies detected (fail-on-security-findings=false; not failing CI)"
+            uv run --frozen $NO_BUILD_FLAG pip-audit $IGNORE_ARGS || echo "::warning::Vulnerable dependencies detected (fail-on-security-findings=false; not failing CI)"
           fi
           echo "::endgroup::"
 
@@ -507,6 +515,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 15
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
 
     strategy:
       fail-fast: false
@@ -533,7 +543,7 @@ jobs:
         run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Run tests
         env:
@@ -541,7 +551,7 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           echo "::group::Testing on Python $PYTHON_VERSION"
-          uv run --frozen --no-build pytest \
+          uv run --frozen $NO_BUILD_FLAG pytest \
             --cov="$SRC_DIR" \
             --cov-report=term-missing \
             -v

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -119,6 +119,11 @@ on:
         type: string
         required: false
         default: ''
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
     outputs:
       matrix-result:
@@ -178,6 +183,8 @@ jobs:
     needs: build-matrix
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: read
     # Skip expensive matrix on draft PRs unless explicitly disabled
@@ -255,7 +262,7 @@ jobs:
         shell: pwsh
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Run tests
         id: tests
@@ -270,13 +277,13 @@ jobs:
 
           if [ "$COVERAGE_REPORT" == "true" ]; then
             # shellcheck disable=SC2086
-            uv run --frozen --no-build $TEST_COMMAND \
+            uv run --frozen $NO_BUILD_FLAG $TEST_COMMAND \
               --cov="$SRC_DIR" \
               --cov-report=xml:coverage-${MATRIX_PYTHON}-${MATRIX_OS}.xml \
               --cov-report=term-missing
           else
             # shellcheck disable=SC2086
-            uv run --frozen --no-build $TEST_COMMAND
+            uv run --frozen $NO_BUILD_FLAG $TEST_COMMAND
           fi
         shell: bash
 

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -263,6 +263,7 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --all-extras --frozen $NO_BUILD_FLAG
+        shell: bash
 
       - name: Run tests
         id: tests

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -46,6 +46,11 @@ on:
         type: number
         required: false
         default: 80
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -54,6 +59,8 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: read
 
@@ -80,7 +87,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Check docstring coverage
         env:
@@ -88,14 +95,14 @@ jobs:
           DOCSTRING_THRESHOLD: ${{ inputs.docstring-threshold }}
         run: |
           echo "📝 Checking docstring coverage..."
-          uv run --frozen --no-build interrogate "$SRC_DIR" \
+          uv run --frozen $NO_BUILD_FLAG interrogate "$SRC_DIR" \
             --fail-under="$DOCSTRING_THRESHOLD" \
             --verbose || echo "⚠️  Docstring coverage below threshold"
 
       - name: Build MkDocs site
         run: |
           echo "🏗️  Building documentation site..."
-          uv run --frozen --no-build mkdocs build --strict --verbose
+          uv run --frozen $NO_BUILD_FLAG mkdocs build --strict --verbose
 
       - name: Upload documentation artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/python-fips-compatibility.yml
+++ b/.github/workflows/python-fips-compatibility.yml
@@ -72,6 +72,11 @@ on:
         type: boolean
         required: false
         default: false
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -83,6 +88,8 @@ jobs:
       contents: read
       pull-requests: write
     timeout-minutes: 15
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
 
     steps:
       - name: Harden Runner
@@ -143,7 +150,7 @@ jobs:
 
           # Run check and capture output
           set +e
-          uv run --frozen --no-build python "$SCRIPT_PATH" \
+          uv run --frozen $NO_BUILD_FLAG python "$SCRIPT_PATH" \
             $FIX_HINTS_FLAG \
             $INCLUDE_TESTS_FLAG \
             $STRICT_FLAG \
@@ -152,7 +159,7 @@ jobs:
           set -e
 
           # Also generate JSON report
-          uv run --frozen --no-build python "$SCRIPT_PATH" \
+          uv run --frozen $NO_BUILD_FLAG python "$SCRIPT_PATH" \
             --json \
             $INCLUDE_TESTS_FLAG \
             > fips-report.json 2>/dev/null || true
@@ -338,6 +345,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
 
     steps:
       - name: Harden Runner
@@ -359,13 +368,13 @@ jobs:
         run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Test crypto imports in simulated FIPS mode
         run: |
           # This tests if the code can import without using non-FIPS algorithms
           # Note: Full FIPS testing requires an actual FIPS-enabled kernel
-          uv run --frozen --no-build python -c "
+          uv run --frozen $NO_BUILD_FLAG python -c "
           import os
           import sys
 

--- a/.github/workflows/python-mutation.yml
+++ b/.github/workflows/python-mutation.yml
@@ -91,6 +91,11 @@ on:
         type: number
         required: false
         default: 14
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
     outputs:
       mutation-score:
@@ -107,6 +112,8 @@ jobs:
     name: Mutation Testing
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: read
       pull-requests: write
@@ -135,7 +142,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras --frozen
+          uv sync --all-extras --frozen $NO_BUILD_FLAG
           uv pip install --no-build 'mutmut==2.5.1'
 
       - name: Run mutation testing
@@ -147,15 +154,15 @@ jobs:
           echo "Starting mutation testing on $SOURCE_DIRECTORY..."
 
           # Run mutmut with configurable paths
-          uv run --frozen --no-build mutmut run \
+          uv run --frozen $NO_BUILD_FLAG mutmut run \
             --paths-to-mutate="$SOURCE_DIRECTORY" \
             --tests-dir="$TEST_DIRECTORY" \
             --no-progress \
             || true
 
           # Generate reports
-          uv run --frozen --no-build mutmut results > mutmut-results.txt || true
-          uv run --frozen --no-build mutmut html || true
+          uv run --frozen $NO_BUILD_FLAG mutmut results > mutmut-results.txt || true
+          uv run --frozen $NO_BUILD_FLAG mutmut html || true
 
       - name: Analyze mutation results
         id: analyze

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -139,6 +139,11 @@ on:
         type: boolean
         required: false
         default: true
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -147,6 +152,8 @@ jobs:
     name: Performance Regression Check
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: read
       pull-requests: write
@@ -179,9 +186,9 @@ jobs:
             while IFS= read -r dep; do
               [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
             done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen
+            uv sync "${EXTRA_ARGS[@]}" --frozen $NO_BUILD_FLAG
           else
-            uv sync --frozen
+            uv sync --frozen $NO_BUILD_FLAG
           fi
 
       - name: Generate Synthetic Test Data
@@ -190,7 +197,7 @@ jobs:
           TEST_DATA_DIR: ${{ inputs.test-data-directory }}
         run: |
           mkdir -p "$TEST_DATA_DIR"
-          uv run --frozen --no-build python scripts/generate_test_data.py
+          uv run --frozen $NO_BUILD_FLAG python scripts/generate_test_data.py
           echo "Synthetic test data generated in $TEST_DATA_DIR"
           ls -lh "$TEST_DATA_DIR" | head -20
 
@@ -221,14 +228,14 @@ jobs:
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          if uv run --frozen --no-build python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
             echo "ℹ️  Script supports --output argument"
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          if uv run --frozen --no-build python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
             echo "ℹ️  Script supports --warmup/--iterations arguments"
           fi
@@ -237,7 +244,7 @@ jobs:
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # Full interface support
             # shellcheck disable=SC2086
-            uv run --frozen --no-build python "$BENCHMARK_SCRIPT" \
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --warmup "$WARMUP_ITERATIONS" \
               --iterations "$BENCHMARK_ITERATIONS" \
               --output /tmp/pr_benchmark.json \
@@ -248,7 +255,7 @@ jobs:
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # Only --output supported
             # shellcheck disable=SC2086
-            uv run --frozen --no-build python "$BENCHMARK_SCRIPT" \
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --output /tmp/pr_benchmark.json \
               $BENCHMARK_ARGS || {
                 echo "⚠️ Benchmark execution failed, creating fallback results"
@@ -258,7 +265,7 @@ jobs:
             # Minimal interface - capture stdout as JSON
             echo "ℹ️  Script uses stdout for output (no --output flag)"
             # shellcheck disable=SC2086
-            uv run --frozen --no-build python "$BENCHMARK_SCRIPT" \
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               $BENCHMARK_ARGS > /tmp/pr_benchmark.json 2>&1 || {
                 echo "⚠️ Benchmark execution failed, creating fallback results"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
@@ -309,27 +316,27 @@ jobs:
             while IFS= read -r dep; do
               [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
             done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen
+            uv sync "${EXTRA_ARGS[@]}" --frozen $NO_BUILD_FLAG
           else
-            uv sync --frozen
+            uv sync --frozen $NO_BUILD_FLAG
           fi
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          if uv run --frozen --no-build python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          if uv run --frozen --no-build python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
           fi
 
           # Run benchmark with detected capabilities
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # shellcheck disable=SC2086
-            uv run --frozen --no-build python "$BENCHMARK_SCRIPT" \
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --warmup "$WARMUP_ITERATIONS" \
               --iterations "$BENCHMARK_ITERATIONS" \
               --output /tmp/baseline_benchmark.json \
@@ -339,7 +346,7 @@ jobs:
               }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # shellcheck disable=SC2086
-            uv run --frozen --no-build python "$BENCHMARK_SCRIPT" \
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --output /tmp/baseline_benchmark.json \
               $BENCHMARK_ARGS || {
                 echo "⚠️ Baseline benchmark failed, using fallback"
@@ -347,7 +354,7 @@ jobs:
               }
           else
             # shellcheck disable=SC2086
-            uv run --frozen --no-build python "$BENCHMARK_SCRIPT" \
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               $BENCHMARK_ARGS > /tmp/baseline_benchmark.json 2>&1 || {
                 echo "⚠️ Baseline benchmark failed, using fallback"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
@@ -376,7 +383,7 @@ jobs:
           IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
           FAIL_ON_REGRESSION: ${{ inputs.fail-on-regression }}
         run: |
-          uv run --frozen --no-build python - <<'EOF'
+          uv run --frozen $NO_BUILD_FLAG python - <<'EOF'
           import json
           import os
           import sys
@@ -546,7 +553,7 @@ jobs:
 
             To reproduce locally:
             \`\`\`bash
-            uv run --frozen --no-build python ${benchmarkScript} --iterations 1000 ${benchmarkArgs}
+            uv run --frozen $NO_BUILD_FLAG python ${benchmarkScript} --iterations 1000 ${benchmarkArgs}
             \`\`\`
             </details>
             `;

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -482,6 +482,7 @@ jobs:
           BASELINE_SOURCE: ${{ steps.baseline_source.outputs.source }}
           BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
           BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
+          NO_BUILD_FLAG: ${{ env.NO_BUILD_FLAG }}
         with:
           script: |
             const baseline = process.env.COMPARE_BASELINE;
@@ -495,6 +496,7 @@ jobs:
             const baselineSource = process.env.BASELINE_SOURCE;
             const benchmarkScript = process.env.BENCHMARK_SCRIPT;
             const benchmarkArgs = process.env.BENCHMARK_ARGS;
+            const noBuildFlag = process.env.NO_BUILD_FLAG || '';
 
             let icon, statusText, actionText;
             if (status === 'regression') {
@@ -553,7 +555,7 @@ jobs:
 
             To reproduce locally:
             \`\`\`bash
-            uv run --frozen $NO_BUILD_FLAG python ${benchmarkScript} --iterations 1000 ${benchmarkArgs}
+            uv run --frozen ${noBuildFlag} python ${benchmarkScript} --iterations 1000 ${benchmarkArgs}
             \`\`\`
             </details>
             `;

--- a/.github/workflows/python-precommit.yml
+++ b/.github/workflows/python-precommit.yml
@@ -39,6 +39,11 @@ on:
         type: boolean
         required: false
         default: true
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -47,6 +52,8 @@ jobs:
     name: Pre-Commit Hooks
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: read
 
@@ -67,7 +74,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen $NO_BUILD_FLAG
 
       - name: Run pre-commit hooks
         env:
@@ -75,9 +82,9 @@ jobs:
           FAIL_FAST: ${{ inputs.fail-fast }}
         run: |
           if [ "$FAIL_FAST" = "true" ]; then
-            uv run --frozen --no-build pre-commit run --all-files --config "$CONFIG_PATH" --show-diff-on-failure
+            uv run --frozen $NO_BUILD_FLAG pre-commit run --all-files --config "$CONFIG_PATH" --show-diff-on-failure
           else
-            uv run --frozen --no-build pre-commit run --all-files --config "$CONFIG_PATH"
+            uv run --frozen $NO_BUILD_FLAG pre-commit run --all-files --config "$CONFIG_PATH"
           fi
 
       - name: Pre-Commit Summary
@@ -90,5 +97,5 @@ jobs:
           else
             echo "One or more pre-commit hooks failed. Review the output above." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "To run locally: \`uv run --frozen --no-build pre-commit run --all-files\`" >> $GITHUB_STEP_SUMMARY
+            echo "To run locally: \`uv run --frozen $NO_BUILD_FLAG pre-commit run --all-files\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -97,6 +97,11 @@ on:
         required: false
         type: boolean
         default: true
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
     outputs:
       released:
         description: 'Whether a release was created'
@@ -121,6 +126,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 15
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99  # v2.19.2
@@ -143,14 +150,14 @@ jobs:
         run: uv python install "$PYTHON_VERSION"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Run tests
         env:
           SRC_DIR: ${{ inputs.source-directory }}
           COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
         run: |
-          uv run --frozen --no-build pytest \
+          uv run --frozen $NO_BUILD_FLAG pytest \
             --cov="$SRC_DIR" \
             --cov-report=term-missing \
             --cov-fail-under="$COVERAGE_THRESHOLD" \
@@ -159,12 +166,12 @@ jobs:
       - name: Run type checker
         env:
           SRC_DIR: ${{ inputs.source-directory }}
-        run: uv run --frozen --no-build basedpyright "$SRC_DIR/"
+        run: uv run --frozen $NO_BUILD_FLAG basedpyright "$SRC_DIR/"
 
       - name: Run linter
         env:
           SRC_DIR: ${{ inputs.source-directory }}
-        run: uv run --frozen --no-build ruff check "$SRC_DIR/"
+        run: uv run --frozen $NO_BUILD_FLAG ruff check "$SRC_DIR/"
 
   # ============================================================================
   # Job 2: Build and Create Release
@@ -175,6 +182,8 @@ jobs:
     if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: write
       id-token: write
@@ -222,7 +231,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Build package
         run: |

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -58,6 +58,11 @@ on:
         required: false
         type: string
         default: '.trivyignore'
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
     # Optional secrets - callers may pass these even if unused by this workflow
     # This prevents startup_failure when callers pass extra secrets
@@ -87,6 +92,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99  # v2.19.2
@@ -111,7 +118,7 @@ jobs:
         run: uv pip install --no-build 'cyclonedx-bom==7.3.0'
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen $NO_BUILD_FLAG
 
       - name: Generate runtime SBOM (production dependencies)
         run: |

--- a/.github/workflows/python-scorecard.yml
+++ b/.github/workflows/python-scorecard.yml
@@ -101,9 +101,12 @@ jobs:
           persist-credentials: false
 
       - name: Warn if SCORECARD_TOKEN is absent
-        if: ${{ secrets.SCORECARD_TOKEN == '' }}  # pragma: allowlist secret
-        run: |  # pragma: allowlist secret
-          echo "::warning::SCORECARD_TOKEN not passed; Branch-Protection will score 0. Pass SCORECARD_TOKEN via the secrets: block -- requires a fine-grained PAT with Administration:Read on the calling repository."  # pragma: allowlist secret
+        env:
+          HAS_SCORECARD_TOKEN: ${{ secrets.SCORECARD_TOKEN }}  # pragma: allowlist secret
+        run: |
+          if [ -z "$HAS_SCORECARD_TOKEN" ]; then
+            echo "::warning::SCORECARD_TOKEN not passed; Branch-Protection will score 0. Pass SCORECARD_TOKEN via the secrets: block; requires a fine-grained PAT with Administration:Read on the calling repository."  # pragma: allowlist secret
+          fi
 
       - name: Warn on deprecated publish-results input
         if: ${{ inputs.publish-results == true }}

--- a/.github/workflows/python-scorecard.yml
+++ b/.github/workflows/python-scorecard.yml
@@ -100,6 +100,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Warn if SCORECARD_TOKEN is absent
+        if: ${{ secrets.SCORECARD_TOKEN == '' }}  # pragma: allowlist secret
+        run: |  # pragma: allowlist secret
+          echo "::warning::SCORECARD_TOKEN not passed; Branch-Protection will score 0. Pass SCORECARD_TOKEN via the secrets: block -- requires a fine-grained PAT with Administration:Read on the calling repository."  # pragma: allowlist secret
+
       - name: Warn on deprecated publish-results input
         if: ${{ inputs.publish-results == true }}
         run: |

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -67,6 +67,11 @@ on:
         type: boolean
         required: false
         default: true
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -115,6 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     timeout-minutes: 20
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: read
       security-events: write
@@ -140,7 +147,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --no-dev --frozen
+        run: uv sync --no-dev --frozen $NO_BUILD_FLAG
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
@@ -199,6 +206,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     timeout-minutes: 15
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     permissions:
       contents: read
       pull-requests: read
@@ -223,7 +232,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
       - name: Bandit Static Analysis
         if: ${{ inputs.run-bandit }}
@@ -231,20 +240,20 @@ jobs:
           SRC_DIR: ${{ inputs.source-directory }}
         run: |
           echo "🔒 Running Bandit security analysis..."
-          uv run --frozen --no-build bandit -r "$SRC_DIR" \
+          uv run --frozen $NO_BUILD_FLAG bandit -r "$SRC_DIR" \
             -f json -o bandit-report.json \
             -c pyproject.toml || true
-          uv run --frozen --no-build bandit -r "$SRC_DIR" -c pyproject.toml
+          uv run --frozen $NO_BUILD_FLAG bandit -r "$SRC_DIR" -c pyproject.toml
 
       - name: Safety Vulnerability Scan
         if: ${{ inputs.run-safety }}
         run: |
           echo "🛡️ Scanning dependencies for vulnerabilities..."
           uv export --format requirements-txt --no-hashes --output-file requirements-scan.txt
-          uv run --frozen --no-build safety check \
+          uv run --frozen $NO_BUILD_FLAG safety check \
             --file requirements-scan.txt \
             --json --output safety-report.json || true
-          uv run --frozen --no-build safety check --file requirements-scan.txt
+          uv run --frozen $NO_BUILD_FLAG safety check --file requirements-scan.txt
 
       - name: Upload Security Reports
         if: always()

--- a/.github/workflows/python-sonarcloud.yml
+++ b/.github/workflows/python-sonarcloud.yml
@@ -144,6 +144,11 @@ on:
         type: number
         required: false
         default: 7
+      no-build:
+        description: 'Pass --no-build to uv sync/run commands (disable for projects with a build backend like hatchling)'
+        required: false
+        type: boolean
+        default: true
 
     secrets:
       SONAR_TOKEN:
@@ -204,6 +209,8 @@ jobs:
       contents: read
       pull-requests: write
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
 
     steps:
       - name: Harden Runner
@@ -231,15 +238,15 @@ jobs:
           EXTRA_DEPENDENCIES: ${{ inputs.extra-dependencies }}
         run: |
           if [ "$EXTRA_DEPENDENCIES" == "all" ]; then
-            uv sync --all-extras --frozen
+            uv sync --all-extras --frozen $NO_BUILD_FLAG
           elif [ -n "$EXTRA_DEPENDENCIES" ]; then
             EXTRA_ARGS=()
             while IFS= read -r dep; do
               [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
             done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen
+            uv sync "${EXTRA_ARGS[@]}" --frozen $NO_BUILD_FLAG
           else
-            uv sync --frozen
+            uv sync --frozen $NO_BUILD_FLAG
           fi
 
       - name: Run tests with coverage
@@ -259,7 +266,7 @@ jobs:
           fi
 
           # Run pytest with coverage
-          uv run --frozen --no-build pytest \
+          uv run --frozen $NO_BUILD_FLAG pytest \
             --cov="$COV_SRC" \
             --cov-report=xml:coverage.xml \
             --cov-report=term \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,14 @@ repos:
   # ============================================================================
   # Secret Detection - TruffleHog
   # ============================================================================
-  - repo: local
+  # Scan staged files only. The git-history mode also traverses fetched remote
+  # branches in the local object store, producing false positives from unmerged
+  # branches. Staged-file scanning is the correct scope for a pre-commit hook;
+  # full git history scanning belongs in CI.
+  # --results=verified,unknown: report only credentials that are confirmed live
+  # or indeterminate; skip detector-level false positives.
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: 05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f  # v3.92.3 # pragma: allowlist secret
     hooks:
       - id: trufflehog
         name: TruffleHog Secret Scanner

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,12 +70,10 @@ repos:
       - id: trufflehog
         name: TruffleHog Secret Scanner
         description: Detect secrets in your data before committing
-        # Scan staged files only. The git-history mode (--since-commit HEAD) also
-        # traverses fetched remote branches in the local object store, producing
-        # false positives from unmerged branches. Staged-file scanning is the
-        # correct scope for a pre-commit hook; git history scanning belongs in CI.
+        # Overrides upstream git-history scan with staged-file filesystem scan.
+        # --results=verified,unknown includes indeterminate credentials (upstream
+        # default is --results=verified only). Git history scanning belongs in CI.
         entry: bash -c 'command -v trufflehog >/dev/null 2>&1 && (git diff --cached -z --diff-filter=d --name-only 2>/dev/null | xargs -0 -r trufflehog filesystem --fail --no-update --results=verified,unknown --exclude-paths .trufflehog-exclude) || echo "TruffleHog not installed - skipping secret scan"'
-        language: system
         pass_filenames: false
         stages: [pre-commit]
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -123,6 +127,15 @@
     }
   ],
   "results": {
+    ".github/workflows/python-scorecard.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/python-scorecard.yml",
+        "hashed_secret": "7488f05aa3fccb372410547cefd8f72d4d142f0a",
+        "is_verified": false,
+        "line_number": 106
+      }
+    ],
     ".pre-commit-config.yaml": [
       {
         "type": "Hex High Entropy String",
@@ -161,5 +174,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T01:01:58Z"
+  "generated_at": "2026-05-15T22:53:29Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ are no numbered releases.
 
 ### Fixed
 
+- `python-performance-regression.yml`: fix `$NO_BUILD_FLAG` reference in the `Post PR Comment` step; the flag appeared as a literal string in the PR body because the step uses `actions/github-script` (JavaScript), not bash; add `NO_BUILD_FLAG` to the step `env:` block and use `${noBuildFlag}` (via `process.env.NO_BUILD_FLAG`) in the template literal
 - `python-scorecard.yml`: replace `if: ${{ secrets.SCORECARD_TOKEN == '' }}` guard with an env-var + shell check pattern (`[ -z "$HAS_SCORECARD_TOKEN" ]`); direct secret comparison in `if:` expressions is unreliable in GitHub Actions (runner issue #520) because secrets are redacted before expression evaluation
 - `python-compatibility.yml`: add `shell: bash` to the `Install dependencies` step to prevent silent failure on Windows matrix legs where the default shell is PowerShell and `$NO_BUILD_FLAG` expands to nothing
 - `python-slsa.yml`, `python-standard-stack.yml`, `scorecard.yml`, `security-analysis.yml`: remove `timeout-minutes` from 6 reusable-workflow-call jobs (`provenance`, `ci`, `security`, `sbom`, `scorecard`); GitHub Actions disallows `timeout-minutes` on jobs that use `uses:`, causing actionlint CI failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ are no numbered releases.
 
 ### Added
 
+- All 11 reusable Python workflows: `no-build` boolean input (default `true`) controls whether `--no-build` is passed to `uv sync`/`uv run` commands; allows repos with a build backend (hatchling, setuptools) to opt out of the flag that prevented local package installation; routed through a job-level `NO_BUILD_FLAG` env var so callers need only set `no-build: false` in their `with:` block
+- `SECURITY.md`: Security Surface Areas section documenting the threat model for this workflow library
 - `python-precommit.yml`: new reusable workflow that runs `pre-commit run --all-files` in the project virtualenv via `uv run`; inputs `config-path`, `python-version`, `fail-fast`; all inputs via env vars; SHA-pinned actions
 - `python-standard-stack.yml`: new composite reusable workflow chaining `python-ci.yml`, `python-security-analysis.yml`, and `python-sbom.yml` via `needs:`; recommended quickstart for new repos; exposes `python-version`, `source-directory`, `coverage-threshold`, `fail-on-high`; optional `SONAR_TOKEN`/`CODECOV_TOKEN` passthroughs
 - `python-supplemental-checks.yml`: `enable-commit-lint` input (default false) that validates PR titles against Conventional Commits format via SHA-pinned `amannn/action-semantic-pull-request`; commit-lint status added to supplemental summary
@@ -57,6 +59,8 @@ are no numbered releases.
 
 ### Fixed
 
+- `python-scorecard.yml`: replace `if: ${{ secrets.SCORECARD_TOKEN == '' }}` guard with an env-var + shell check pattern (`[ -z "$HAS_SCORECARD_TOKEN" ]`); direct secret comparison in `if:` expressions is unreliable in GitHub Actions (runner issue #520) because secrets are redacted before expression evaluation
+- `python-compatibility.yml`: add `shell: bash` to the `Install dependencies` step to prevent silent failure on Windows matrix legs where the default shell is PowerShell and `$NO_BUILD_FLAG` expands to nothing
 - `python-slsa.yml`, `python-standard-stack.yml`, `scorecard.yml`, `security-analysis.yml`: remove `timeout-minutes` from 6 reusable-workflow-call jobs (`provenance`, `ci`, `security`, `sbom`, `scorecard`); GitHub Actions disallows `timeout-minutes` on jobs that use `uses:`, causing actionlint CI failure
 - `python-scorecard.yml`: hard-code `publish_results: false` in the `ossf/scorecard-action` step and remove `id-token: write` from the workflow permissions; the OIDC token `repository` claim resolves to the `.github` org repo when the workflow runs as a reusable callee, causing scorecard-action to publish to the wrong repository and error; the `publish-results` input is retained for backwards compatibility but is now deprecated and always treated as false; SARIF upload to the Security tab is unaffected
 - `scorecard.yml`: remove `publish-results: true` and `id-token: write` from the `.github` org repo's own scorecard caller to align with the reusable workflow fix
@@ -80,6 +84,7 @@ are no numbered releases.
 
 ### Security
 
+- `.pre-commit-config.yaml`: upgrade TruffleHog from `repo: local` with a pinned system binary to `repo: https://github.com/trufflesecurity/trufflehog` at SHA `05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f` (v3.92.3); upstream repo is the recommended distribution channel; adds `scorecard.yml` warning about the `SCORECARD_TOKEN` scope requirement
 - Remediate SonarCloud S7630 script injection in 9 workflow files: move all `${{ inputs.* }}` references used in `run:` shell bodies to `env:` blocks; affects `python-ci.yml`, `python-compatibility.yml`, `python-docs.yml`, `python-mutation.yml`, `python-publish-pypi.yml`, `python-release.yml`, `python-sbom.yml`, `python-sonarcloud.yml`, `python-performance-regression.yml`
 - Remediate SonarCloud S8233/S8264 permission over-grant in 14 workflow files: move workflow-level `permissions:` blocks to per-job scope to enforce least-privilege; `id-token: write` and `pages: write` grants preserved at per-job level where required
 - Remediate SonarCloud S8541/S8544 in 7 workflow files: add `--frozen --no-build` to `uv sync` and `uv pip install` commands; add `--only-binary :all:` to `pip install cyclonedx-bom==7.3.0` (`python-sbom.yml`, `python-release.yml`) and `pip install twine==6.2.0` (`python-publish-pypi.yml`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ Our standard practices include:
 ## Security Surface Areas
 
 This repository is a GitHub Actions workflow library. Its security surface differs from
-application repos -- there is no deployed service, but the workflows run with elevated
+application repos; there is no deployed service, but the workflows run with elevated
 permissions in every downstream repo that calls them.
 
 Primary attack surfaces and mitigations:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,32 @@ Our standard practices include:
 - **Secrets Detection** integrated in CI pipelines
 - **Hardened CI Runners** with minimal privileges
 
+## Security Surface Areas
+
+This repository is a GitHub Actions workflow library. Its security surface differs from
+application repos -- there is no deployed service, but the workflows run with elevated
+permissions in every downstream repo that calls them.
+
+Primary attack surfaces and mitigations:
+
+- **Script injection via workflow inputs**: reusable workflows that interpolate
+  `${{ inputs.* }}` directly into `run:` blocks are vulnerable to injection if a caller
+  passes adversarial input. Mitigation: route all inputs through `env:` variables before
+  using in shell commands. Tracked with SonarCloud (githubactions:S7630).
+
+- **Overly broad token permissions**: workflows using `permissions: write-all` or setting
+  write grants at the workflow level rather than the job level violate least-privilege.
+  Mitigation: scope `permissions:` to the job level; request only the specific write
+  permission needed for each job. Tracked via OpenSSF Scorecard Token-Permissions check.
+
+- **Mutable action and workflow refs**: `uses:` fields referencing `@main`, `@v1`, or other
+  mutable tags allow upstream supply chain compromise. Mitigation: pin all external `uses:`
+  to a 40-character commit SHA. Renovate is configured to open SHA-bump PRs automatically.
+
+- **Unchecked caller inputs**: inputs from calling repos are not sanitized before use.
+  Mitigation: treat all inputs as untrusted; validate ranges and expected values in the
+  workflow before acting on them.
+
 ## CVE & Advisory Workflow
 
 We track and publish advisories for all confirmed vulnerabilities:


### PR DESCRIPTION
## Problem

Repos using a build backend (hatchling, setuptools) fail CI with errors like:

```
error: Distribution `gleif==0.1.0 @ editable+file:///home/runner/work/gleif/gleif`
can't be installed because it is not a wheel and --no-build is set
```

The cause: `uv sync --no-build` was hardcoded into every reusable workflow. That flag is correct for repos that are pure scripts with no build step, but it prevents repos with a proper package build from using the shared workflow library at all.

## Root Cause

There are two distinct uses of `--no-build` in these workflows:

1. **`uv pip install --no-build 'pkg==version'`** (security fix from PR #110) -- refuses to download and execute arbitrary sdist build scripts from PyPI. This is an S8541/S8544 control and must stay.

2. **`uv sync --no-build` / `uv run --frozen --no-build`** (pre-existing) -- refuses to build the calling repo's own package. This breaks repos with hatchling/setuptools.

PR #110 fixed #1 but did not address #2.

## Solution

Add a `no-build` boolean input (default: `true`) to all 11 affected workflows. Callers with a build backend opt out with `no-build: false`:

```yaml
jobs:
  ci:
    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
    with:
      no-build: false   # repo has hatchling build backend
```

Implementation: each job exports `NO_BUILD_FLAG` at the job `env:` level so the variable is available to every step without per-step changes:

```yaml
env:
  NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
```

Then all `uv sync/run` commands reference `$NO_BUILD_FLAG` unquoted -- an empty string word-splits away cleanly, passing no extra argument.

## Files Changed

**Commit 1 -- pre-existing unrelated fixes bundled with the pre-commit run:**
- `SECURITY.md` -- adds Security Surface Areas section
- `.pre-commit-config.yaml` -- upgrades TruffleHog hook to upstream repo (v3.92.3, SHA-pinned) instead of local script; adds `pragma: allowlist secret` for SHA false positive
- `python-scorecard.yml` -- adds `SCORECARD_TOKEN` absence warning so callers get an actionable message when Branch-Protection scores 0; adds `pragma: allowlist secret` for false positive

**Commit 2 -- the no-build fix:**
- `python-ci.yml` -- 2 jobs patched (`quality-checks`, `matrix-testing`)
- `python-compatibility.yml` -- 1 job patched (`test-matrix`)
- `python-docs.yml` -- 1 job patched (`build`)
- `python-fips-compatibility.yml` -- 2 jobs patched (`fips-check`, `fips-runtime-test`)
- `python-mutation.yml` -- 1 job patched (`mutation-testing`)
- `python-performance-regression.yml` -- 1 job patched (`performance-regression`)
- `python-precommit.yml` -- 1 job patched (`pre-commit`)
- `python-release.yml` -- 2 jobs patched (`test`, `release`)
- `python-sbom.yml` -- 1 job patched (`generate-sbom`)
- `python-security-analysis.yml` -- 2 jobs patched (`codeql`, `python-security`)
- `python-sonarcloud.yml` -- 1 job patched (`sonarcloud-analysis`)

## Test Plan

- [ ] Verify a repo with hatchling/setuptools passes CI with `no-build: false`
- [ ] Verify a repo without a build backend passes CI with the default `no-build: true`
- [ ] Confirm `uv pip install --no-build` lines (S8541/S8544 security controls) are untouched in all files

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reusable workflows now support a configurable `no-build` input parameter (default: enabled).

* **Chores**
  * Updated TruffleHog pre-commit hook configuration to official repository, pinned to v3.92.3.
  * GitHub Actions workflows now emit warning when security token is missing.

* **Documentation**
  * Expanded security policy with new "Security Surface Areas" section describing workflow attack vectors and mitigation strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/.github/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->