### PR TITLE
fix(python-precommit): detect repo state instead of hardcoding uv sync --frozen

### DIFF
--- a/.github/workflows/python-precommit.yml
+++ b/.github/workflows/python-precommit.yml
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Pre-Commit Summary
-        if: always()
+        if: always() && steps.detect.outputs.state != 'skip'
         run: |
           echo "## Pre-Commit Hook Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-precommit.yml
+++ b/.github/workflows/python-precommit.yml
@@ -73,17 +73,65 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - name: Install dependencies
-        run: uv sync --frozen $NO_BUILD_FLAG
+      # Detect the repo state before attempting uv sync. The reusable workflow is uv-only
+      # by org policy (poetry repos are being converted to uv in separate work), but it is
+      # still called by some repos that don't have a pyproject.toml (template / docs-only
+      # forks) and by uv-managed repos that haven't yet committed a uv.lock. Hardcoding
+      # `uv sync --frozen` failed for both categories. Auto-detection skips cleanly when
+      # pyproject is absent and drops --frozen when no lockfile exists yet. Poetry repos
+      # are explicitly rejected with an actionable error.
+      - name: Detect repo state
+        id: detect
+        run: |
+          if [ ! -f pyproject.toml ]; then
+            echo "state=skip" >> $GITHUB_OUTPUT
+            echo "::notice::No pyproject.toml found at repo root; pre-commit will be skipped."
+          elif [ -f poetry.lock ] || grep -qE '^\[tool\.poetry(\.|])' pyproject.toml; then
+            echo "state=poetry-not-supported" >> $GITHUB_OUTPUT
+            echo "::error::This repo uses Poetry. python-precommit.yml is uv-only by org policy. Convert to uv before re-enabling."
+            exit 1
+          elif [ -f uv.lock ]; then
+            echo "state=uv-locked" >> $GITHUB_OUTPUT
+            echo "Detected: uv with lockfile"
+          else
+            echo "state=uv-no-lock" >> $GITHUB_OUTPUT
+            echo "Detected: uv without lockfile (PEP 621 pyproject.toml only); will sync without --frozen"
+          fi
+        shell: bash
 
+      - name: Install dependencies (uv-locked)
+        if: steps.detect.outputs.state == 'uv-locked'
+        run: uv sync --frozen $NO_BUILD_FLAG  # NOSONAR(S8541): --no-build is opt-out via `no-build` input; precedent at python-mutation.yml:159-169
+        shell: bash
+
+      # SonarCloud cannot follow the $NO_BUILD_FLAG env-var indirection, and by design no
+      # uv.lock exists yet on this path until this step generates one. Inline NOSONAR with
+      # rationale; the uv-locked install step above keeps the literal --frozen visible.
+      - name: Install dependencies (uv-no-lock)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        run: uv sync $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path
+        shell: bash
+
+      - name: Skip notice (no pyproject.toml)
+        if: steps.detect.outputs.state == 'skip'
+        run: |
+          echo "## Pre-Commit Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No pyproject.toml at repo root, nothing to run pre-commit against." >> $GITHUB_STEP_SUMMARY
+
+      # The install step above guarantees uv.lock exists by the time this step runs
+      # (uv sync generates one on the uv-no-lock path), so literal --frozen is safe here.
       - name: Run pre-commit hooks
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           CONFIG_PATH: ${{ inputs.config-path }}
           SHOW_DIFF_ON_FAILURE: ${{ inputs.show-diff-on-failure }}
         run: |
           if [ "$SHOW_DIFF_ON_FAILURE" = "true" ]; then
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG pre-commit run --all-files --config "$CONFIG_PATH" --show-diff-on-failure
           else
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG pre-commit run --all-files --config "$CONFIG_PATH"
           fi
 


### PR DESCRIPTION
## Summary
- Apply split-install detect-state pattern to `python-precommit.yml` (matches merged PRs #156, #159, #160).
- Add `Detect repo state` step (skip / poetry-not-supported / uv-locked / uv-no-lock).
- Split `Install dependencies` into two `if:`-guarded steps with literal flags (avoids the dynamic-`$FROZEN_FLAG`-inside-`run: |` anti-pattern empirically found broken in PRs #157/#158/#159).
- `Run pre-commit hooks` step uses literal `--frozen` (install step guarantees `uv.lock` exists) with preceding-line `# NOSONAR(S8541)` for `--no-build` only.
- Cite NOSONAR S8541 precedent from `python-mutation.yml:159-169`.

## Pattern choices
- Install (uv-locked) [line 104]: Pattern A inline with `# NOSONAR(S8541)` (literal `--frozen` makes S8544 inapplicable).
- Install (uv-no-lock) [line 112]: Pattern A inline with `# NOSONAR(S8541,S8544)` (no `--frozen` by design).
- Run pre-commit hooks [lines 124-135]: Pattern B (preceding-line `# NOSONAR(S8541)` inside `run: |` block, two branches both with literal `--frozen`).

## Affected downstream repos
Per `/tmp/ci-failure-inventory.tsv`: pre-commit runs on most uv repos; not specifically tracked on the inventory but exercised by every uv-managed downstream caller.

## Test plan
- [x] `actionlint -shellcheck= .github/workflows/python-precommit.yml` passes (zero errors; embedded shellcheck `-shellcheck=` flag per `feedback_actionlint_shellcheck_embed`).
- [ ] CI on `.github` passes.
- [ ] SonarCloud quality gate = OK with 0 open vulns.
- [ ] After merge, one sample downstream caller workflow re-run succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Python pre-commit workflow to intelligently detect and adapt to different repository dependency-management configurations. The workflow now conditionally manages dependency installation based on the presence of lock files, with improved error handling for incompatible setups. Pre-commit hook execution is optimized based on repository state detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByronWilliamsCPA/.github/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->