### PR TITLE
feat(workflows): add python-qlty-gate reusable workflow

### DIFF
--- a/.github/workflows/python-qlty-gate.yml
+++ b/.github/workflows/python-qlty-gate.yml
@@ -1,0 +1,149 @@
+# ===========================================================================
+# Reusable Qlty Gate Workflow
+# ===========================================================================
+# Runs qlty check as a blocking CI gate and optionally as an informational
+# full-codebase health scan.
+#
+# Two operating modes controlled by the check-all input:
+#
+#   Diff mode (default, check-all: false)
+#     Analyzes only files changed relative to the upstream ref.
+#     Use for PR gates to catch newly introduced issues.
+#
+#   Full scan mode (check-all: true)
+#     Analyzes the entire codebase via --all.
+#     Use for scheduled health scans on the default branch.
+#
+# The resulting CheckRun is named "{caller-job-id} / Qlty Gate".
+# Callers must use the job id "qlty-gate" so the required_status_checks
+# entry "qlty-gate / Qlty Gate" matches consistently across repos.
+#
+# Minimal caller example (PR gate):
+#
+#   jobs:
+#     qlty-gate:
+#       if: github.event_name == 'pull_request'
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@<sha>
+#       with:
+#         fail-level: medium
+#         upstream: origin/${{ github.base_ref }}
+#       permissions:
+#         contents: read
+#
+# Minimal caller example (weekly health scan):
+#
+#   jobs:
+#     qlty-gate:
+#       if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@<sha>
+#       with:
+#         fail-level: high
+#         check-all: true
+#         no-fail: true
+#       permissions:
+#         contents: read
+# ===========================================================================
+
+name: Qlty Gate (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      fail-level:
+        description: >
+          Minimum severity level that triggers a non-zero exit.
+          Options: note, fmt, low, medium, high. Default: medium.
+        type: string
+        required: false
+        default: 'medium'
+
+      check-all:
+        description: >
+          When true, analyze the entire codebase (--all) instead of only
+          changed files. Use for scheduled full health scans.
+        type: boolean
+        required: false
+        default: false
+
+      no-fail:
+        description: >
+          When true, exit 0 regardless of findings. Use for informational
+          scans that should not block workflows.
+        type: boolean
+        required: false
+        default: false
+
+      upstream:
+        description: >
+          Base ref for diff comparison in diff mode, e.g. origin/main.
+          Ignored when check-all is true.
+        type: string
+        required: false
+        default: ''
+
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        type: number
+        required: false
+        default: 15
+
+permissions: {}
+
+jobs:
+  gate:
+    name: Qlty Gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install Qlty CLI
+        uses: qltysh/qlty-action/install@fd52dc852530a708d68c3b7342f8d33d1df4cd55  # v2.2.1
+
+      - name: Run qlty check
+        env:
+          FAIL_LEVEL: ${{ inputs.fail-level }}
+          CHECK_ALL: ${{ inputs.check-all }}
+          NO_FAIL: ${{ inputs.no-fail }}
+          UPSTREAM: ${{ inputs.upstream }}
+        run: |
+          args=("--fail-level" "$FAIL_LEVEL")
+          if [ "$CHECK_ALL" = "true" ]; then
+            args+=("--all")
+          elif [ -n "$UPSTREAM" ]; then
+            args+=("--upstream" "$UPSTREAM")
+          fi
+          [ "$NO_FAIL" = "true" ] && args+=("--no-fail")
+          qlty check "${args[@]}"
+
+      - name: Write job summary
+        if: always()
+        env:
+          FAIL_LEVEL: ${{ inputs.fail-level }}
+          CHECK_ALL: ${{ inputs.check-all }}
+          NO_FAIL: ${{ inputs.no-fail }}
+        run: |
+          {
+            echo "## Qlty Gate"
+            echo ""
+            echo "| Setting | Value |"
+            echo "|---------|-------|"
+            if [ "$CHECK_ALL" = "true" ]; then
+              echo "| Mode | Full scan (\`--all\`) |"
+            else
+              echo "| Mode | Diff only (changed files) |"
+            fi
+            echo "| Fail level | \`$FAIL_LEVEL\` |"
+            echo "| Informational only | \`$NO_FAIL\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-qlty-gate.yml
+++ b/.github/workflows/python-qlty-gate.yml
@@ -7,7 +7,9 @@
 # Two operating modes controlled by the check-all input:
 #
 #   Diff mode (default, check-all: false)
-#     Analyzes only files changed relative to the upstream ref.
+#     Analyzes only files changed relative to the upstream ref. Requires the
+#     upstream input to be set (e.g. origin/main); the gate fails fast when
+#     neither check-all nor upstream is provided.
 #     Use for PR gates to catch newly introduced issues.
 #
 #   Full scan mode (check-all: true)
@@ -23,7 +25,7 @@
 #   jobs:
 #     qlty-gate:
 #       if: github.event_name == 'pull_request'
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@<sha>
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@v1
 #       with:
 #         fail-level: medium
 #         upstream: origin/${{ github.base_ref }}
@@ -35,7 +37,7 @@
 #   jobs:
 #     qlty-gate:
 #       if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@<sha>
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@v1
 #       with:
 #         fail-level: high
 #         check-all: true
@@ -76,7 +78,7 @@ on:
       upstream:
         description: >
           Base ref for diff comparison in diff mode, e.g. origin/main.
-          Ignored when check-all is true.
+          Required when check-all is false; ignored when check-all is true.
         type: string
         required: false
         default: ''
@@ -87,12 +89,19 @@ on:
         required: false
         default: 15
 
+# #CRITICAL: deny-by-default at workflow scope. A reusable workflow inherits no
+# token scope implicitly; each job below requests the minimum it needs, and a
+# caller can never grant this workflow more than the caller's own token holds.
+# #VERIFY: confirm no job added later depends on an implicit (unset) permission.
 permissions: {}
 
 jobs:
   gate:
     name: Qlty Gate
     runs-on: ubuntu-latest
+    # #ASSUME: read-only checkout is the only access qlty check needs; it reads
+    # source files and writes findings to the step summary, never to the repo or API.
+    # #VERIFY: widen to security-events: write only if a future step uploads SARIF.
     permissions:
       contents: read
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -107,6 +116,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          # #ASSUME: qlty check needs no Git credentials; disabling persistence keeps
+          # GITHUB_TOKEN out of .git/config while scanning checked-out code.
+          # #VERIFY: re-enable only if a future step pushes or calls the API.
+          persist-credentials: false
 
       - name: Install Qlty CLI
         uses: qltysh/qlty-action/install@fd52dc852530a708d68c3b7342f8d33d1df4cd55  # v2.2.1
@@ -118,6 +131,19 @@ jobs:
           NO_FAIL: ${{ inputs.no-fail }}
           UPSTREAM: ${{ inputs.upstream }}
         run: |
+          # #EDGE: diff mode needs an explicit upstream ref. Without --all or
+          # --upstream, qlty check's scan scope is ambiguous, so fail fast.
+          if [ "$CHECK_ALL" != "true" ] && [ -z "$UPSTREAM" ]; then
+            echo "::error::Either check-all must be true or upstream must be set for diff mode."
+            exit 1
+          fi
+          case "$FAIL_LEVEL" in
+            note | fmt | low | medium | high) ;;
+            *)
+              echo "::error::Invalid fail-level '$FAIL_LEVEL'. Must be one of: note, fmt, low, medium, high."
+              exit 1
+              ;;
+          esac
           args=("--fail-level" "$FAIL_LEVEL")
           if [ "$CHECK_ALL" = "true" ]; then
             args+=("--all")
@@ -133,6 +159,7 @@ jobs:
           FAIL_LEVEL: ${{ inputs.fail-level }}
           CHECK_ALL: ${{ inputs.check-all }}
           NO_FAIL: ${{ inputs.no-fail }}
+          UPSTREAM: ${{ inputs.upstream }}
         run: |
           {
             echo "## Qlty Gate"
@@ -146,4 +173,5 @@ jobs:
             fi
             echo "| Fail level | \`$FAIL_LEVEL\` |"
             echo "| Informational only | \`$NO_FAIL\` |"
+            [ -n "$UPSTREAM" ] && echo "| Upstream ref | \`$UPSTREAM\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ### Added
 
+- `python-qlty-gate.yml`: new reusable workflow that runs `qlty check` as a
+  blocking CI gate. Two modes via the `check-all` input: diff mode (default)
+  analyzes only files changed against the `upstream` ref for PR gates, and full
+  scan mode (`check-all: true`) runs `qlty check --all` for scheduled health
+  scans. Inputs: `fail-level` (default `medium`, validated against
+  `note/fmt/low/medium/high`), `no-fail` (informational runs that always exit 0),
+  `upstream` (required in diff mode; the gate fails fast when neither `check-all`
+  nor `upstream` is set), and `timeout-minutes` (default 15). Carries
+  deny-by-default `permissions: {}` with a job-scoped `contents: read`, sets
+  `persist-credentials: false` on checkout, and SHA-pins all actions. Callers
+  must use job id `qlty-gate` so the resulting `qlty-gate / Qlty Gate` CheckRun
+  matches the `required_status_checks` entry across repos. Documented in
+  `docs/workflows/python-qlty-gate.md`.
 - Repo-local `.github/workflows/pre-commit.yml` lint gate (yamllint, markdownlint, the mandatory no-em-dash guard, and secret scans) now runs on every push and PR, closing the gap where these hooks ran only for developers who had run `pre-commit install`. Carries deny-by-default `permissions: {}` and installs pre-commit via the locked `uv pip install --no-build` pattern (not bare pip), satisfying the S8541/S8544 supply-chain gates.
 - Operator scripts: `scripts/transfer-repos.sh` gains `--dry-run` (and `--help`) and surfaces the underlying `gh` error on failure instead of discarding it; `scripts/sync-secrets.sh` surfaces `gh` errors with a `GH_DEBUG`/`GH_PAGER` guard so a secret cannot leak into the failure output. New Bats suites cover `transfer-repos.sh`, `sync-secrets.sh`, and `sync_org_files.sh`.
 - `python-sbom.yml`: OSV-Scanner runs alongside Trivy and Grype as a third

--- a/docs/workflows/python-qlty-gate.md
+++ b/docs/workflows/python-qlty-gate.md
@@ -1,0 +1,61 @@
+# python-qlty-gate.yml -- Reusable Qlty check gate
+
+Runs `qlty check` as a blocking CI gate and, optionally, as an informational
+full-codebase health scan. Use it as a required PR gate (diff mode) and as a
+scheduled debt tracker (full scan mode).
+
+## Operating modes
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| Diff (default) | `check-all: false` | Analyzes only files changed against `upstream`. Requires `upstream` to be set; the gate fails fast when neither `check-all` nor `upstream` is provided. |
+| Full scan | `check-all: true` | Runs `qlty check --all` over the whole codebase. Pair with `no-fail: true` for non-blocking scheduled health scans. |
+
+## Minimal usage (PR gate)
+
+```yaml
+jobs:
+  qlty-gate:
+    if: github.event_name == 'pull_request'
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@v1
+    with:
+      fail-level: medium
+      upstream: origin/${{ github.base_ref }}
+    permissions:
+      contents: read
+```
+
+## Minimal usage (weekly health scan)
+
+```yaml
+jobs:
+  qlty-gate:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@v1
+    with:
+      fail-level: high
+      check-all: true
+      no-fail: true
+    permissions:
+      contents: read
+```
+
+## Inputs
+
+| Input | Default | Purpose |
+|-------|---------|---------|
+| `fail-level` | `medium` | Minimum severity that triggers a non-zero exit. One of `note`, `fmt`, `low`, `medium`, `high`; an invalid value fails the gate with an explicit error. |
+| `check-all` | `false` | Full scan (`--all`) instead of diff mode. |
+| `no-fail` | `false` | Always exit 0; use for informational scans that must not block. |
+| `upstream` | `''` | Base ref for diff comparison, e.g. `origin/main`. Required when `check-all` is false; ignored when it is true. |
+| `timeout-minutes` | `15` | Job timeout in minutes. |
+
+See `.github/workflows/python-qlty-gate.yml` for the authoritative input list.
+
+## Required status check
+
+The job inside the reusable workflow is named `Qlty Gate`. Callers must use the
+job id `qlty-gate` so the resulting CheckRun is named `qlty-gate / Qlty Gate`.
+That is the exact name to add to `required_status_checks` in the org baseline
+ruleset, and it must match across repos for branch protection to resolve
+consistently.


### PR DESCRIPTION
## Summary

Adds a reusable workflow that runs `qlty check` as a blocking CI gate.

- **Diff mode** (default): analyzes only changed files relative to an upstream ref; used for PR gates so only newly introduced issues block merges
- **Full scan mode** (`check-all: true`): runs `qlty check --all`; used for scheduled health scans to track accumulated debt on the default branch

The job inside the reusable workflow is named `Qlty Gate`. When called with caller job id `qlty-gate` (required by convention), the resulting CheckRun name is `qlty-gate / Qlty Gate`. This is the name to add to `required_status_checks` in the org baseline ruleset.

## Inputs

| Input | Default | Purpose |
|-------|---------|---------|
| `fail-level` | `medium` | Minimum severity that triggers non-zero exit |
| `check-all` | `false` | Full scan vs diff mode |
| `no-fail` | `false` | Informational mode (always exits 0) |
| `upstream` | `''` | Base ref for diff comparison |
| `timeout-minutes` | `15` | Job timeout |

## Context

Part of a two-PR set to wire up qlty enforcement:
1. This PR: add the reusable workflow
2. reference-library PR: call this workflow from `qlty.yml` with fail-level medium (PR gate) and scheduled full scan

The companion PR references commit `040026ab682aa4b9ef491750d62cdd1592cdb659` from this branch.

## Test plan

- [ ] `python-qlty-gate.yml` validates with `actionlint`
- [ ] Companion reference-library PR shows `qlty-gate / Qlty Gate` CheckRun after this merges
- [ ] Verify `qlty-gate / Qlty Gate` added to `ByronWilliamsCPA-default-branch-baseline` required checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new reusable CI workflow for code quality checks. Includes configurable fail severity levels, flexible scanning modes (differential or full codebase analysis), upstream base reference specification, custom timeout values, optional informational reporting, and detailed job summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->