### PR TITLE
fix(python-performance-regression): detect repo state instead of hardcoding uv sync --frozen

### DIFF
--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -267,16 +267,18 @@ jobs:
           echo "No pyproject.toml at repo root, nothing to benchmark." >> $GITHUB_STEP_SUMMARY
 
       # The install step above guaranteed uv.lock exists on the uv-locked path; on the
-      # uv-no-lock path, `uv sync` created one. Literal --frozen is safe on both. The
-      # NOSONAR(S8541) suppression for the dynamic $NO_BUILD_FLAG is same-line per
-      # SonarCloud's standard NOSONAR mechanism.
+      # uv-no-lock path, `uv sync` created one. Literal --frozen is safe on both.
+      # Pattern B (preceding-line NOSONAR inside `run: |`) is acceptable here because
+      # every uv invocation in the block carries literal --frozen and only S8541
+      # (--no-build dynamic) needs suppression.
       - name: Generate Synthetic Test Data
         if: inputs.generate-synthetic-data && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           TEST_DATA_DIR: ${{ inputs.test-data-directory }}
         run: |
           mkdir -p "$TEST_DATA_DIR"
-          uv run --frozen $NO_BUILD_FLAG python scripts/generate_test_data.py  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          uv run --frozen $NO_BUILD_FLAG python scripts/generate_test_data.py
           echo "Synthetic test data generated in $TEST_DATA_DIR"
           ls -lh "$TEST_DATA_DIR" | head -20
 
@@ -323,10 +325,11 @@ jobs:
           echo "✅ Benchmark script found: $BENCHMARK_SCRIPT"
 
       # The install step above guaranteed uv.lock exists on both detect-state branches,
-      # so literal --frozen is safe throughout this block. uv run invocations are
-      # collapsed to single lines so each carries a same-line NOSONAR(S8541) for the
-      # dynamic $NO_BUILD_FLAG; S8544 does not fire because literal --frozen is
-      # structurally present on every line.
+      # so literal --frozen is safe throughout this block. This run: | shell logic is
+      # genuinely multi-line (capability detection branching with three argv variants),
+      # so we keep the block scalar and use Pattern B (preceding-line NOSONAR(S8541)
+      # for the dynamic $NO_BUILD_FLAG). S8544 does not fire here because literal
+      # --frozen is structurally present on every line.
       - name: Run PR Benchmarks
         id: pr_bench
         if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
@@ -341,44 +344,53 @@ jobs:
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
             echo "Script supports --output argument"
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
             echo "Script supports --warmup/--iterations arguments"
           fi
 
-          # Run benchmark with detected capabilities. The uv run invocations are
-          # collapsed onto single lines so each carries a same-line NOSONAR(S8541)
-          # suppression for the dynamic $NO_BUILD_FLAG; SonarCloud's NOSONAR
-          # mechanism is same-line, not preceding-line.
+          # Run benchmark with detected capabilities
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # Full interface support
             # shellcheck disable=SC2086
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --warmup "$WARMUP_ITERATIONS" --iterations "$BENCHMARK_ITERATIONS" --output /tmp/pr_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-              echo "Benchmark execution failed, creating fallback results"
-              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
-            }
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
+              --warmup "$WARMUP_ITERATIONS" \
+              --iterations "$BENCHMARK_ITERATIONS" \
+              --output /tmp/pr_benchmark.json \
+              $BENCHMARK_ARGS || {
+                echo "Benchmark execution failed, creating fallback results"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+              }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # Only --output supported
             # shellcheck disable=SC2086
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --output /tmp/pr_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-              echo "Benchmark execution failed, creating fallback results"
-              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
-            }
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
+              --output /tmp/pr_benchmark.json \
+              $BENCHMARK_ARGS || {
+                echo "Benchmark execution failed, creating fallback results"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+              }
           else
             # Minimal interface - capture stdout as JSON
             echo "Script uses stdout for output (no --output flag)"
             # shellcheck disable=SC2086
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" $BENCHMARK_ARGS > /tmp/pr_benchmark.json 2>&1 || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-              echo "Benchmark execution failed, creating fallback results"
-              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
-            }
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
+              $BENCHMARK_ARGS > /tmp/pr_benchmark.json 2>&1 || {
+                echo "Benchmark execution failed, creating fallback results"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+              }
           fi
 
           if [ -f /tmp/pr_benchmark.json ]; then
@@ -415,23 +427,27 @@ jobs:
       # main's tree, so uv.lock presence MUST be re-checked. The `detect` step ran against
       # the PR-branch worktree and cannot describe main: if the PR adds uv.lock to a repo
       # that previously had none (or removes one), trusting steps.detect.outputs.state
-      # picks the wrong install path. #CRITICAL: inline `[ -f uv.lock ]` always reflects
-      # the current worktree, so it is the only correct gate at this point in the flow.
-      - name: Install dependencies on main
-        if: steps.baseline_source.outputs.source == 'generated' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
+      # picks the wrong install path. #CRITICAL: `hashFiles('uv.lock')` re-evaluates per
+      # step against the current worktree (returns '' when the file is absent, a hash
+      # when present), so it is the only correct gate at this point in the flow. Split
+      # into two single-line `run:` steps so each carries Pattern A inline NOSONAR
+      # (the most reliable suppression form per docs/sonarcloud-nosonar-patterns.md).
+      - name: Install dependencies on main (uv with lockfile)
+        if: steps.baseline_source.outputs.source == 'generated' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock') && hashFiles('uv.lock') != ''
         env:
           EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
-        run: |
-          if [ -f uv.lock ]; then
-            uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-          else
-            uv sync $EXTRA_FLAGS $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock on main (uv sync creates one)
-          fi
+        run: uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
         shell: bash
 
-      # Same NOSONAR rationale as the PR-branch benchmark block: every uv run carries
-      # literal --frozen so only S8541 (dynamic $NO_BUILD_FLAG) needs suppression, on
-      # the same line per SonarCloud's standard NOSONAR mechanism.
+      - name: Install dependencies on main (uv without lockfile)
+        if: steps.baseline_source.outputs.source == 'generated' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock') && hashFiles('uv.lock') == ''
+        env:
+          EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
+        run: uv sync $EXTRA_FLAGS $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock on main (uv sync creates one)
+        shell: bash
+
+      # Same Pattern B rationale as the PR-branch benchmark block: multi-line capability
+      # detection with literal --frozen on every uv run; only S8541 needs suppression.
       - name: Run Baseline Benchmarks
         if: steps.baseline_source.outputs.source == 'generated' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
@@ -445,37 +461,47 @@ jobs:
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
           fi
 
-          # Run benchmark with detected capabilities. Same Pattern A rationale as the
-          # PR-branch benchmark block above: uv run args collapsed to single line so a
-          # same-line NOSONAR(S8541) suppression for $NO_BUILD_FLAG is possible.
+          # Run benchmark with detected capabilities
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # shellcheck disable=SC2086
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --warmup "$WARMUP_ITERATIONS" --iterations "$BENCHMARK_ITERATIONS" --output /tmp/baseline_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-              echo "Baseline benchmark failed, using fallback"
-              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
-            }
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
+              --warmup "$WARMUP_ITERATIONS" \
+              --iterations "$BENCHMARK_ITERATIONS" \
+              --output /tmp/baseline_benchmark.json \
+              $BENCHMARK_ARGS || {
+                echo "Baseline benchmark failed, using fallback"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
+              }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # shellcheck disable=SC2086
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --output /tmp/baseline_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-              echo "Baseline benchmark failed, using fallback"
-              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
-            }
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
+              --output /tmp/baseline_benchmark.json \
+              $BENCHMARK_ARGS || {
+                echo "Baseline benchmark failed, using fallback"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
+              }
           else
             # shellcheck disable=SC2086
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" $BENCHMARK_ARGS > /tmp/baseline_benchmark.json 2>&1 || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-              echo "Baseline benchmark failed, using fallback"
-              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
-            }
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
+              $BENCHMARK_ARGS > /tmp/baseline_benchmark.json 2>&1 || {
+                echo "Baseline benchmark failed, using fallback"
+                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
+              }
           fi
 
           if [ -f /tmp/baseline_benchmark.json ]; then
@@ -492,9 +518,9 @@ jobs:
           echo "Committed Baseline:"
           cat /tmp/baseline_benchmark.json | python3 -m json.tool
 
-      # Python heredoc inside `run: |`; same-line NOSONAR(S8541) on the `uv run`
-      # line covers the dynamic $NO_BUILD_FLAG, and literal --frozen prevents S8544
-      # from firing.
+      # Python heredoc inside `run: |` is a genuinely multi-line shell construct; we
+      # keep the block scalar and apply Pattern B (preceding-line NOSONAR(S8541) for
+      # the dynamic $NO_BUILD_FLAG; literal --frozen prevents S8544 from firing).
       - name: Compare Performance
         id: compare
         if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
@@ -503,7 +529,8 @@ jobs:
           REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
           IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
         run: |
-          uv run --frozen $NO_BUILD_FLAG python - <<'EOF'  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+          uv run --frozen $NO_BUILD_FLAG python - <<'EOF'
           import json
           import os
           from pathlib import Path

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -215,9 +215,24 @@ jobs:
         run: |
           FLAGS=""
           if [ -n "$EXTRA_DEPENDENCIES" ]; then
+            # Normalize whitespace separators (spaces, tabs, or newlines from
+            # YAML block scalars) to one extra-name per line. `tr -s` squeezes
+            # consecutive whitespace so blank tokens never reach the loop.
             while IFS= read -r dep; do
-              [[ -n "$dep" ]] && FLAGS="$FLAGS --extra $dep"
-            done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
+              if [ -z "$dep" ]; then
+                continue
+              fi
+              # #CRITICAL PEP 508 extra-name allowlist: letters, digits, dot,
+              # underscore, hyphen. Caller-controlled `inputs.extra-dependencies`
+              # flows unquoted into `uv sync $EXTRA_FLAGS` downstream; rejecting
+              # malformed names here prevents glob expansion, unintended argv
+              # tokens, and accidental word-splitting on stray bytes.
+              if [[ ! "$dep" =~ ^[A-Za-z0-9._-]+$ ]]; then
+                echo "::error::extra-dependencies value '$dep' rejected: must match ^[A-Za-z0-9._-]+\$ (PEP 508 extra name)"
+                exit 1
+              fi
+              FLAGS="$FLAGS --extra $dep"
+            done < <(echo "$EXTRA_DEPENDENCIES" | tr -s ' \t\n' '\n')
           fi
           # Trim leading whitespace; emit single-line for safe word-splitting downstream.
           FLAGS="${FLAGS# }"
@@ -268,6 +283,7 @@ jobs:
           ls -lh "$TEST_DATA_DIR" | head -20
 
       - name: Validate Benchmark Script
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
           PRIMARY_METRIC: ${{ inputs.primary-metric }}
@@ -408,21 +424,23 @@ jobs:
           fi
 
       # Baseline-on-main install path. After `git checkout origin/main` the worktree is on
-      # main's tree, so uv.lock presence has to be re-checked. We branch on detect.state
-      # for the install path (matches the PR-branch install above), then the downstream
-      # uv run lines can use literal --frozen with Pattern B (preceding-line NOSONAR).
-      - name: Install dependencies on main (uv with lockfile)
-        if: steps.baseline_source.outputs.source == 'generated' && steps.detect.outputs.state == 'uv-locked'
+      # main's tree, so uv.lock presence MUST be re-checked. The `detect` step ran against
+      # the PR-branch worktree and cannot describe main: if the PR adds uv.lock to a repo
+      # that previously had none (or removes one), trusting steps.detect.outputs.state
+      # picks the wrong install path. #CRITICAL: inline `[ -f uv.lock ]` always reflects
+      # the current worktree, so it is the only correct gate at this point in the flow.
+      - name: Install dependencies on main
+        if: steps.baseline_source.outputs.source == 'generated' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
-        run: uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-        shell: bash
-
-      - name: Install dependencies on main (uv without lockfile)
-        if: steps.baseline_source.outputs.source == 'generated' && steps.detect.outputs.state == 'uv-no-lock'
-        env:
-          EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
-        run: uv sync $EXTRA_FLAGS $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path (uv sync creates one)
+        run: |
+          if [ -f uv.lock ]; then
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+            uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG
+          else
+            # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock on main (uv sync creates one)
+            uv sync $EXTRA_FLAGS $NO_BUILD_FLAG
+          fi
         shell: bash
 
       # Same Pattern B rationale as the PR-branch benchmark block: multi-line capability
@@ -507,13 +525,11 @@ jobs:
           PRIMARY_METRIC: ${{ inputs.primary-metric }}
           REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
           IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
-          FAIL_ON_REGRESSION: ${{ inputs.fail-on-regression }}
         run: |
           # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           uv run --frozen $NO_BUILD_FLAG python - <<'EOF'
           import json
           import os
-          import sys
           from pathlib import Path
 
           # Load results
@@ -585,12 +601,14 @@ jobs:
               f.write(f"primary_metric={primary_metric}\n")
               f.write(f"summary_metrics={json.dumps(summary_metrics)}\n")
 
-          # Exit with error if regression detected and fail-on-regression is true
-          fail_on_regression = os.environ.get("FAIL_ON_REGRESSION", "false").lower() == "true"
-          if regression_detected and fail_on_regression:
-              sys.exit(1)
-          else:
-              sys.exit(0)
+          # Compare must always exit 0 so subsequent steps (Post PR Comment,
+          # Performance Summary) run even on regression. The dedicated `Fail on
+          # Regression` step at the end of the job consumes
+          # `steps.compare.outputs.regression_detected` and is the single
+          # authoritative place that fails the job when fail-on-regression is
+          # true. Two failure paths (here AND the trailing step) is a design
+          # smell: the trailing step is unreachable on regression and the PR
+          # comment is suppressed in exactly the case where it matters most.
           EOF
 
       - name: Post PR Comment

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -267,18 +267,16 @@ jobs:
           echo "No pyproject.toml at repo root, nothing to benchmark." >> $GITHUB_STEP_SUMMARY
 
       # The install step above guaranteed uv.lock exists on the uv-locked path; on the
-      # uv-no-lock path, `uv sync` created one. Literal --frozen is safe on both.
-      # Pattern B (preceding-line NOSONAR inside `run: |`) is acceptable here because
-      # every uv invocation in the block carries literal --frozen and only S8541
-      # (--no-build dynamic) needs suppression.
+      # uv-no-lock path, `uv sync` created one. Literal --frozen is safe on both. The
+      # NOSONAR(S8541) suppression for the dynamic $NO_BUILD_FLAG is same-line per
+      # SonarCloud's standard NOSONAR mechanism.
       - name: Generate Synthetic Test Data
         if: inputs.generate-synthetic-data && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           TEST_DATA_DIR: ${{ inputs.test-data-directory }}
         run: |
           mkdir -p "$TEST_DATA_DIR"
-          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-          uv run --frozen $NO_BUILD_FLAG python scripts/generate_test_data.py
+          uv run --frozen $NO_BUILD_FLAG python scripts/generate_test_data.py  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           echo "Synthetic test data generated in $TEST_DATA_DIR"
           ls -lh "$TEST_DATA_DIR" | head -20
 
@@ -325,11 +323,10 @@ jobs:
           echo "✅ Benchmark script found: $BENCHMARK_SCRIPT"
 
       # The install step above guaranteed uv.lock exists on both detect-state branches,
-      # so literal --frozen is safe throughout this block. This run: | shell logic is
-      # genuinely multi-line (capability detection branching with three argv variants),
-      # so we keep the block scalar and use Pattern B (preceding-line NOSONAR(S8541)
-      # for the dynamic $NO_BUILD_FLAG). S8544 does not fire here because literal
-      # --frozen is structurally present on every line.
+      # so literal --frozen is safe throughout this block. uv run invocations are
+      # collapsed to single lines so each carries a same-line NOSONAR(S8541) for the
+      # dynamic $NO_BUILD_FLAG; S8544 does not fire because literal --frozen is
+      # structurally present on every line.
       - name: Run PR Benchmarks
         id: pr_bench
         if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
@@ -344,53 +341,44 @@ jobs:
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             SUPPORTS_OUTPUT=true
             echo "Script supports --output argument"
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             SUPPORTS_ITERATIONS=true
             echo "Script supports --warmup/--iterations arguments"
           fi
 
-          # Run benchmark with detected capabilities
+          # Run benchmark with detected capabilities. The uv run invocations are
+          # collapsed onto single lines so each carries a same-line NOSONAR(S8541)
+          # suppression for the dynamic $NO_BUILD_FLAG; SonarCloud's NOSONAR
+          # mechanism is same-line, not preceding-line.
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # Full interface support
             # shellcheck disable=SC2086
-            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
-              --warmup "$WARMUP_ITERATIONS" \
-              --iterations "$BENCHMARK_ITERATIONS" \
-              --output /tmp/pr_benchmark.json \
-              $BENCHMARK_ARGS || {
-                echo "Benchmark execution failed, creating fallback results"
-                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
-              }
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --warmup "$WARMUP_ITERATIONS" --iterations "$BENCHMARK_ITERATIONS" --output /tmp/pr_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+              echo "Benchmark execution failed, creating fallback results"
+              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+            }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # Only --output supported
             # shellcheck disable=SC2086
-            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
-              --output /tmp/pr_benchmark.json \
-              $BENCHMARK_ARGS || {
-                echo "Benchmark execution failed, creating fallback results"
-                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
-              }
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --output /tmp/pr_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+              echo "Benchmark execution failed, creating fallback results"
+              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+            }
           else
             # Minimal interface - capture stdout as JSON
             echo "Script uses stdout for output (no --output flag)"
             # shellcheck disable=SC2086
-            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
-              $BENCHMARK_ARGS > /tmp/pr_benchmark.json 2>&1 || {
-                echo "Benchmark execution failed, creating fallback results"
-                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
-              }
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" $BENCHMARK_ARGS > /tmp/pr_benchmark.json 2>&1 || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+              echo "Benchmark execution failed, creating fallback results"
+              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
+            }
           fi
 
           if [ -f /tmp/pr_benchmark.json ]; then
@@ -435,16 +423,15 @@ jobs:
           EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
         run: |
           if [ -f uv.lock ]; then
-            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG
+            uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           else
-            # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock on main (uv sync creates one)
-            uv sync $EXTRA_FLAGS $NO_BUILD_FLAG
+            uv sync $EXTRA_FLAGS $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock on main (uv sync creates one)
           fi
         shell: bash
 
-      # Same Pattern B rationale as the PR-branch benchmark block: multi-line capability
-      # detection with literal --frozen on every uv run; only S8541 needs suppression.
+      # Same NOSONAR rationale as the PR-branch benchmark block: every uv run carries
+      # literal --frozen so only S8541 (dynamic $NO_BUILD_FLAG) needs suppression, on
+      # the same line per SonarCloud's standard NOSONAR mechanism.
       - name: Run Baseline Benchmarks
         if: steps.baseline_source.outputs.source == 'generated' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
@@ -458,47 +445,37 @@ jobs:
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
-          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             SUPPORTS_OUTPUT=true
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
-          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
+          if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             SUPPORTS_ITERATIONS=true
           fi
 
-          # Run benchmark with detected capabilities
+          # Run benchmark with detected capabilities. Same Pattern A rationale as the
+          # PR-branch benchmark block above: uv run args collapsed to single line so a
+          # same-line NOSONAR(S8541) suppression for $NO_BUILD_FLAG is possible.
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # shellcheck disable=SC2086
-            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
-              --warmup "$WARMUP_ITERATIONS" \
-              --iterations "$BENCHMARK_ITERATIONS" \
-              --output /tmp/baseline_benchmark.json \
-              $BENCHMARK_ARGS || {
-                echo "Baseline benchmark failed, using fallback"
-                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
-              }
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --warmup "$WARMUP_ITERATIONS" --iterations "$BENCHMARK_ITERATIONS" --output /tmp/baseline_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+              echo "Baseline benchmark failed, using fallback"
+              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
+            }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # shellcheck disable=SC2086
-            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
-              --output /tmp/baseline_benchmark.json \
-              $BENCHMARK_ARGS || {
-                echo "Baseline benchmark failed, using fallback"
-                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
-              }
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --output /tmp/baseline_benchmark.json $BENCHMARK_ARGS || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+              echo "Baseline benchmark failed, using fallback"
+              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
+            }
           else
             # shellcheck disable=SC2086
-            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
-              $BENCHMARK_ARGS > /tmp/baseline_benchmark.json 2>&1 || {
-                echo "Baseline benchmark failed, using fallback"
-                echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
-              }
+            uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" $BENCHMARK_ARGS > /tmp/baseline_benchmark.json 2>&1 || {  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+              echo "Baseline benchmark failed, using fallback"
+              echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
+            }
           fi
 
           if [ -f /tmp/baseline_benchmark.json ]; then
@@ -515,9 +492,9 @@ jobs:
           echo "Committed Baseline:"
           cat /tmp/baseline_benchmark.json | python3 -m json.tool
 
-      # Python heredoc inside `run: |` is a genuinely multi-line shell construct; we
-      # keep the block scalar and apply Pattern B (preceding-line NOSONAR(S8541) for
-      # the dynamic $NO_BUILD_FLAG; literal --frozen prevents S8544 from firing).
+      # Python heredoc inside `run: |`; same-line NOSONAR(S8541) on the `uv run`
+      # line covers the dynamic $NO_BUILD_FLAG, and literal --frozen prevents S8544
+      # from firing.
       - name: Compare Performance
         id: compare
         if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
@@ -526,8 +503,7 @@ jobs:
           REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
           IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
         run: |
-          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
-          uv run --frozen $NO_BUILD_FLAG python - <<'EOF'
+          uv run --frozen $NO_BUILD_FLAG python - <<'EOF'  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           import json
           import os
           from pathlib import Path

--- a/.github/workflows/python-performance-regression.yml
+++ b/.github/workflows/python-performance-regression.yml
@@ -177,26 +177,92 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies
+      # Detect the repo state before attempting uv sync. The reusable workflow is uv-only
+      # by org policy (poetry repos are being converted to uv in separate work), but it is
+      # still called by some repos that don't have a pyproject.toml (template / docs-only
+      # forks) and by uv-managed repos that haven't yet committed a uv.lock. Hardcoding
+      # `uv sync --frozen` failed for both categories. Auto-detection skips cleanly when
+      # pyproject is absent and drops --frozen when no lockfile exists yet. Poetry repos
+      # are explicitly rejected with an actionable error.
+      - name: Detect repo state
+        id: detect
+        run: |
+          if [ ! -f pyproject.toml ]; then
+            echo "state=skip" >> $GITHUB_OUTPUT
+            echo "::notice::No pyproject.toml found at repo root; performance regression testing will be skipped. Remove the python-performance-regression.yml caller from this repo if it does not need benchmarks."
+          elif [ -f poetry.lock ] || grep -qE '^\[tool\.poetry(\.|])' pyproject.toml; then
+            echo "state=poetry-not-supported" >> $GITHUB_OUTPUT
+            echo "::error::This repo uses Poetry. The python-performance-regression.yml reusable workflow is uv-only by org policy. Convert this repo to uv before re-enabling benchmarks."
+            exit 1
+          elif [ -f uv.lock ]; then
+            echo "state=uv-locked" >> $GITHUB_OUTPUT
+            echo "Detected: uv with lockfile"
+          else
+            echo "state=uv-no-lock" >> $GITHUB_OUTPUT
+            echo "Detected: uv without lockfile (PEP 621 pyproject.toml only); will sync without --frozen"
+          fi
+        shell: bash
+
+      # Build the --extra flag list once, here, so the per-state install steps below can
+      # be single-line shell (Pattern A NOSONAR placement). The output is a flat string of
+      # the form "--extra dev --extra ml" that gets word-split into uv's argv at install
+      # time. Empty when no extras requested.
+      - name: Resolve extra dependency flags
+        id: extras
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           EXTRA_DEPENDENCIES: ${{ inputs.extra-dependencies }}
         run: |
+          FLAGS=""
           if [ -n "$EXTRA_DEPENDENCIES" ]; then
-            EXTRA_ARGS=()
             while IFS= read -r dep; do
-              [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
+              [[ -n "$dep" ]] && FLAGS="$FLAGS --extra $dep"
             done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen $NO_BUILD_FLAG
-          else
-            uv sync --frozen $NO_BUILD_FLAG
           fi
+          # Trim leading whitespace; emit single-line for safe word-splitting downstream.
+          FLAGS="${FLAGS# }"
+          echo "flags=$FLAGS" >> $GITHUB_OUTPUT
+          echo "Resolved extras: ${FLAGS:-<none>}"
+        shell: bash
 
+      # S8541 suppression rationale: $NO_BUILD_FLAG (from inputs.no-build, default 'true'
+      # -> '--no-build') is dynamic by design so consumers with PEP 517 build backends
+      # (e.g. hatchling) can pass 'no-build: false'. SonarCloud cannot resolve the env
+      # var. The lockfile-based 'uv sync --frozen' (uv-locked path) constrains installable
+      # versions to the consumer's audited uv.lock.
+      - name: Install dependencies (uv with lockfile)
+        if: steps.detect.outputs.state == 'uv-locked'
+        env:
+          EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
+        run: uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+        shell: bash
+
+      - name: Install dependencies (uv without lockfile)
+        if: steps.detect.outputs.state == 'uv-no-lock'
+        env:
+          EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
+        run: uv sync $EXTRA_FLAGS $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path (uv sync creates one)
+        shell: bash
+
+      - name: Skip notice (no pyproject.toml)
+        if: steps.detect.outputs.state == 'skip'
+        run: |
+          echo "## Performance Regression Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No pyproject.toml at repo root, nothing to benchmark." >> $GITHUB_STEP_SUMMARY
+
+      # The install step above guaranteed uv.lock exists on the uv-locked path; on the
+      # uv-no-lock path, `uv sync` created one. Literal --frozen is safe on both.
+      # Pattern B (preceding-line NOSONAR inside `run: |`) is acceptable here because
+      # every uv invocation in the block carries literal --frozen and only S8541
+      # (--no-build dynamic) needs suppression.
       - name: Generate Synthetic Test Data
-        if: inputs.generate-synthetic-data
+        if: inputs.generate-synthetic-data && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           TEST_DATA_DIR: ${{ inputs.test-data-directory }}
         run: |
           mkdir -p "$TEST_DATA_DIR"
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           uv run --frozen $NO_BUILD_FLAG python scripts/generate_test_data.py
           echo "Synthetic test data generated in $TEST_DATA_DIR"
           ls -lh "$TEST_DATA_DIR" | head -20
@@ -242,8 +308,15 @@ jobs:
           fi
           echo "✅ Benchmark script found: $BENCHMARK_SCRIPT"
 
+      # The install step above guaranteed uv.lock exists on both detect-state branches,
+      # so literal --frozen is safe throughout this block. This run: | shell logic is
+      # genuinely multi-line (capability detection branching with three argv variants),
+      # so we keep the block scalar and use Pattern B (preceding-line NOSONAR(S8541)
+      # for the dynamic $NO_BUILD_FLAG). S8544 does not fire here because literal
+      # --frozen is structurally present on every line.
       - name: Run PR Benchmarks
         id: pr_bench
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
           BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
@@ -251,111 +324,130 @@ jobs:
           BENCHMARK_ITERATIONS: ${{ inputs.benchmark-iterations }}
           PRIMARY_METRIC: ${{ inputs.primary-metric }}
         run: |
-          echo "🏃 Running benchmark on PR branch..."
+          echo "Running benchmark on PR branch..."
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
-            echo "ℹ️  Script supports --output argument"
+            echo "Script supports --output argument"
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
-            echo "ℹ️  Script supports --warmup/--iterations arguments"
+            echo "Script supports --warmup/--iterations arguments"
           fi
 
           # Run benchmark with detected capabilities
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # Full interface support
             # shellcheck disable=SC2086
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --warmup "$WARMUP_ITERATIONS" \
               --iterations "$BENCHMARK_ITERATIONS" \
               --output /tmp/pr_benchmark.json \
               $BENCHMARK_ARGS || {
-                echo "⚠️ Benchmark execution failed, creating fallback results"
+                echo "Benchmark execution failed, creating fallback results"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
               }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # Only --output supported
             # shellcheck disable=SC2086
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --output /tmp/pr_benchmark.json \
               $BENCHMARK_ARGS || {
-                echo "⚠️ Benchmark execution failed, creating fallback results"
+                echo "Benchmark execution failed, creating fallback results"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
               }
           else
             # Minimal interface - capture stdout as JSON
-            echo "ℹ️  Script uses stdout for output (no --output flag)"
+            echo "Script uses stdout for output (no --output flag)"
             # shellcheck disable=SC2086
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               $BENCHMARK_ARGS > /tmp/pr_benchmark.json 2>&1 || {
-                echo "⚠️ Benchmark execution failed, creating fallback results"
+                echo "Benchmark execution failed, creating fallback results"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/pr_benchmark.json
               }
           fi
 
           if [ -f /tmp/pr_benchmark.json ]; then
-            echo "📊 PR Benchmark Results:"
+            echo "PR Benchmark Results:"
             cat /tmp/pr_benchmark.json | python3 -m json.tool || cat /tmp/pr_benchmark.json
           else
-            echo "❌ No benchmark results generated"
+            echo "No benchmark results generated"
             exit 1
           fi
 
       - name: Checkout Main Branch
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         run: |
           git fetch origin main
           git checkout origin/main
 
       - name: Determine Baseline Source
         id: baseline_source
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           BASELINE_FILE: ${{ inputs.baseline-file }}
         run: |
           if [ -n "$BASELINE_FILE" ] && [ -f "$BASELINE_FILE" ]; then
             echo "source=committed" >> $GITHUB_OUTPUT
             echo "file=$BASELINE_FILE" >> $GITHUB_OUTPUT
-            echo "✅ Using committed baseline: $BASELINE_FILE"
+            echo "Using committed baseline: $BASELINE_FILE"
           else
             echo "source=generated" >> $GITHUB_OUTPUT
             echo "file=/tmp/baseline_benchmark.json" >> $GITHUB_OUTPUT
-            echo "ℹ️  Will generate baseline from main branch"
+            echo "Will generate baseline from main branch"
           fi
 
+      # Baseline-on-main install path. After `git checkout origin/main` the worktree is on
+      # main's tree, so uv.lock presence has to be re-checked. We branch on detect.state
+      # for the install path (matches the PR-branch install above), then the downstream
+      # uv run lines can use literal --frozen with Pattern B (preceding-line NOSONAR).
+      - name: Install dependencies on main (uv with lockfile)
+        if: steps.baseline_source.outputs.source == 'generated' && steps.detect.outputs.state == 'uv-locked'
+        env:
+          EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
+        run: uv sync $EXTRA_FLAGS --frozen $NO_BUILD_FLAG  # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
+        shell: bash
+
+      - name: Install dependencies on main (uv without lockfile)
+        if: steps.baseline_source.outputs.source == 'generated' && steps.detect.outputs.state == 'uv-no-lock'
+        env:
+          EXTRA_FLAGS: ${{ steps.extras.outputs.flags }}
+        run: uv sync $EXTRA_FLAGS $NO_BUILD_FLAG  # NOSONAR(S8541,S8544): --no-build opt-out via `no-build` input; no uv.lock by design on this path (uv sync creates one)
+        shell: bash
+
+      # Same Pattern B rationale as the PR-branch benchmark block: multi-line capability
+      # detection with literal --frozen on every uv run; only S8541 needs suppression.
       - name: Run Baseline Benchmarks
-        if: steps.baseline_source.outputs.source == 'generated'
+        if: steps.baseline_source.outputs.source == 'generated' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           BENCHMARK_SCRIPT: ${{ inputs.benchmark-script }}
           BENCHMARK_ARGS: ${{ inputs.benchmark-args }}
           WARMUP_ITERATIONS: ${{ inputs.warmup-iterations }}
           BENCHMARK_ITERATIONS: ${{ inputs.benchmark-iterations }}
           PRIMARY_METRIC: ${{ inputs.primary-metric }}
-          EXTRA_DEPENDENCIES: ${{ inputs.extra-dependencies }}
         run: |
-          echo "🏃 Running baseline benchmark on main branch..."
-          if [ -n "$EXTRA_DEPENDENCIES" ]; then
-            EXTRA_ARGS=()
-            while IFS= read -r dep; do
-              [[ -n "$dep" ]] && EXTRA_ARGS+=("--extra" "$dep")
-            done < <(echo "$EXTRA_DEPENDENCIES" | tr ' ' '\n')
-            uv sync "${EXTRA_ARGS[@]}" --frozen $NO_BUILD_FLAG
-          else
-            uv sync --frozen $NO_BUILD_FLAG
-          fi
+          echo "Running baseline benchmark on main branch..."
 
           # Check if script supports --output argument
           SUPPORTS_OUTPUT=false
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--output'; then
             SUPPORTS_OUTPUT=true
           fi
 
           # Check if script supports --warmup/--iterations arguments
           SUPPORTS_ITERATIONS=false
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           if uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" --help 2>&1 | grep -q -- '--iterations'; then
             SUPPORTS_ITERATIONS=true
           fi
@@ -363,53 +455,61 @@ jobs:
           # Run benchmark with detected capabilities
           if [ "$SUPPORTS_OUTPUT" = "true" ] && [ "$SUPPORTS_ITERATIONS" = "true" ]; then
             # shellcheck disable=SC2086
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --warmup "$WARMUP_ITERATIONS" \
               --iterations "$BENCHMARK_ITERATIONS" \
               --output /tmp/baseline_benchmark.json \
               $BENCHMARK_ARGS || {
-                echo "⚠️ Baseline benchmark failed, using fallback"
+                echo "Baseline benchmark failed, using fallback"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
               }
           elif [ "$SUPPORTS_OUTPUT" = "true" ]; then
             # shellcheck disable=SC2086
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               --output /tmp/baseline_benchmark.json \
               $BENCHMARK_ARGS || {
-                echo "⚠️ Baseline benchmark failed, using fallback"
+                echo "Baseline benchmark failed, using fallback"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
               }
           else
             # shellcheck disable=SC2086
+            # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
             uv run --frozen $NO_BUILD_FLAG python "$BENCHMARK_SCRIPT" \
               $BENCHMARK_ARGS > /tmp/baseline_benchmark.json 2>&1 || {
-                echo "⚠️ Baseline benchmark failed, using fallback"
+                echo "Baseline benchmark failed, using fallback"
                 echo "{\"$PRIMARY_METRIC\": 0, \"status\": \"failed\"}" > /tmp/baseline_benchmark.json
               }
           fi
 
           if [ -f /tmp/baseline_benchmark.json ]; then
-            echo "📊 Baseline Benchmark Results:"
+            echo "Baseline Benchmark Results:"
             cat /tmp/baseline_benchmark.json | python3 -m json.tool || cat /tmp/baseline_benchmark.json
           fi
 
       - name: Copy Committed Baseline
-        if: steps.baseline_source.outputs.source == 'committed'
+        if: steps.baseline_source.outputs.source == 'committed' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           BASELINE_FILE: ${{ inputs.baseline-file }}
         run: |
           cp "$BASELINE_FILE" /tmp/baseline_benchmark.json
-          echo "📊 Committed Baseline:"
+          echo "Committed Baseline:"
           cat /tmp/baseline_benchmark.json | python3 -m json.tool
 
+      # Python heredoc inside `run: |` is a genuinely multi-line shell construct; we
+      # keep the block scalar and apply Pattern B (preceding-line NOSONAR(S8541) for
+      # the dynamic $NO_BUILD_FLAG; literal --frozen prevents S8544 from firing).
       - name: Compare Performance
         id: compare
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         env:
           PRIMARY_METRIC: ${{ inputs.primary-metric }}
           REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
           IMPROVEMENT_THRESHOLD: ${{ inputs.improvement-threshold }}
           FAIL_ON_REGRESSION: ${{ inputs.fail-on-regression }}
         run: |
+          # NOSONAR(S8541): --no-build is opt-out via `no-build` workflow input
           uv run --frozen $NO_BUILD_FLAG python - <<'EOF'
           import json
           import os
@@ -494,7 +594,7 @@ jobs:
           EOF
 
       - name: Post PR Comment
-        if: inputs.comment-on-pr && github.event_name == 'pull_request'
+        if: inputs.comment-on-pr && github.event_name == 'pull_request' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           COMPARE_BASELINE: ${{ steps.compare.outputs.baseline_value }}
@@ -595,7 +695,7 @@ jobs:
             });
 
       - name: Performance Summary
-        if: always()
+        if: always() && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           COMPARE_PRIMARY_METRIC: ${{ steps.compare.outputs.primary_metric }}
           COMPARE_BASELINE: ${{ steps.compare.outputs.baseline_value }}
@@ -633,7 +733,7 @@ jobs:
           fi
 
       - name: Fail on Regression
-        if: inputs.fail-on-regression && steps.compare.outputs.regression_detected == 'true'
+        if: inputs.fail-on-regression && steps.compare.outputs.regression_detected == 'true' && (steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock')
         env:
           COMPARE_REGRESSION_PCT: ${{ steps.compare.outputs.regression_pct }}
           REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}


### PR DESCRIPTION
## Summary
- Apply detect-state pattern to `python-performance-regression.yml` (largest reusable workflow in the org, 642 lines, 17 unguarded uv invocations).
- Wave 2C of CI Repair Sprint Phase 2 (Task 2.7). Pattern citation: `.github/workflows/python-mutation.yml:159-169` (Wave 2B / PR #172).

## Pattern application

| Step | Shape | Pattern | Rationale |
|---|---|---|---|
| Install (PR-branch, uv-locked) | single-line `run:` | A inline `# NOSONAR(S8541)` | Helper step `extras` emits flat `--extra` string so install is single-line |
| Install (PR-branch, uv-no-lock) | single-line `run:` | A inline `# NOSONAR(S8541,S8544)` | `--frozen` absent by design (uv sync creates the lockfile) |
| Install (main-branch, uv-locked) | single-line `run:` | A inline `# NOSONAR(S8541)` | Re-install after `git checkout origin/main` |
| Install (main-branch, uv-no-lock) | single-line `run:` | A inline `# NOSONAR(S8541,S8544)` | Same rationale |
| Generate Synthetic Test Data | `run: \|` | B preceding-line `# NOSONAR(S8541)` | Multi-line (mkdir + uv run + listings); literal `--frozen` present |
| Run PR Benchmarks | `run: \|` | B preceding-line `# NOSONAR(S8541)` per uv run | Multi-line capability detection with three argv variants |
| Run Baseline Benchmarks | `run: \|` | B preceding-line `# NOSONAR(S8541)` per uv run | Same shape as PR benchmarks |
| Compare Performance | `run: \|` | B preceding-line `# NOSONAR(S8541)` | Python heredoc; multi-line essential |

Pattern B is acceptable per strengthened guidance (2026-05-26): every uv invocation inside these `run: |` blocks carries literal `--frozen`, so only S8541 (dynamic `$NO_BUILD_FLAG`) needs suppression. S8544 does not fire structurally. SonarCloud gate verification per PR is the empirical check.

## Skip / fail-fast handling
- No pyproject.toml -> `state=skip`; downstream steps gated; `Skip notice` step writes a clear summary entry.
- Poetry detected -> `state=poetry-not-supported`; immediate failure with actionable error.
- All downstream summary / PR-comment / fail steps carry the state guard so a `skip` run exits green.

## S8541 rationale (cite in every detect-state PR)
`$NO_BUILD_FLAG` (from `inputs.no-build`, default `true` -> `--no-build`) is dynamic by design so consumers with PEP 517 build backends like hatchling can pass `no-build: false`. SonarCloud's static analyzer cannot resolve the env var. The lockfile-based `uv sync --frozen` (uv-locked path) constrains installable versions to the consumer's audited `uv.lock`.

## Test plan
- [x] actionlint passes (`-shellcheck=` to skip pre-existing SC2086 noise on unrelated lines)
- [ ] CI on .github passes
- [ ] SonarCloud gate OK with 0 open vulns
- [ ] After merge, one sample downstream caller workflow re-run succeeds