### PR TITLE
chore(security)!: remove redundant safety scanner

### DIFF
--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -1,5 +1,5 @@
 # Python Security Analysis - Reusable Workflow
-# Comprehensive security scanning with CodeQL, Bandit, Safety, OSV-Scanner, and OWASP
+# Comprehensive security scanning with CodeQL, Bandit, OSV-Scanner, and Dependency-Review
 #
 # Usage from downstream repos:
 #   jobs:
@@ -52,12 +52,6 @@ on:
 
       run-bandit:
         description: 'Run Bandit static analysis'
-        type: boolean
-        required: false
-        default: true
-
-      run-safety:
-        description: 'Run Safety vulnerability scan'
         type: boolean
         required: false
         default: true
@@ -199,10 +193,10 @@ jobs:
           comment-summary-in-pr: always
           deny-licenses: GPL-2.0, GPL-3.0
 
-  # Python security scanning (Bandit + Safety)
+  # Python security scanning (Bandit)
   python-security:
-    name: Python Security Scan
-    if: ${{ inputs.run-bandit || inputs.run-safety }}
+    name: Python SAST (Bandit)
+    if: ${{ inputs.run-bandit }}
     runs-on: ubuntu-latest
     needs: detect-changes
     timeout-minutes: 15
@@ -247,30 +241,12 @@ jobs:
             -f json -o bandit-report.json \
             -c pyproject.toml
 
-      - name: Safety Vulnerability Scan
-        if: ${{ inputs.run-safety }}
-        run: |
-          echo "🛡️ Scanning dependencies for vulnerabilities..."
-          # safety 3.x deprecated `safety check` and changed CLI semantics.
-          # Use `safety scan` which auto-discovers project files
-          # (pyproject.toml, requirements*.txt, uv.lock), persists JSON
-          # via --save-as, and propagates exit code on findings.
-          # `--no-build` is set as a literal flag (not via $NO_BUILD_FLAG)
-          # so SonarCloud's S8541 rule can verify it is present; safety
-          # scan reads dependency metadata only, no setup scripts run.
-          # Suppress false positives via the Safety ignore mechanism or a
-          # policy file, not exit-code suppression.
-          uv run --frozen --no-build safety scan \
-            --save-as json safety-report.json
-
       - name: Upload Security Reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-security-reports
-          path: |
-            bandit-report.json
-            safety-report.json
+          path: bandit-report.json
 
   # OSV Scanner
   osv-scanner:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ are no numbered releases.
 
 ## [Unreleased]
 
+### Removed
+
+- `safety` SCA scanner from `python-security-analysis.yml` and the
+  `workflow-templates/` mirror. Python dependency vulnerability scanning
+  is fully covered by OSV-Scanner, Dependency-Review, and consumer-side
+  `pip-audit`. Resolves the cascading regressions from PRs #136/#137/#138
+  and the editable-install blocker from #138's merged form.
+
 ### Breaking Changes
 
 - `python-precommit.yml`: the `fail-fast` input has been renamed to `show-diff-on-failure` to accurately reflect what it controls. Callers passing `fail-fast:` in their `with:` block must update to `show-diff-on-failure:`. Default value (`true`) and type (`boolean`) are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,41 @@ are no numbered releases.
 
 ## [Unreleased]
 
-### Removed
-
-- `safety` SCA scanner from `python-security-analysis.yml` and the
-  `workflow-templates/` mirror. Python dependency vulnerability scanning
-  is fully covered by OSV-Scanner, Dependency-Review, and consumer-side
-  `pip-audit`. Resolves the cascading regressions from PRs #136/#137/#138
-  and the editable-install blocker from #138's merged form.
-
 ### Breaking Changes
+
+- `python-security-analysis.yml`: the `safety` SCA scanner has been
+  removed from the reusable workflow and its `workflow-templates/`
+  mirror. Three downstream-visible surfaces change:
+
+  1. **Input removed.** The `run-safety` boolean input is gone.
+     Callers still passing `run-safety:` in their `with:` block will
+     fail GitHub Actions workflow-call input validation and the run
+     will not start.
+  2. **Required-check name change.** The `python-security` job display
+     name changed from `Python Security Scan` to `Python SAST (Bandit)`.
+     Consumer repos with branch protection rules or required-check
+     configurations referencing the old name will see merges silently
+     blocked until those rules are updated.
+  3. **Conditional narrowed.** The `python-security` job's `if:`
+     condition changed from `run-bandit || run-safety` to `run-bandit`
+     alone. Callers that previously set `run-bandit: false,
+     run-safety: true` to scope scanning to dependency CVEs only now
+     receive no Python security job at all.
+
+  Migration:
+
+  1. Remove `run-safety:` from any `with:` block in caller workflows.
+  2. Rename references to `Python Security Scan` in branch protection
+     rules and required-check configurations to `Python SAST (Bandit)`.
+  3. If you depended on the `run-bandit: false, run-safety: true`
+     configuration, drop the `run-safety: true` line; dependency
+     vulnerability scanning is now performed exclusively by OSV-Scanner
+     and the Dependency-Review action.
+
+  Rationale: `safety` is the only Python dep CVE scanner in the fleet
+  whose data sources are a strict subset of OSV-Scanner's. Removal
+  eliminates the cascading regressions traced in PRs #136/#137/#138
+  and the editable-install blocker from #138's merged form.
 
 - `python-precommit.yml`: the `fail-fast` input has been renamed to `show-diff-on-failure` to accurately reflect what it controls. Callers passing `fail-fast:` in their `with:` block must update to `show-diff-on-failure:`. Default value (`true`) and type (`boolean`) are unchanged.
 

--- a/workflow-templates/python-security-analysis.yml
+++ b/workflow-templates/python-security-analysis.yml
@@ -1,11 +1,10 @@
 # Python Project - Security Analysis Workflow
-# Comprehensive security scanning with CodeQL, Bandit, Safety, and OSV-Scanner
+# Comprehensive security scanning with CodeQL, Bandit, OSV-Scanner, and Dependency-Review
 #
 # WORKFLOW SCANS (Centralized Here):
 #   - CodeQL: Python security-extended and quality queries
 #   - Dependency Review: PR-based dependency vulnerability detection
 #   - Bandit: Python static security analysis
-#   - Safety: Python dependency CVE scanning
 #   - OSV-Scanner: Multi-ecosystem vulnerability detection
 #
 # EXTERNAL GITHUB APPS (Complementary - No Duplication):
@@ -144,9 +143,9 @@ jobs:
           comment-summary-in-pr: always
           deny-licenses: GPL-2.0, GPL-3.0
 
-  # Multi-tool security scanning
+  # Python SAST scanning (Bandit)
   security-scanning:
-    name: Multi-Tool Security Scan
+    name: Python SAST (Bandit)
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.security_files == 'true'
@@ -187,27 +186,12 @@ jobs:
             -c pyproject.toml || true
           uv run bandit -r src -c pyproject.toml || true
 
-      # Safety dependency vulnerability scanning
-      - name: Safety Vulnerability Scan
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "🛡️ Scanning for known vulnerabilities..."
-          poetry self add poetry-plugin-export==1.8.0
-          poetry export -f requirements.txt --output requirements-scan.txt
-          uv run safety check \
-            --file requirements-scan.txt \
-            --json --output safety-report.json || true
-          uv run safety check --file requirements-scan.txt || true
-
       - name: Upload Security Reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: security-scan-reports
-          path: |
-            bandit-report.json
-            safety-report.json
-            requirements-scan.txt
+          path: bandit-report.json
 
   # OSV-Scanner vulnerability detection
   osv-scanner:

--- a/workflow-templates/python-security-analysis.yml
+++ b/workflow-templates/python-security-analysis.yml
@@ -1,11 +1,13 @@
 # Python Project - Security Analysis Workflow
-# Comprehensive security scanning with CodeQL, Bandit, OSV-Scanner, and Dependency-Review
+# Comprehensive security scanning with CodeQL, Bandit, OSV-Scanner,
+# Dependency-Review, and OWASP Dependency-Check
 #
 # WORKFLOW SCANS (Centralized Here):
 #   - CodeQL: Python security-extended and quality queries
 #   - Dependency Review: PR-based dependency vulnerability detection
 #   - Bandit: Python static security analysis
 #   - OSV-Scanner: Multi-ecosystem vulnerability detection
+#   - OWASP Dependency-Check: Cross-ecosystem dependency CVE scan with SARIF upload
 #
 # EXTERNAL GITHUB APPS (Complementary - No Duplication):
 #   - Semgrep Cloud Platform: Advanced SAST with better UI/tracking


### PR DESCRIPTION
## Summary

Removes the `safety` SCA call from the org's reusable
`python-security-analysis.yml` workflow and its `workflow-templates/`
mirror. Replaces nothing.

## Breaking changes for downstream callers

This PR alters three surfaces of the reusable workflow's public
contract. See CHANGELOG.md `[Unreleased] / Breaking Changes` for the
full migration text.

1. **`run-safety` workflow input removed.** Callers still passing
   `with: run-safety: true|false` will fail workflow-call input
   validation and the run will not start. Remove the input from
   caller `with:` blocks.
2. **Required-check name change.** The `python-security` job display
   name changed from `Python Security Scan` to `Python SAST (Bandit)`.
   Branch protection rules and required-check configurations that
   reference the old name will block merges until updated. Rename
   references in those configs to `Python SAST (Bandit)`.
3. **Silent narrowing of the conditional.** The job's `if:` previously
   ran when either `run-bandit` or `run-safety` was true; it now runs
   only when `run-bandit` is true. Callers using
   `run-bandit: false, run-safety: true` to scope scanning to
   dependency CVEs only must drop the `run-safety: true` line;
   dependency vulnerability scanning is performed exclusively by
   OSV-Scanner and the Dependency-Review action.

## Why

The fleet runs five independent Python-dep vulnerability scanners
today (OSV-Scanner, Dependency-Review action, consumer-side pip-audit,
Renovate `osvVulnerabilityAlerts`, Renovate `vulnerabilityAlerts`).
`safety` is the only one currently broken (Layer 8d from the
regression report) and the only one whose Python-CVE coverage is a
strict subset of OSV-Scanner's data sources.

The fleet's own standards manifest (CHECK-PYTOOL-005) already declared
the directional intent: "safety absent from dependencies (replaced by
pip-audit)." This PR extends that intent to workflow YAML.

## Resolves

- Layer 8d (`--no-build` hardcode breaks editable-install consumers)
  from the security-analysis-workflow-regression-report
- The cascading safety-upstream drift surface that produced PRs
  #136, #137, #138

## Verification needed before merge

- [ ] Workflow self-test green on this PR
- [ ] Manually retrigger `fragrance-rater` PR #22's Security Analysis
      workflow run against this PR's branch (pin
      `uses: ByronWilliamsCPA/.github/.github/workflows/python-security-analysis.yml@chore/remove-safety-scanner`
      on a throwaway branch in fragrance-rater) and confirm Security
      Gate Validation flips from FAILURE to SUCCESS
- [ ] Manually retrigger latest `llc-manager` main run: same flip

## Coverage preserved (by trigger event)

| Concern | pull_request | push / schedule |
|---|---|---|
| Python dep CVE (full lockfile) | OSV-Scanner, pip-audit (consumer) | OSV-Scanner, pip-audit (consumer) |
| Python dep CVE (PR diff) | Dependency-Review action | n/a (no diff to review) |
| Multi-ecosystem CVE | OSV-Scanner | OSV-Scanner |
| Ongoing vuln alerts | Renovate osvVulnerabilityAlerts + vulnerabilityAlerts | same |
| Third-party license check (PR diff) | Dependency-Review `license-check: true` | n/a |
| Own-source SPDX | REUSE workflow | REUSE workflow |
| SAST | Bandit, CodeQL, SonarCloud | Bandit, CodeQL, SonarCloud |
| SBOM | sbom.yml | sbom.yml |

Note: on `push` and `schedule` events, Dependency-Review does not run
(it requires a PR base ref). On those triggers the only in-workflow
Python dep CVE tool is OSV-Scanner; this is intentional.

## Out of scope

- Centralizing williaby's per-repo security workflow copies; tracked
  separately
- Adding a downstream-consumer smoke test for the reusable workflow;
  tracked separately
- Removing safety from consumer-repo local workflow copies; covered by
  follow-up PRs across cookiecutter-python-template,
  cookiecutter-template-sample, xero-crypto, image-preprocessing-detector,
  data_ingestor, PromptCraft, and testing

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed Safety scanner from Python security analysis workflows
  * The `run-safety` input parameter is no longer available; remove this parameter from any workflows that reference it
  * Python security job now runs Bandit-only scanning; workflows relying on Safety for dependency vulnerability detection must adopt an alternative approach
  * Job display name changed from "Python Security Scan" to "Python SAST (Bandit)"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/.github/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->