### PR TITLE
chore(renovate): add uv to org-default enabledManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,7 @@
     }
   ],
   "enabledManagers": [
+    "uv",
     "pep621",
     "pip_requirements",
     "github-actions"


### PR DESCRIPTION
## Summary

Add `uv` to `enabledManagers` in the org-default Renovate config so downstream repos that use `uv.lock` actually get dependency PRs.

## Context

Renovate's `enabledManagers` is replace-not-merge: declaring it in this org-default file overrides the global config completely. The previous list (`pep621`, `pip_requirements`, `github-actions`) silently omitted the `uv` manager, so every downstream repo inheriting this template skipped uv-managed lockfile updates.

Affected downstream repos (uv.lock present, inherit org defaults):

- backpacking
- gleif
- homelab-infra
- williaby-claude
- .claude
- image-generation
- reference-library
- (plus any future repo using uv)

## Change

```diff
   "enabledManagers": [
+    "uv",
     "pep621",
     "pip_requirements",
     "github-actions"
   ],
```

`pep621` and `pip_requirements` stay as fallbacks for non-uv projects.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, observe Renovate runs on downstream repos pick up uv updates
- [ ] No regression on existing pip/pep621-managed repos

Generated with [Claude Code](https://claude.com/claude-code)
