### PR TITLE
fix(release): apply PSR v10.5.3 bug mitigations to reusable workflow

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -66,7 +66,7 @@ on:
         description: 'Publish to PyPI after release'
         required: false
         type: boolean
-        default: true
+        default: false
       pypi-package-name:
         description: 'PyPI package name'
         required: false
@@ -249,6 +249,17 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Verify trusted workflow_run source
+        if: github.event_name == 'workflow_run'
+        env:
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [ "$HEAD_OWNER" != "$REPO_OWNER" ]; then
+            echo "::error::Refusing: triggering workflow originated from a fork (owner: $HEAD_OWNER)"
+            exit 1
+          fi
+
       - name: Validate skip-tests opt-out
         if: ${{ !inputs.run-tests }}
         env:
@@ -266,6 +277,16 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ github.token }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Attach HEAD to branch
+        if: github.event_name == 'workflow_run'
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          # Checking out a SHA leaves the repo in detached HEAD state.
+          # PSR needs an attached branch to match against branches config.
+          git checkout -B "$HEAD_BRANCH"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -347,6 +368,15 @@ jobs:
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
           force_level: ${{ inputs.force-release }}
+          # Branch ruleset blocks direct commits; tag refs are exempt. Skipping
+          # the version-bump commit means PSR only pushes a tag, which succeeds
+          # without any bypass actor.
+          commit: "false"
+          # PSR v10.5.3 serializes draft/prerelease as JSON strings ("false")
+          # instead of booleans, which GitHub's Releases API rejects with 422.
+          # Release creation is handled by the step below via gh, which types
+          # booleans correctly.
+          vcs_release: "false"
 
       - name: Sign artifacts with Sigstore
         if: ${{ inputs.sign-artifacts && (steps.semantic-release.outputs.released == 'true' || !inputs.semantic-release) }}
@@ -355,12 +385,17 @@ jobs:
           inputs: ./dist/*.tar.gz ./dist/*.whl
           release-signing-artifacts: true
 
-      - name: Upload to GitHub Release (Semantic)
+      - name: Create GitHub Release
         if: ${{ inputs.semantic-release && steps.semantic-release.outputs.released == 'true' }}
-        uses: python-semantic-release/publish-action@310a9983a0ae878b29f3aac778d7c77c1db27378  # v10.5.3
-        with:
-          github_token: ${{ github.token }}
-          tag: ${{ steps.semantic-release.outputs.tag }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.semantic-release.outputs.tag }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --repo "$GITHUB_REPOSITORY" \
+            dist/*
 
       # Manual Release Mode
       - name: Manual Release


### PR DESCRIPTION
## Summary

- **PSR 422 bug**: `vcs_release: "false"` + separate `gh release create dist/*` step — avoids the `github3` boolean serialization bug that returns 422 from GitHub Releases API
- **Detached HEAD bug**: SHA-pinned checkout + `git checkout -B "$HEAD_BRANCH"` step for `workflow_run` callers — PSR requires an attached branch to match `[tool.semantic_release.branches]` config
- **Branch ruleset bypass**: `commit: "false"` so PSR only pushes tags; tag refs are exempt from branch rulesets, no bypass actor needed
- **Fork security**: fork-owner verification step (S7631) for `workflow_run` callers
- **Default safety**: `publish-to-pypi` default flipped from `true` to `false` — callers must now opt in explicitly

## Validated against

End-to-end validation on `ByronWilliamsCPA/.claude` (release v0.14.0, 2026-05-28). All five mitigations confirmed working.

## Test plan

- [ ] Merge PR
- [ ] Verify `python-release.yml` is updated on main
- [ ] Trigger a release in a downstream repo — confirm tag push succeeds and GitHub Release is created via `gh release create`

Generated with [Claude Code](https://claude.com/claude-code)