### PR TITLE
fix(python-ci): pass --skip-editable to pip-audit for editable-only consumers

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -419,10 +419,14 @@ jobs:
           fi
           if [ "$FAIL_ON_FINDINGS" = "true" ]; then
             # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG pip-audit $IGNORE_ARGS
+            # --skip-editable: locally-built editable installs are not on PyPI;
+            # pip-audit 2.10+ otherwise errors with "Dependency not found on PyPI"
+            uv run --frozen $NO_BUILD_FLAG pip-audit --skip-editable $IGNORE_ARGS
           else
             # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG pip-audit $IGNORE_ARGS || echo "::warning::Vulnerable dependencies detected (fail-on-security-findings=false; not failing CI)"
+            # --skip-editable: locally-built editable installs are not on PyPI;
+            # pip-audit 2.10+ otherwise errors with "Dependency not found on PyPI"
+            uv run --frozen $NO_BUILD_FLAG pip-audit --skip-editable $IGNORE_ARGS || echo "::warning::Vulnerable dependencies detected (fail-on-security-findings=false; not failing CI)"
           fi
           echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

- Adds `--skip-editable` to both pip-audit invocations in `.github/workflows/python-ci.yml` (the `Dependency vulnerability scan` step).
- Unblocks every consumer that installs its own package editable (e.g. `ByronWilliamsCPA/.claude`), which started failing on pip-audit 2.10+ with `Dependency not found on PyPI and could not be audited`.
- Security coverage unchanged: `--skip-editable` only excludes packages installed via `pip install -e`, which by definition are locally-developed and not eligible for a PyPI vulnerability lookup. Every PyPI-installed dependency continues to be audited.

## Background

pip-audit 2.10 (released 2026-05-19) made \"Dependency not found on PyPI\" a fatal error. `--skip-editable` is a stable pip-audit flag since 2.4 and matches pre-2.10 semantics for local editable installs.

Closes #144.

## Verification path

1. Land this PR.
2. Revert the local `pip-audit>=2.7.0,<2.10` pin in [ByronWilliamsCPA/.claude PR #122](https://github.com/ByronWilliamsCPA/.claude/pull/122) (or a follow-up) and confirm CI stays green with pip-audit 2.10+.
3. Sweep other BWCPA Python repos for similar local pip-audit pins added for this reason; remove once verified.

## Test plan

- [ ] Self-test workflow run passes (`Self-Test / *` checks)
- [ ] No new yamllint or no-em-dash findings (pre-commit already green locally)
- [ ] Verify on a real editable-install consumer post-merge (`.claude` is the canonical case)

Generated with [Claude Code](https://claude.com/claude-code)