### PR TITLE
ci(python-ci): fail fast when source-directory is missing

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -140,6 +140,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate source layout
+        env:
+          SRC_DIR: ${{ inputs.source-directory }}
+          TEST_DIR: ${{ inputs.test-directory }}
+        run: |
+          missing=()
+          [ -d "$SRC_DIR" ] || missing+=("$SRC_DIR")
+          [ -d "$TEST_DIR" ] || missing+=("$TEST_DIR")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::python-ci.yml requires the following directories to exist: ${missing[*]}"
+            echo "::error::This reusable workflow assumes a Python src/ layout. If your repo"
+            echo "::error::is a configuration repo (no Python package), use a hand-rolled CI"
+            echo "::error::workflow instead. See ByronWilliamsCPA/.github/docs/workflows/python-ci.md"
+            echo "::error::for the full layout requirement and an alternative template."
+            exit 1
+          fi
+
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -141,6 +141,7 @@ jobs:
           fetch-depth: 0
 
       - name: Validate source layout
+        shell: bash
         env:
           SRC_DIR: ${{ inputs.source-directory }}
           TEST_DIR: ${{ inputs.test-directory }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ are no numbered releases.
 - `docs/known-vulnerabilities.md`: empty CVE baseline satisfying the OpenSSF FOUND-007 foundation check; no known vulnerabilities as of 2026-05-14
 - `docs/architecture/adr-000-index.md`, `docs/architecture/adr-001-scorecard-publish-results.md`: ADR infrastructure and first decision record documenting the `publish-results: false` constraint in the reusable scorecard workflow and the plan for a direct `self-scorecard` job (FOUND-008)
 - `.gitignore`: narrow `.claude/` exclusion from directory-level to specific transient subdirs so `.claude/CLAUDE.md` and `.claude/settings.json` are tracked by git
+- `python-ci.yml`: add `Validate source layout` precondition step that fails fast with an actionable `::error::` block when `source-directory` or `test-directory` does not exist, replacing the previous opaque `Failed to format src: No such file or directory` failure from ruff; step uses explicit `shell: bash` and reads inputs via `env:`; behavior change for misuse cases (callers without `src/`/`tests/` now fail one step earlier with a clearer message), no breaking change for correctly configured callers
+- `docs/workflows/python-ci.md`: new docs page documenting the required `src/` layout, when to use vs not use the workflow, flat-layout support via `source-directory: '.'` override, minimal usage example, and selected inputs
 
 ### Fixed
 

--- a/docs/workflows/python-ci.md
+++ b/docs/workflows/python-ci.md
@@ -31,16 +31,27 @@ Do not call `python-ci.yml` from:
 
 - Configuration repositories (agent configs, Claude prompt repos, docs-only
   repositories)
-- Repositories with a flat Python layout (no `src/` directory)
 - Repositories that are not Python at all
 
-If you do, the validation step will fail. Choose an alternative:
+If you do, the validation step will fail. Write a hand-rolled CI workflow
+instead that emits the `CI Gate` required status context using appropriate
+tooling (yamllint, markdownlint, actionlint, em-dash check).
 
-- For **flat-layout Python packages**, pass `source-directory: '.'` (or the
-  actual package directory) so the validation finds the code.
-- For **non-Python or pure config repositories**, write a hand-rolled CI
-  workflow that emits the `CI Gate` required status context using
-  appropriate tooling (yamllint, markdownlint, actionlint, em-dash check).
+### Flat-layout Python packages
+
+Flat-layout Python packages (no `src/` directory) are supported via input
+overrides. Pass `source-directory: '.'` (or the actual package directory)
+along with the matching `test-directory`, and the validation step will
+locate the code without complaint:
+
+```yaml
+jobs:
+  ci:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
+    with:
+      source-directory: '.'
+      test-directory: tests
+```
 
 ## Minimal usage
 
@@ -55,7 +66,7 @@ on:
 
 jobs:
   ci:
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@v1
     with:
       python-version: "3.12"
       coverage-threshold: 80
@@ -82,7 +93,3 @@ from `${{ inputs.source-directory }}`. If the directory does not exist, the
 first step that runs against it errors out with a tool-specific message,
 which is hard to diagnose from the caller side. The precondition step
 exists so future misuse fails with the same actionable error every time.
-
-For the original investigation that prompted this hardening, see
-`docs/superpowers/plans/2026-05-16-reusable-ci-workflow-audit.md` in the
-downstream `.claude` configuration repo.

--- a/docs/workflows/python-ci.md
+++ b/docs/workflows/python-ci.md
@@ -1,0 +1,88 @@
+# python-ci.yml -- Reusable Python CI workflow
+
+The `python-ci.yml` reusable workflow runs the full Python quality stack
+(format, lint, type check, test, security scan, dependency audit, LLM
+governance) against a caller repository.
+
+## Required directory layout
+
+This workflow **requires** the caller repository to follow a Python `src/`
+layout. By default it expects:
+
+- A `src/` directory (overridable via the `source-directory` input)
+- A `tests/` directory (overridable via the `test-directory` input)
+- A `pyproject.toml` at the repository root declaring a Python package
+  (PEP 621 `[project]` table or Poetry-style `[tool.poetry]`)
+
+If either directory is missing, the workflow now fails fast at the
+"Validate source layout" step with a clear actionable error, instead of
+producing the older opaque `Failed to format src: No such file or directory`
+failure.
+
+## When to use this workflow
+
+Use `python-ci.yml` for any repository that is a **Python package** with the
+canonical src layout. Most ByronWilliamsCPA Python packages call this
+workflow from their `.github/workflows/ci.yml`.
+
+## When NOT to use it
+
+Do not call `python-ci.yml` from:
+
+- Configuration repositories (agent configs, Claude prompt repos, docs-only
+  repositories)
+- Repositories with a flat Python layout (no `src/` directory)
+- Repositories that are not Python at all
+
+If you do, the validation step will fail. Choose an alternative:
+
+- For **flat-layout Python packages**, pass `source-directory: '.'` (or the
+  actual package directory) so the validation finds the code.
+- For **non-Python or pure config repositories**, write a hand-rolled CI
+  workflow that emits the `CI Gate` required status context using
+  appropriate tooling (yamllint, markdownlint, actionlint, em-dash check).
+
+## Minimal usage
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@main
+    with:
+      python-version: "3.12"
+      coverage-threshold: 80
+    secrets: inherit
+```
+
+## Inputs (selected)
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `python-version` | string | `3.12` | Primary Python version for quality checks |
+| `source-directory` | string | `src` | Directory containing the package source |
+| `test-directory` | string | `tests` | Directory containing the test suite |
+| `coverage-threshold` | number | `80` | Minimum coverage percentage |
+| `enable-matrix-testing` | boolean | `false` | Enable tiered multi-version matrix testing |
+
+See the workflow file for the full input list.
+
+## Rationale for the layout requirement
+
+Every quality step in `python-ci.yml` (ruff format check, ruff lint,
+basedpyright, vulture, pytest with coverage, bandit, LLM tag scan) reads
+from `${{ inputs.source-directory }}`. If the directory does not exist, the
+first step that runs against it errors out with a tool-specific message,
+which is hard to diagnose from the caller side. The precondition step
+exists so future misuse fails with the same actionable error every time.
+
+For the original investigation that prompted this hardening, see
+`docs/superpowers/plans/2026-05-16-reusable-ci-workflow-audit.md` in the
+downstream `.claude` configuration repo.


### PR DESCRIPTION
## Summary

Insert a precondition step in the Code Quality Checks job of the reusable
`python-ci.yml` workflow that asserts the configured `source-directory`
and `test-directory` actually exist before any tool setup. If either is
missing, the workflow exits 1 with an actionable error that points to the
new `docs/workflows/python-ci.md`.

## Why

A downstream audit of every caller of `python-ci.yml` across the
ByronWilliamsCPA and williaby orgs (14 callers total) found that this
workflow assumes a Python `src/` layout. When a caller is missing `src/`,
the workflow today fails at the ruff format step with an opaque
`Failed to format src: No such file or directory (os error 2)`. That
message points at ruff, not at the structural mismatch.

Audit results (CSV in the downstream `.claude` config repo):

- **KEEP**: 13 callers (correct Python packages with src/ layout)
- **HANDOFF**: 1 caller (williaby/image-generation; owned by a separate
  team) — this is the case that surfaced the issue
- **REMEDIATE**: 0 callers

Zero config-repo callers were found, so no downstream remediation PRs are
needed. The remaining value of this audit is the defensive hardening in
this PR plus the documentation it points to.

## Behaviour change

Callers that previously failed at the ruff format step will now fail one
step earlier with a clearer message. All 13 KEEP callers are unaffected;
their `src/` and `tests/` already exist.

This is arguably a SemVer MAJOR for misuse cases. I have not bumped any
version tag in this PR. If the convention here is to bump the workflow's
documented `@vN`, point me at it and I will follow up.

## Files

- `.github/workflows/python-ci.yml` — +17 lines, new \"Validate source layout\" step
- `docs/workflows/python-ci.md` — new file, follows the existing
  `docs/workflows/python-*.md` convention

## Verification

- [ ] CI on this PR is green (the .github repo itself is not affected by
      the precondition; only callers are)
- [ ] Manual smoke test: a draft PR in a no-src/ repo (e.g. a forked test
      repo) that pins `uses: ByronWilliamsCPA/.github/.github/workflows/python-ci.yml@<this-branch-sha>`
      should fail at the new step with the documented error block

## Refs

- williaby/image-generation#15 — the broken PR that surfaced the issue
- Audit plan: `docs/superpowers/plans/2026-05-16-reusable-ci-workflow-audit.md` (in the downstream `.claude` repo)

Generated with [Claude Code](https://claude.com/claude-code)