### PR TITLE
fix(security): use stdout redirect for safety JSON output

### DIFF
--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -258,7 +258,7 @@ jobs:
           # ignore mechanism or a policy file, not exit-code suppression.
           uv run --frozen $NO_BUILD_FLAG safety check \
             --file requirements-scan.txt \
-            --json --output safety-report.json
+            --json > safety-report.json
 
       - name: Upload Security Reports
         if: always()


### PR DESCRIPTION
## Summary

Follow-up to #136. With Security Analysis no longer hitting `startup_failure`, consumer repos can now actually run the security jobs — which surfaced a second bug: the `safety check` invocation uses 2.x-era syntax that fails on safety 3.x.

## Symptom

Every consumer repo's `Security Analysis / Python Security Scan` job now fails with:

```
Error: Invalid value for '--output' / '-o': 'safety-report.json' is not one of 'screen', 'text', 'json', 'bare', 'html'.
```

Verified on `ByronWilliamsCPA/fragrance-rater` PR #22 after PR #136 merged. This is the next-layer regression that #136's fix exposed.

## Root cause

`safety 3.x` changed `--output` semantics: it now selects an output **format** (screen, text, json, bare, html), not a destination file. The org workflow's current `--output safety-report.json` is rejected.

## Fix

Drop `--output` and pipe `--json` output to the report file via stdout. Same artifact written, compatible with both safety 2.x and 3.x.

```diff
-            --json --output safety-report.json
+            --json > safety-report.json
```

## Verification post-merge

Re-run Security Analysis on `fragrance-rater` PR #22; the Python Security Scan should pass (or fail only on actual findings, not on the CLI flag mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security vulnerability scanning workflow to improve report generation and output handling during automated safety checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/.github/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->