### PR TITLE
chore(claude): add JSON schema reference to settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(git status*)",


### PR DESCRIPTION
## Summary

Adds the schemastore `$schema` field to the top of `.claude/settings.json`
so editors with JSON schema support (VSCode, JetBrains) provide
autocompletion and validation when editing the file.

## Why

Working in `.claude/settings.json` without a schema reference means every
edit is unvalidated until pre-commit (or claude-code itself) catches a
typo. Adding the schemastore reference gives the same protection at edit
time as the runtime validator does at apply time, eliminating an entire
class of "I shipped a malformed JSON pointer" mistakes.

The URL is the canonical Claude Code settings schema published on
[json.schemastore.org](https://www.schemastore.org/json/), which Claude
Code itself uses for runtime validation.

## Changes

```diff
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     ...
```

## Verification

- Pre-commit (yamllint, markdownlint, trufflehog, no-em-dash, commitizen) passes locally.
- No behavioral change. The `$schema` key is metadata; Claude Code ignores it at runtime.

Generated with [Claude Code](https://claude.com/claude-code)