### PR TITLE
fix(security): migrate Safety check to safety 3.x scan command

### DIFF
--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -253,13 +253,14 @@ jobs:
           echo "🛡️ Scanning dependencies for vulnerabilities..."
           # safety 3.x deprecated `safety check` and changed CLI semantics.
           # Use `safety scan` which auto-discovers project files
-          # (pyproject.toml, requirements*.txt, uv.lock), supports --output
-          # for stdout format and --save-as for file persistence, and
-          # propagates exit code on findings.
+          # (pyproject.toml, requirements*.txt, uv.lock), persists JSON
+          # via --save-as, and propagates exit code on findings.
+          # `--no-build` is set as a literal flag (not via $NO_BUILD_FLAG)
+          # so SonarCloud's S8541 rule can verify it is present; safety
+          # scan reads dependency metadata only, no setup scripts run.
           # Suppress false positives via the Safety ignore mechanism or a
           # policy file, not exit-code suppression.
-          uv run --frozen $NO_BUILD_FLAG safety scan \
-            --output json \
+          uv run --frozen --no-build safety scan \
             --save-as json safety-report.json
 
       - name: Upload Security Reports

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -251,14 +251,16 @@ jobs:
         if: ${{ inputs.run-safety }}
         run: |
           echo "🛡️ Scanning dependencies for vulnerabilities..."
-          uv export --format requirements-txt --no-hashes --output-file requirements-scan.txt
-          # Single invocation: writes the JSON report and propagates the exit
-          # code so real findings fail the job. Mirrors the Bandit pattern in
-          # this same workflow. Suppress false positives via the Safety
-          # ignore mechanism or a policy file, not exit-code suppression.
-          uv run --frozen $NO_BUILD_FLAG safety check \
-            --file requirements-scan.txt \
-            --json > safety-report.json
+          # safety 3.x deprecated `safety check` and changed CLI semantics.
+          # Use `safety scan` which auto-discovers project files
+          # (pyproject.toml, requirements*.txt, uv.lock), supports --output
+          # for stdout format and --save-as for file persistence, and
+          # propagates exit code on findings.
+          # Suppress false positives via the Safety ignore mechanism or a
+          # policy file, not exit-code suppression.
+          uv run --frozen $NO_BUILD_FLAG safety scan \
+            --output json \
+            --save-as json safety-report.json
 
       - name: Upload Security Reports
         if: always()
@@ -268,7 +270,6 @@ jobs:
           path: |
             bandit-report.json
             safety-report.json
-            requirements-scan.txt
 
   # OSV Scanner
   osv-scanner:


### PR DESCRIPTION
## Summary

Third fix in the safety-version-drift chain (after #136 egress-policy revert and #137 `--output` syntax). Migrates the org workflow's Safety integration from the deprecated `safety check` command to the safety 3.x `safety scan` command.

## Symptom

After #137 merged, consumer repos' Safety Vulnerability Scan step still fails:

```
HINT: [Errno 2] No such file or directory: '.safety-policy.yml'
Process completed with exit code 2.
```

Verified on `ByronWilliamsCPA/fragrance-rater` PR #22 in run [26054343142](https://github.com/ByronWilliamsCPA/fragrance-rater/actions/runs/26054343142).

## Root cause

`safety check` was deprecated by Safety upstream after 1 May 2024. In safety 3.x, the legacy `check` command requires a `.safety-policy.yml` in the project root. Requiring per-consumer policy files breaks the shared-workflow contract.

## Fix

Migrate to `safety scan` (the 3.x recommended invocation):

```diff
-          uv export --format requirements-txt --no-hashes --output-file requirements-scan.txt
-          uv run --frozen $NO_BUILD_FLAG safety check \
-            --file requirements-scan.txt \
-            --json > safety-report.json
+          uv run --frozen $NO_BUILD_FLAG safety scan \
+            --output json \
+            --save-as json safety-report.json
```

Also removes `requirements-scan.txt` from the Upload Security Reports artifact list (no longer produced; `safety scan` reads `pyproject.toml`/`uv.lock` directly).

## Behavior preserved

- Vulnerability detection: `safety scan` covers the same Python dependency DB as `safety check` did
- Exit code on findings: both commands return non-zero on real findings (suppress via safety policy file or `--ignore` flag, not exit-code suppression)
- JSON report at `safety-report.json`: same artifact path, same shape (safety scan's JSON output is a superset of safety check's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)