### PR TITLE
revert(renovate): drop "uv" from enabledManagers (#149)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,7 +77,6 @@
     }
   ],
   "enabledManagers": [
-    "uv",
     "pep621",
     "pip_requirements",
     "github-actions"


### PR DESCRIPTION
Reverts: #149

## Summary

Reverts #149, which added `"uv"` to `enabledManagers` in `renovate.json`. The added entry caused Renovate to reject the entire org-default config with a validation error on every downstream run.

## What broke

Renovate (v42.92.14) does not ship a manager named `uv`. The homelab team verified this by inspecting the manager directory inside the running Renovate container. With `"uv"` in `enabledManagers`, Renovate emits:

```
Config validation errors found: The following managers configured in enabledManagers are not supported: "uv"
```

This rejects the **entire** config, not just the offending line. Every downstream repo that inherits `ByronWilliamsCPA/.github:renovate.json` (homelab-infra, gleif, backpacking, williaby-claude, .claude, image-generation, reference-library, plus future repos) stopped getting Renovate updates after #149 merged.

## How uv projects are actually covered

PR #149 was based on a wrong mental model. `uv` support in Renovate works as follows:

1. **Dependency detection**: `uv` uses the standard PEP 621 `[project]` table in `pyproject.toml`. The existing `pep621` manager (already in `enabledManagers`) finds these dependencies. No separate `uv` manager is needed.
2. **Lockfile regeneration**: `uv.lock` is regenerated as a PR artifact by the Renovate container. This is handled in `homelab-infra/services/renovate/docker-compose.yml` via `RENOVATE_BINARY_SOURCE=install`, which lets containerbase download the `uv` binary at runtime. Configured in homelab-infra PR #309 (merged), follow-up cleanup in PR #314.

The absence of `"uv"` from `enabledManagers` is therefore deliberate, not an oversight.

## Why this trap is sticky

`"uv"` is intuitively the right manager name for a uv-lockfile-managed project. Two independent agents have now reached for it (the homelab team in May, and the author of #149). Without a tombstone, the next contributor will reach for it again.

This PR captures the tombstone in the PR body and in the maintainer's session memory (so future Claude Code sessions on this repo will not re-suggest the same fix). A future contributor who proposes adding `"uv"` to `enabledManagers` should be referred to this PR.

## Pre-merge audit suggestion

The lookup that would have prevented #149:

```bash
gh pr list --repo ByronWilliamsCPA/homelab-infra --search "renovate enabledManagers uv" --state all
git -C ~/dev/homelab-infra log --all -S '"uv"' -- services/renovate/config/config.json
```

Either would have surfaced PR #309 and #314 within seconds, exposing the deliberate-revert reasoning that lived in the consumer repo rather than the source repo.

## Change

```diff
   "enabledManagers": [
-    "uv",
     "pep621",
     "pip_requirements",
     "github-actions"
   ],
```

One-line removal. Restores the pre-#149 config.

## Test plan

- [x] Pre-commit hooks pass locally (`pre-commit run --all-files`)
- [ ] CI passes on this PR
- [ ] After merge, observe Renovate runs on downstream repos succeed (no validation error)
- [ ] Confirm pep621-managed uv deps continue to receive update PRs

Generated with [Claude Code](https://claude.com/claude-code)
