### PR TITLE
feat(ci): add qlty gate and weekly health scan

### DIFF
--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -1,0 +1,39 @@
+name: Qlty
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full-codebase health scan: Monday 07:00 UTC
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: qlty-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # PR gate: diff mode, block merges that introduce medium+ severity issues.
+  # Check name: "qlty-gate / Qlty Gate" -- required by org docs-tier ruleset.
+  qlty-gate:
+    if: github.event_name == 'pull_request'
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    permissions:
+      contents: read
+    with:
+      fail-level: medium
+      upstream: origin/${{ github.base_ref }}
+
+  # Weekly health scan: full codebase, informational only.
+  # Remove no-fail once existing qlty debt is resolved.
+  qlty-health:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    permissions:
+      contents: read
+    with:
+      fail-level: high
+      check-all: true
+      no-fail: true

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -8,7 +8,11 @@ on:
     - cron: '0 7 * * 1'
   workflow_dispatch:
 
-permissions: read-all
+# Deny-by-default at workflow scope; each job opts into the minimum below.
+# #ASSUME reusable-workflow callees inherit the caller job's permissions
+# (contents: read), not this empty workflow-level set. #VERIFY each job
+# declares its own permissions block.
+permissions: {}
 
 concurrency:
   group: qlty-${{ github.ref }}
@@ -19,7 +23,7 @@ jobs:
   # Check name: "qlty-gate / Qlty Gate" -- required by org docs-tier ruleset.
   qlty-gate:
     if: github.event_name == 'pull_request'
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@1561a3ef04892ffd6c4a0c4c46fdf1de5a34ed02
     permissions:
       contents: read
     with:
@@ -27,10 +31,11 @@ jobs:
       upstream: origin/${{ github.base_ref }}
 
   # Weekly health scan: full codebase, informational only.
-  # Remove no-fail once existing qlty debt is resolved.
+  # fail-level is advisory while no-fail is set; remove no-fail once existing
+  # qlty debt is resolved so fail-level begins to enforce.
   qlty-health:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@040026ab682aa4b9ef491750d62cdd1592cdb659
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-qlty-gate.yml@1561a3ef04892ffd6c4a0c4c46fdf1de5a34ed02
     permissions:
       contents: read
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
   must use job id `qlty-gate` so the resulting `qlty-gate / Qlty Gate` CheckRun
   matches the `required_status_checks` entry across repos. Documented in
   `docs/workflows/python-qlty-gate.md`.
+- `.github/workflows/qlty.yml`: repo-local caller that wires
+  `python-qlty-gate.yml` into this repo. A `qlty-gate` job runs the diff-mode
+  gate on every PR (`fail-level: medium`), producing the `qlty-gate / Qlty Gate`
+  required check; a `qlty-health` job runs a weekly full-codebase scan (Monday
+  07:00 UTC) plus `workflow_dispatch`, informational only (`no-fail: true`).
+  Carries deny-by-default `permissions: {}` with job-scoped `contents: read` and
+  SHA-pins the reusable workflow.
 - Repo-local `.github/workflows/pre-commit.yml` lint gate (yamllint, markdownlint, the mandatory no-em-dash guard, and secret scans) now runs on every push and PR, closing the gap where these hooks ran only for developers who had run `pre-commit install`. Carries deny-by-default `permissions: {}` and installs pre-commit via the locked `uv pip install --no-build` pattern (not bare pip), satisfying the S8541/S8544 supply-chain gates.
 - Operator scripts: `scripts/transfer-repos.sh` gains `--dry-run` (and `--help`) and surfaces the underlying `gh` error on failure instead of discarding it; `scripts/sync-secrets.sh` surfaces `gh` errors with a `GH_DEBUG`/`GH_PAGER` guard so a secret cannot leak into the failure output. New Bats suites cover `transfer-repos.sh`, `sync-secrets.sh`, and `sync_org_files.sh`.
 - `python-sbom.yml`: OSV-Scanner runs alongside Trivy and Grype as a third


### PR DESCRIPTION
Adds qlty-gate job (PR diff gate, fail-level medium) and qlty-health job (weekly Monday scan, informational) to the .github infra repo itself. No coverage upload since this is a config/infra repo. Depends on PR #188 merging first (which adds the python-qlty-gate.yml reusable workflow this calls).