### PR TITLE
fix(python-security-analysis): detect repo state instead of hardcoding uv sync/run --frozen

### DIFF
--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -147,6 +147,7 @@ jobs:
       # Hardcoding `uv sync --frozen` failed for both categories. Auto-detection skips
       # cleanly when pyproject is absent and drops --frozen when no lockfile exists yet.
       # Poetry repos are explicitly rejected with an actionable error.
+      # Mirrored in the python-security job below; keep both blocks in sync.
       - name: Detect repo state
         id: detect
         run: |

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -166,11 +166,20 @@ jobs:
           fi
         shell: bash
 
-      - name: Install dependencies
-        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
-        env:
-          FROZEN_FLAG: ${{ steps.detect.outputs.state == 'uv-locked' && '--frozen' || '' }}
-        run: uv sync --no-dev $FROZEN_FLAG $NO_BUILD_FLAG  # NOSONAR S8541
+      - name: Install dependencies (uv with lockfile)
+        if: steps.detect.outputs.state == 'uv-locked'
+        run: uv sync --no-dev --frozen $NO_BUILD_FLAG
+        shell: bash
+
+      # SonarCloud cannot follow the $NO_BUILD_FLAG env-var indirection (set at the workflow
+      # env from the `no-build` input per PR #112), and by design no uv.lock exists yet on
+      # this path until this step generates one. S8541 (--no-build) and S8544 (lockfile) are
+      # suppressed inline with rationale; the uv-locked install step above keeps the literal
+      # --frozen so the scanner can see it.
+      - name: Install dependencies (uv without lockfile)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        run: uv sync --no-dev $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path
+        shell: bash
 
       - name: Skip notice (no pyproject.toml)
         if: steps.detect.outputs.state == 'skip'
@@ -285,11 +294,18 @@ jobs:
           fi
         shell: bash
 
-      - name: Install dependencies
-        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
-        env:
-          FROZEN_FLAG: ${{ steps.detect.outputs.state == 'uv-locked' && '--frozen' || '' }}
-        run: uv sync --all-extras $FROZEN_FLAG $NO_BUILD_FLAG  # NOSONAR S8541
+      - name: Install dependencies (uv with lockfile)
+        if: steps.detect.outputs.state == 'uv-locked'
+        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
+        shell: bash
+
+      # SonarCloud cannot follow the $NO_BUILD_FLAG env-var indirection, and by design no
+      # uv.lock exists yet on this path until this step generates one. Inline NOSONAR with
+      # rationale; the uv-locked install step above keeps the literal --frozen visible.
+      - name: Install dependencies (uv without lockfile)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        run: uv sync --all-extras $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path
+        shell: bash
 
       - name: Skip notice (no pyproject.toml)
         if: steps.detect.outputs.state == 'skip'
@@ -298,18 +314,22 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "No pyproject.toml at repo root, nothing to scan." >> $GITHUB_STEP_SUMMARY
 
+      # --frozen is safe in both detected states: the install step above always produces
+      # uv.lock before this step runs. Hardcoding the literal eliminates SonarCloud S8544
+      # on the uv run line below. S8541 is suppressed via the preceding-line NOSONAR.
       - name: Bandit Static Analysis
         if: ${{ inputs.run-bandit && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock') }}
         env:
           SRC_DIR: ${{ inputs.source-directory }}
-          FROZEN_FLAG: ${{ steps.detect.outputs.state == 'uv-locked' && '--frozen' || '' }}
+        shell: bash
         run: |
           echo "🔒 Running Bandit security analysis..."
           # Single invocation: writes the JSON report and propagates the exit
           # code so real findings fail the job. Suppress false positives via a
           # .bandit config or inline `# nosec` with justification in source.
           # shellcheck disable=SC2086
-          uv run $FROZEN_FLAG $NO_BUILD_FLAG bandit -r "$SRC_DIR" \
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          uv run --frozen $NO_BUILD_FLAG bandit -r "$SRC_DIR" \
             -f json -o bandit-report.json \
             -c pyproject.toml
 

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -140,10 +140,49 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies
+      # Detect the repo state before attempting uv sync. The reusable workflow is uv-only
+      # by org policy (poetry repos are being converted to uv in separate work), but it is
+      # still called by some repos that don't have a pyproject.toml (template / docs-only
+      # forks like DeQA-Doc) and by uv-managed repos that haven't yet committed a uv.lock.
+      # Hardcoding `uv sync --frozen` failed for both categories. Auto-detection skips
+      # cleanly when pyproject is absent and drops --frozen when no lockfile exists yet.
+      # Poetry repos are explicitly rejected with an actionable error.
+      - name: Detect repo state
+        id: detect
+        run: |
+          if [ ! -f pyproject.toml ]; then
+            echo "state=skip" >> $GITHUB_OUTPUT
+            echo "::notice::No pyproject.toml found at repo root; CodeQL analysis will be skipped. Remove the python-security-analysis.yml caller from this repo if it does not need Python security scanning."
+          elif [ -f poetry.lock ] || grep -qE '^\[tool\.poetry(\.|])' pyproject.toml; then
+            echo "state=poetry-not-supported" >> $GITHUB_OUTPUT
+            echo "::error::This repo uses Poetry. The python-security-analysis.yml reusable workflow is uv-only by org policy. Convert this repo to uv before re-enabling Python security analysis."
+            exit 1
+          elif [ -f uv.lock ]; then
+            echo "state=uv-locked" >> $GITHUB_OUTPUT
+            echo "Detected: uv with lockfile"
+          else
+            echo "state=uv-no-lock" >> $GITHUB_OUTPUT
+            echo "Detected: uv without lockfile (PEP 621 pyproject.toml only); will sync without --frozen"
+          fi
+        shell: bash
+
+      - name: Install dependencies (uv with lockfile)
+        if: steps.detect.outputs.state == 'uv-locked'
         run: uv sync --no-dev --frozen $NO_BUILD_FLAG
 
+      - name: Install dependencies (uv without lockfile)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        run: uv sync --no-dev $NO_BUILD_FLAG
+
+      - name: Skip notice (no pyproject.toml)
+        if: steps.detect.outputs.state == 'skip'
+        run: |
+          echo "## CodeQL Analysis Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No pyproject.toml at repo root, nothing to analyze." >> $GITHUB_STEP_SUMMARY
+
       - name: Initialize CodeQL
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
         with:
           languages: python
@@ -157,9 +196,11 @@ jobs:
               - scripts
 
       - name: Build CodeQL Database
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
 
       - name: Perform CodeQL Analysis
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
         with:
           category: "/language:python"
@@ -225,24 +266,59 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies
+      # Detect repo state. Same logic as the codeql job above; each job runs
+      # on its own runner so the detect step must be repeated per job.
+      - name: Detect repo state
+        id: detect
+        run: |
+          if [ ! -f pyproject.toml ]; then
+            echo "state=skip" >> $GITHUB_OUTPUT
+            echo "::notice::No pyproject.toml found at repo root; Bandit SAST will be skipped. Remove the python-security-analysis.yml caller from this repo if it does not need Python security scanning."
+          elif [ -f poetry.lock ] || grep -qE '^\[tool\.poetry(\.|])' pyproject.toml; then
+            echo "state=poetry-not-supported" >> $GITHUB_OUTPUT
+            echo "::error::This repo uses Poetry. The python-security-analysis.yml reusable workflow is uv-only by org policy. Convert this repo to uv before re-enabling Python security analysis."
+            exit 1
+          elif [ -f uv.lock ]; then
+            echo "state=uv-locked" >> $GITHUB_OUTPUT
+            echo "Detected: uv with lockfile"
+          else
+            echo "state=uv-no-lock" >> $GITHUB_OUTPUT
+            echo "Detected: uv without lockfile (PEP 621 pyproject.toml only); will sync without --frozen"
+          fi
+        shell: bash
+
+      - name: Install dependencies (uv with lockfile)
+        if: steps.detect.outputs.state == 'uv-locked'
         run: uv sync --all-extras --frozen $NO_BUILD_FLAG
 
+      - name: Install dependencies (uv without lockfile)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        run: uv sync --all-extras $NO_BUILD_FLAG
+
+      - name: Skip notice (no pyproject.toml)
+        if: steps.detect.outputs.state == 'skip'
+        run: |
+          echo "## Bandit SAST Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No pyproject.toml at repo root, nothing to scan." >> $GITHUB_STEP_SUMMARY
+
       - name: Bandit Static Analysis
-        if: ${{ inputs.run-bandit }}
+        if: ${{ inputs.run-bandit && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock') }}
         env:
           SRC_DIR: ${{ inputs.source-directory }}
+          FROZEN_FLAG: ${{ steps.detect.outputs.state == 'uv-locked' && '--frozen' || '' }}
         run: |
           echo "🔒 Running Bandit security analysis..."
           # Single invocation: writes the JSON report and propagates the exit
           # code so real findings fail the job. Suppress false positives via a
           # .bandit config or inline `# nosec` with justification in source.
-          uv run --frozen $NO_BUILD_FLAG bandit -r "$SRC_DIR" \
+          # shellcheck disable=SC2086
+          uv run $FROZEN_FLAG $NO_BUILD_FLAG bandit -r "$SRC_DIR" \
             -f json -o bandit-report.json \
             -c pyproject.toml
 
       - name: Upload Security Reports
-        if: always()
+        if: always() && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-security-reports

--- a/.github/workflows/python-security-analysis.yml
+++ b/.github/workflows/python-security-analysis.yml
@@ -166,13 +166,11 @@ jobs:
           fi
         shell: bash
 
-      - name: Install dependencies (uv with lockfile)
-        if: steps.detect.outputs.state == 'uv-locked'
-        run: uv sync --no-dev --frozen $NO_BUILD_FLAG
-
-      - name: Install dependencies (uv without lockfile)
-        if: steps.detect.outputs.state == 'uv-no-lock'
-        run: uv sync --no-dev $NO_BUILD_FLAG
+      - name: Install dependencies
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
+        env:
+          FROZEN_FLAG: ${{ steps.detect.outputs.state == 'uv-locked' && '--frozen' || '' }}
+        run: uv sync --no-dev $FROZEN_FLAG $NO_BUILD_FLAG  # NOSONAR S8541
 
       - name: Skip notice (no pyproject.toml)
         if: steps.detect.outputs.state == 'skip'
@@ -287,13 +285,11 @@ jobs:
           fi
         shell: bash
 
-      - name: Install dependencies (uv with lockfile)
-        if: steps.detect.outputs.state == 'uv-locked'
-        run: uv sync --all-extras --frozen $NO_BUILD_FLAG
-
-      - name: Install dependencies (uv without lockfile)
-        if: steps.detect.outputs.state == 'uv-no-lock'
-        run: uv sync --all-extras $NO_BUILD_FLAG
+      - name: Install dependencies
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
+        env:
+          FROZEN_FLAG: ${{ steps.detect.outputs.state == 'uv-locked' && '--frozen' || '' }}
+        run: uv sync --all-extras $FROZEN_FLAG $NO_BUILD_FLAG  # NOSONAR S8541
 
       - name: Skip notice (no pyproject.toml)
         if: steps.detect.outputs.state == 'skip'


### PR DESCRIPTION
## Summary

Applies the detect-state pattern from PR #156 (`python-compatibility.yml`) and PR #157 (`python-fips-compatibility.yml`) to both jobs in `python-security-analysis.yml`. Repairs Security Analysis across 6 uv repos and surfaces an actionable error on the 4 Poetry repos being migrated.

After review (#158 comment), restructured to mirror the proven SonarCloud-safe pattern from `python-compatibility.yml`: split install steps into uv-locked / uv-no-lock variants, expose literal `--frozen` on the Bandit `uv run` step, and use inline `NOSONAR(S8541,S8544)` only on the uv-no-lock install (where no `uv.lock` exists by design). See [`docs/sonarcloud-nosonar-patterns.md`](docs/sonarcloud-nosonar-patterns.md) for the empirical NOSONAR placement rules.

## Root cause

Both `codeql` and `python-security` jobs hardcoded `uv sync --frozen` / `uv run --frozen`, crashing on:

| Caller state | Symptom |
|---|---|
| No pyproject.toml | uv errors with no context |
| uv repo without uv.lock | --frozen requires uv.lock |
| Poetry repo | uv cannot read poetry projects |

## Fix

Detect-state step added to both `codeql` and `python-security` jobs. Logic identical to PR #156 / #157.

| State | Behavior |
|---|---|
| `skip` | No pyproject.toml. Step notice + skip uv calls. |
| `uv-locked` | `uv sync --frozen $NO_BUILD_FLAG` (literal `--frozen`, no NOSONAR needed for S8544) |
| `uv-no-lock` | `uv sync $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): ...` (single-line `run:` so inline NOSONAR is honored) |
| `poetry-not-supported` | Fails fast with actionable error pointing at migration issues |

Bandit Static Analysis step: literal `uv run --frozen $NO_BUILD_FLAG bandit ...` with preceding-line `# NOSONAR(S8541)`. No `FROZEN_FLAG` env indirection (SonarCloud cannot follow it; see PR #157's findings).

Notes:
- `codeql` install uses `--no-dev`, `python-security` (Bandit) uses `--all-extras`. Both preserved.
- Detect-state block is duplicated across both jobs by GHA design (each job runs on its own runner). Both blocks now carry reciprocal "keep in sync" comments.

## Affected downstream repos (10)

| Outcome | Repos |
|---|---|
| Repaired (6) | `audio-processor`, `dna`, `fragrance-rater`, `image-preprocessing-detector`, `python-libs`, `rag-processor` |
| Still failing (intentional, awaits migration) (4) | `PromptCraft` (#328), `ledgerbase` (#147), `data_ingestor` (#38), `pp-security-master` (#38) |

## Test plan

- [x] Pre-commit passes locally
- [x] SonarCloud Quality Gate: OK (Critical findings resolved by restructure in commit 774408d7)
- [ ] After merge, spot-check 2 `@main` callers (e.g., `audio-processor`, `dna`): confirm Security Analysis succeeds
- [ ] Spot-check 1 Poetry repo: confirm new actionable error appears

Reference: `docs/audits/cve-scan-coverage-2026-05-25.md` (CI Repair Sprint).

Related: #155, #156, #157.

Generated with [Claude Code](https://claude.com/claude-code)