### PR TITLE
fix(python-release): detect repo state instead of hardcoding uv sync/run --frozen

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -149,14 +149,59 @@ jobs:
           PYTHON_VERSION: ${{ inputs.python-version }}
         run: uv python install "$PYTHON_VERSION"
 
-      - name: Install dependencies
+      # Detect the repo state before attempting uv sync. The reusable workflow is uv-only
+      # by org policy (poetry repos are being converted to uv in separate work), but it is
+      # still called by some repos that don't have a pyproject.toml (template / docs-only
+      # forks) and by uv-managed repos that haven't yet committed a uv.lock. Hardcoding
+      # `uv sync --frozen` failed for both categories. Auto-detection skips cleanly when
+      # pyproject is absent and drops --frozen when no lockfile exists yet. Poetry repos
+      # are explicitly rejected with an actionable error.
+      - name: Detect repo state
+        id: detect
+        run: |
+          if [ ! -f pyproject.toml ]; then
+            echo "state=skip" >> $GITHUB_OUTPUT
+            echo "::notice::No pyproject.toml found at repo root; pre-release tests will be skipped. Remove the python-release.yml caller from this repo if it does not need Python release automation."
+          elif [ -f poetry.lock ] || grep -qE '^\[tool\.poetry(\.|])' pyproject.toml; then
+            echo "state=poetry-not-supported" >> $GITHUB_OUTPUT
+            echo "::error::This repo uses Poetry. The python-release.yml reusable workflow is uv-only by org policy. Convert this repo to uv before re-enabling Python release automation."
+            exit 1
+          elif [ -f uv.lock ]; then
+            echo "state=uv-locked" >> $GITHUB_OUTPUT
+            echo "Detected: uv with lockfile"
+          else
+            echo "state=uv-no-lock" >> $GITHUB_OUTPUT
+            echo "Detected: uv without lockfile (PEP 621 pyproject.toml only); will sync without --frozen"
+          fi
+        shell: bash
+
+      - name: Install dependencies (uv with lockfile)
+        if: steps.detect.outputs.state == 'uv-locked'
         run: uv sync --all-extras --frozen $NO_BUILD_FLAG
+        shell: bash
+
+      # SonarCloud cannot follow the $NO_BUILD_FLAG env-var indirection, and by design no
+      # uv.lock exists yet on this path until this step generates one. Inline NOSONAR with
+      # rationale; the uv-locked install step above keeps the literal --frozen visible.
+      - name: Install dependencies (uv without lockfile)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        run: uv sync --all-extras $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path
+        shell: bash
+
+      - name: Skip notice (no pyproject.toml)
+        if: steps.detect.outputs.state == 'skip'
+        run: |
+          echo "## Pre-Release Tests Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No pyproject.toml at repo root, nothing to test." >> $GITHUB_STEP_SUMMARY
 
       - name: Run tests
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           SRC_DIR: ${{ inputs.source-directory }}
           COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
         run: |
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           uv run --frozen $NO_BUILD_FLAG pytest \
             --cov="$SRC_DIR" \
             --cov-report=term-missing \
@@ -164,14 +209,16 @@ jobs:
             -v
 
       - name: Run type checker
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           SRC_DIR: ${{ inputs.source-directory }}
-        run: uv run --frozen $NO_BUILD_FLAG basedpyright "$SRC_DIR/"
+        run: uv run --frozen $NO_BUILD_FLAG basedpyright "$SRC_DIR/"  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
 
       - name: Run linter
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           SRC_DIR: ${{ inputs.source-directory }}
-        run: uv run --frozen $NO_BUILD_FLAG ruff check "$SRC_DIR/"
+        run: uv run --frozen $NO_BUILD_FLAG ruff check "$SRC_DIR/"  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
 
   # ============================================================================
   # Job 2: Build and Create Release
@@ -230,17 +277,52 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies
+      # Detect the repo state before attempting uv sync. Mirrors the test job; same
+      # rationale (callers may be uv-locked, uv-no-lock, poetry, or have no pyproject).
+      # Release flow exits 1 on poetry-not-supported and skip states because a release
+      # requires a buildable Python package.
+      - name: Detect repo state
+        id: detect
+        run: |
+          if [ ! -f pyproject.toml ]; then
+            echo "state=skip" >> $GITHUB_OUTPUT
+            echo "::error::No pyproject.toml found at repo root; python-release.yml requires a Python package to build and release. Remove the python-release.yml caller from this repo if it does not produce a Python package."
+            exit 1
+          elif [ -f poetry.lock ] || grep -qE '^\[tool\.poetry(\.|])' pyproject.toml; then
+            echo "state=poetry-not-supported" >> $GITHUB_OUTPUT
+            echo "::error::This repo uses Poetry. The python-release.yml reusable workflow is uv-only by org policy. Convert this repo to uv before re-enabling Python release automation."
+            exit 1
+          elif [ -f uv.lock ]; then
+            echo "state=uv-locked" >> $GITHUB_OUTPUT
+            echo "Detected: uv with lockfile"
+          else
+            echo "state=uv-no-lock" >> $GITHUB_OUTPUT
+            echo "Detected: uv without lockfile (PEP 621 pyproject.toml only); will sync without --frozen"
+          fi
+        shell: bash
+
+      - name: Install dependencies (uv with lockfile)
+        if: steps.detect.outputs.state == 'uv-locked'
         run: uv sync --all-extras --frozen $NO_BUILD_FLAG
+        shell: bash
+
+      # SonarCloud cannot follow the $NO_BUILD_FLAG env-var indirection, and by design no
+      # uv.lock exists yet on this path until this step generates one. Inline NOSONAR with
+      # rationale; the uv-locked install step above keeps the literal --frozen visible.
+      - name: Install dependencies (uv without lockfile)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        run: uv sync --all-extras $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path
+        shell: bash
 
       - name: Build package
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         run: |
           uv build
           echo "Built packages:"
           ls -lh dist/
 
       - name: Generate SBOM
-        if: ${{ inputs.generate-sbom }}
+        if: ${{ inputs.generate-sbom && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock') }}
         run: |
           echo "Generating Software Bill of Materials..."
           uv pip install --no-build 'cyclonedx-bom==7.3.0'


### PR DESCRIPTION
## Summary
- Apply split-install detect-state pattern to python-release.yml (matches merged PRs #156, #157, #159).
- Add Detect repo state step at top of `test` and `release` jobs; split single `uv sync` install step into uv-locked (literal `--frozen`) and uv-no-lock variants.
- Downstream `uv run` steps use literal `--frozen` with Pattern A inline NOSONAR or Pattern B preceding-line NOSONAR per shape.
- No dynamic `$FROZEN_FLAG` env var anywhere.
- `publish-pypi` job unchanged (uses `uv publish` only, no `--frozen`).

## Affected downstream repos
8 repos failing on this workflow per `/tmp/ci-failure-inventory.tsv`, including ByronWilliamsCPA/homelab-infra, ByronWilliamsCPA/.claude, ByronWilliamsCPA/rag-processor.

## State-handling differences vs python-ci.yml
- `test` job: `skip` state emits notice and exits cleanly (matches python-ci pattern).
- `release` job: `skip` state exits 1 because a release without a buildable package is nonsensical; poetry repos also exit 1 in both jobs.

## Test plan
- [x] actionlint passes (with shellcheck disabled; SC2086 `info` findings on `$NO_BUILD_FLAG` match merged python-ci.yml conventions)
- [ ] CI on .github passes
- [ ] SonarCloud quality gate = OK, 0 vulns
- [ ] After merge, one sample downstream caller workflow re-run succeeds (target: ByronWilliamsCPA/homelab-infra `Semantic Release`)

## References
- Pattern Selection Guide: `docs/superpowers/plans/2026-05-25-ci-repair-sprint-completion.md` (Phase 2 header)
- Empirical NOSONAR patterns: `docs/sonarcloud-nosonar-patterns.md` (this repo, delivered in PR #157)
