### PR TITLE
fix(renovate): correct matcher for requires-python suppression

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,8 +52,11 @@
       "pinDigests": true
     },
     {
-      "description": "Python version updates - manual review required",
-      "matchDepTypes": [
+      "description": "Do not auto-update requires-python; the version range is managed per repo alongside the CI matrix strategy",
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchDepNames": [
         "python"
       ],
       "enabled": false,


### PR DESCRIPTION
## Summary

- Fixes the `Python version updates - manual review required` packageRule in `renovate.json`. The matcher was `matchDepTypes: ["python"]`, which never matches the pep621 manager because pep621 classifies `requires-python` by **dep name** (`python`), not dep type. The rule was silently ignored.
- Replaces with `matchManagers: ["pep621"]` + `matchDepNames: ["python"]`, the correct combination for how pep621 registers the `requires-python` field.

## Evidence the current rule does not work

- [ByronWilliamsCPA/family-office-portal#12](https://github.com/ByronWilliamsCPA/family-office-portal/pull/12) was a Renovate-generated PR proposing `requires-python = \">=3.14,<3.15\"` despite this rule being present in the org config. That repo has a local `renovate.json` workaround using the correct matcher as a stopgap, which can be removed after this lands.

## Scope

Affects any repo in the org that has a `pyproject.toml` with a `requires-python` field and relies on the org-level Renovate config without a local override.

Closes #147.

## Test plan

- [ ] Renovate's next scheduled run picks up the updated org config (validate by checking the next Renovate run logs, no new `requires-python` PR opened against any consumer)
- [ ] Remove the local stopgap `renovate.json` rule from `family-office-portal` and confirm Renovate still does not open a `requires-python` PR there
- [ ] Pre-commit clean locally (already verified)

Generated with [Claude Code](https://claude.com/claude-code)