### PR TITLE
chore(deps): add detection-only dependabot.yml (Renovate sole PR-opener)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+# Detection-only: Renovate is the sole PR-opener. open-pull-requests-limit: 0
+# suppresses Dependabot version PRs. Dependabot alerts (a repo setting) remain
+# the multi-ecosystem detection ledger. Refs: standards CI-021 (amended), CI-074.
+updates:
+  - package-ecosystem: "github-actions" # if .github/workflows/ present
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Adds a detection-only `.github/dependabot.yml` for the org `.github` repo. Only the `github-actions` ecosystem block is included (verified `.github/workflows/` exists). `open-pull-requests-limit: 0` suppresses Dependabot version PRs so Renovate stays the sole PR-opener; Dependabot alerts (a repo setting) remain the detection ledger. Refs: standards CI-021 (amended), CI-074.