### PR TITLE
fix(sbom): use explicit venv path for cyclonedx-py invocation

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Generate runtime SBOM (production dependencies)
         run: |
-          cyclonedx-py environment \
+          .venv/bin/cyclonedx-py environment \
             --output-format JSON \
             --output-file "$GITHUB_WORKSPACE/sbom-runtime.json" \
             .venv/bin/python3
@@ -295,4 +295,5 @@ jobs:
           echo '```json' >> $GITHUB_STEP_SUMMARY
           echo "$FORBIDDEN_LICENSES" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
 


### PR DESCRIPTION
## Summary

- Change `cyclonedx-py environment` to `.venv/bin/cyclonedx-py environment` in `python-sbom.yml`

## Why

Follow-up to #113. After fixing the install order (uv sync before uv pip install), a second issue surfaced: `uv pip install` places the `cyclonedx-py` binary in `.venv/bin`, not on the system PATH. The "Generate runtime SBOM" step called `cyclonedx-py` bare, causing a command-not-found failure in any downstream repo.

The previous `pip install` approach installed into the system Python's bin directory, which IS on PATH. The uv migration broke that assumption.

## Changes

`.github/workflows/python-sbom.yml`: replace `cyclonedx-py environment` with `.venv/bin/cyclonedx-py environment`. The venv path is guaranteed by the preceding `uv sync` step.

## Impact

- Resolves the "Generate runtime SBOM" failure in downstream repos
- No change to SBOM output or any other step
- Explicit path is safer than PATH reliance; future uv version changes won't affect it

Observed failure in `ByronWilliamsCPA/gleif` PR #37 (related to #106).