### PR TITLE
fix(scorecard): tolerate webapp upload failure that ignores publish_results: false

### DIFF
--- a/.github/workflows/python-scorecard.yml
+++ b/.github/workflows/python-scorecard.yml
@@ -114,12 +114,29 @@ jobs:
           echo "::warning::The 'publish-results' input is deprecated and always treated as false. Remove it from your workflow to suppress this warning. See python-scorecard.yml Known Limitations for details."
 
       - name: Run OpenSSF Scorecard
+        # continue-on-error: scorecard-action v2.4.3 attempts to publish results to the
+        # securityscorecards.dev webapp via an internal code path that ignores
+        # publish_results: false. The webapp rejects the upload from a reusable-workflow
+        # context with HTTP 400 ("workflow verification failed: global perm is set to write")
+        # which fails the entire step. The SARIF file is still written before the orphan
+        # upload attempt, so subsequent steps (Security tab upload, artifact upload, score
+        # gate evaluation) all proceed correctly. The next "Verify SARIF was generated" step
+        # turns missing-SARIF into an explicit failure so we don't silently lose detection.
+        continue-on-error: true
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: false
           repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+      - name: Verify SARIF was generated
+        run: |
+          if [ ! -s scorecard-results.sarif ]; then
+            echo "::error::scorecard-results.sarif was not generated or is empty. The scorecard step likely failed before SARIF write, not at the webapp upload."
+            exit 1
+          fi
+          echo "SARIF file generated: $(wc -l < scorecard-results.sarif) lines, $(wc -c < scorecard-results.sarif) bytes"
 
       - name: Upload Scorecard SARIF to Security tab
         if: ${{ inputs.upload-sarif }}


### PR DESCRIPTION
## Summary

Restores OpenSSF Scorecard across the 16 downstream Python repos that have been silently failing since at least 2026-05-19. One reusable-workflow fix repairs the fleet.

## Root cause

`ossf/scorecard-action@v2.4.3` (latest version, no newer release available) attempts to publish results to the `securityscorecards.dev` webapp via an internal code path that ignores `publish_results: false`. From a reusable-workflow context, the OIDC token's `repository` claim resolves to `.github` rather than the calling repo, and the webapp rejects the upload with HTTP 400:

> workflow verification failed: workflow verification failed: global perm is set to write: permission for security-events is set to write

The scorecard analysis itself completes successfully (SARIF written, score reported in step output) before the orphan upload attempt fails. The pre-fix behavior masked the working SARIF generation and prevented the SARIF upload to the GitHub Security tab.

## Fix

1. Add `continue-on-error: true` to the **Run OpenSSF Scorecard** step so the orphan webapp upload failure does not fail the whole job.
2. Add an explicit **Verify SARIF was generated** step so a genuine SARIF-write failure (which would be a real problem) surfaces as an explicit error instead of being masked by the continue-on-error.

## Affected downstream repos (16)

| Org | Repos |
|---|---|
| ByronWilliamsCPA | `DeQA-Doc`, `audio-processor`, `.github`, `maester-tests`, `python-libs`, `homelab-infra`, `llc-manager`, `rag-processor`, `taxdome` |
| williaby | `CR-10-`, `dna`, `GCS`, `exercise-competition`, `LifeSphere`, `testing`, `zen-mcp-server` |

Most callers use `@main` floating refs, so the fix propagates automatically. SHA-pinned callers will need a follow-up pin bump (deferred per CI Repair Sprint plan).

## Test plan

- [ ] Pre-commit passes locally
- [ ] After merge, monitor Scorecard runs on `.github` itself (also affected, will be the first repo to validate the fix)
- [ ] Spot-check 2-3 downstream repos that use `@main`: confirm next Scorecard run completes successfully
- [ ] Spot-check 1 SHA-pinned downstream repo to confirm it's still failing (expected until pins are bumped)

Reference: `docs/audits/cve-scan-coverage-2026-05-25.md` (CI Repair Sprint addendum, Task 9 in current session).

Generated with [Claude Code](https://claude.com/claude-code)