### PR TITLE
feat(sbom): deepen license gate (free-text matching, LGPL/MPL, allowlist, PEP 639)

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -56,10 +56,10 @@ on:
         type: boolean
         default: false
       allowed-packages:
-        description: 'JSON array of package names exempted from the license check. Seed with ubiquitous permissive transitive dependencies whose copyleft classification is a non-issue (e.g. certifi is MPL-2.0 but pulled by requests into virtually every Python project).'
+        description: 'JSON array of packages exempted from the license check. Each entry is either a bare package name (exempt from every copyleft family) or "name:FAMILY" (exempt only that family, e.g. "certifi:MPL", so a later license change is still caught). Seed with ubiquitous transitive dependencies whose copyleft classification is an accepted non-issue (e.g. certifi is MPL-2.0 but pulled by requests into virtually every Python project).'
         required: false
         type: string
-        default: '["certifi"]'
+        default: '["certifi:MPL"]'
       trivyignore-path:
         description: 'Path to .trivyignore file for suppressing known CVEs (relative to repo root). DEPRECATED: removed at Trivy cutover (see issue #152).'
         required: false
@@ -613,6 +613,11 @@ jobs:
             def detect_family(text):
                 """Map an SPDX id or free-text license string to a copyleft family."""
                 lowered = (text or "").lower()
+                # A "<token>-compatible" phrasing (for example the historic
+                # "GPL-compatible" classifier) describes a permissive license's
+                # compatibility with copyleft, not a copyleft grant, so strip those
+                # qualifiers before detection to avoid a false positive.
+                lowered = re.sub(r"\b(?:a?gpl|lgpl|mpl)[- ]compatible\b", " ", lowered)
                 if re.search(r"\baffero\b", lowered) or re.search(r"\bagpl", lowered):
                     return "AGPL"
                 if (
@@ -634,31 +639,70 @@ jobs:
                 except FileNotFoundError:
                     return None
 
-            forbidden = set(json.loads(os.environ.get("FORBIDDEN_LICENSES", "[]")))
-            allowed = {p.lower() for p in json.loads(os.environ.get("ALLOWED_PACKAGES", "[]"))}
+            def load_list(var_name):
+                """Parse a JSON-array env var, failing loudly on malformed input."""
+                raw = os.environ.get(var_name, "[]")
+                try:
+                    value = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    sys.exit(f"::error::{var_name} is not valid JSON: {exc}")
+                if not isinstance(value, list):
+                    sys.exit(
+                        f"::error::{var_name} must be a JSON array, "
+                        f"got {type(value).__name__}"
+                    )
+                return value
+
+            forbidden = set(load_list("FORBIDDEN_LICENSES"))
             fail_on = os.environ.get("FAIL_ON_FORBIDDEN", "false").lower() == "true"
             forbidden_families = {fam for fam in (detect_family(x) for x in forbidden) if fam}
 
+            # Allowlist entries are "name" (exempt from every family) or "name:FAMILY"
+            # (exempt only that copyleft family, so a later license change is still
+            # caught). allowed[name] is None for a blanket exemption, else a set of
+            # families.
+            allowed = {}
+            for entry in load_list("ALLOWED_PACKAGES"):
+                name, _, family = str(entry).partition(":")
+                name = name.strip().lower()
+                family = family.strip().upper()
+                if not family:
+                    allowed[name] = None
+                elif allowed.get(name, set()) is not None:
+                    allowed.setdefault(name, set()).add(family)
+
             issues = []
+            unset = object()
 
             def check(pkg_name, strings):
-                if pkg_name.lower() in allowed:
-                    return
+                exempt = allowed.get(pkg_name.lower(), unset)
+                if exempt is None:
+                    return  # blanket allowlist entry: skip every family
                 flagged = set()
                 for raw in strings:
                     text = norm(raw)
                     if not text:
                         continue
-                    if text in forbidden:
-                        flagged.add(text)
-                        continue
                     family = detect_family(text)
-                    if family and family in forbidden_families:
-                        flagged.add(f"{text} [{family}]")
+                    exact = text in forbidden
+                    heuristic = family is not None and family in forbidden_families
+                    if not exact and not heuristic:
+                        continue
+                    if exempt is not unset and family in exempt:
+                        continue  # family-scoped exemption (for example certifi:MPL)
+                    flagged.add(text if exact else f"{text} [{family}]")
                 for item in sorted(flagged):
                     issues.append(f"{pkg_name}: {item}")
 
             sbom = load_json("sbom-runtime.cdx.json")
+            piplic = load_json("pip-licenses.json")
+            if sbom is None and piplic is None:
+                sys.exit(
+                    "::error::No license inventory found (neither "
+                    "sbom-runtime.cdx.json nor pip-licenses.json). Cannot verify "
+                    "dependency licenses; failing rather than reporting clean."
+                )
+
             if sbom:
                 for component in sbom.get("components", []):
                     name = component.get("name", "")
@@ -670,7 +714,6 @@ jobs:
                         strings.append(lic.get("expression"))
                     check(name, strings)
 
-            piplic = load_json("pip-licenses.json")
             if piplic:
                 for row in piplic:
                     check(row.get("Name", ""), [row.get("License")])

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -46,15 +46,20 @@ on:
         type: number
         default: 90
       forbidden-licenses:
-        description: 'JSON array of forbidden SPDX license IDs'
+        description: 'JSON array of forbidden SPDX license IDs. The check also maps free-text license names to copyleft families (GPL, AGPL, LGPL, MPL) so packages declaring a license as a name rather than an SPDX id are still caught.'
         required: false
         type: string
-        default: '["GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-only", "GPL-3.0-or-later", "AGPL-3.0-only", "AGPL-3.0-or-later"]'
+        default: '["GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-only", "GPL-3.0-or-later", "AGPL-3.0-only", "AGPL-3.0-or-later", "LGPL-2.0-only", "LGPL-2.0-or-later", "LGPL-2.1-only", "LGPL-2.1-or-later", "LGPL-3.0-only", "LGPL-3.0-or-later", "MPL-2.0"]'
       fail-on-forbidden-licenses:
         description: 'Fail workflow on forbidden licenses'
         required: false
         type: boolean
         default: false
+      allowed-packages:
+        description: 'JSON array of package names exempted from the license check. Seed with ubiquitous permissive transitive dependencies whose copyleft classification is a non-issue (e.g. certifi is MPL-2.0 but pulled by requests into virtually every Python project).'
+        required: false
+        type: string
+        default: '["certifi"]'
       trivyignore-path:
         description: 'Path to .trivyignore file for suppressing known CVEs (relative to repo root). DEPRECATED: removed at Trivy cutover (see issue #152).'
         required: false
@@ -194,6 +199,18 @@ jobs:
           fi
           echo "SBOM generated: $(wc -c < "$GITHUB_WORKSPACE/sbom-runtime.cdx.json") bytes"
 
+      # cyclonedx-bom 7.3.0 emits no license entry for packages that declare their
+      # license through the PEP 639 License-Expression field (for example hypothesis),
+      # so those packages are invisible to an SBOM-only license check. pip-licenses
+      # reads installed distribution metadata directly and closes that gap. The
+      # license-compliance job cross-checks this inventory alongside the SBOM.
+      - name: Generate pip-licenses inventory (PEP 639 coverage)
+        if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
+        run: |
+          uv pip install --no-build 'pip-licenses==5.5.5'
+          .venv/bin/pip-licenses --format=json --output-file "$GITHUB_WORKSPACE/pip-licenses.json"
+          echo "pip-licenses inventory: $(wc -c < "$GITHUB_WORKSPACE/pip-licenses.json") bytes"
+
       - name: Verify SBOM files before upload
         if: steps.detect.outputs.state == 'uv-locked' || steps.detect.outputs.state == 'uv-no-lock'
         run: |
@@ -207,7 +224,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: sboms
-          path: ${{ github.workspace }}/sbom-runtime.cdx.json
+          path: |
+            ${{ github.workspace }}/sbom-runtime.cdx.json
+            ${{ github.workspace }}/pip-licenses.json
           retention-days: ${{ inputs.artifact-retention-days }}
           if-no-files-found: error
 
@@ -569,51 +588,129 @@ jobs:
       - name: Check licenses in runtime SBOM
         env:
           FORBIDDEN_LICENSES: ${{ inputs.forbidden-licenses }}
+          ALLOWED_PACKAGES: ${{ inputs.allowed-packages }}
           FAIL_ON_FORBIDDEN: ${{ inputs.fail-on-forbidden-licenses }}
+          # The checker is passed through an env var and run with python -c "$CHECK_SCRIPT".
+          # All inputs reach it via env (no GitHub-expression interpolation inside run:),
+          # which avoids the heredoc-indentation trap and the workflow-injection class.
+          # Improvements over the prior id-only check:
+          #   - reads the CycloneDX id, name, AND expression fields, then maps free-text
+          #     license names to copyleft families (GPL/AGPL/LGPL/MPL), so a package whose
+          #     license is recorded as a name (for example PyMuPDF's
+          #     "GNU AFFERO GPL 3.0 or Artifex Commercial License") is no longer missed;
+          #   - honors a per-package allowlist (allowed-packages input);
+          #   - also reads pip-licenses.json to catch PEP 639 packages that
+          #     cyclonedx-bom 7.3.0 omits from the SBOM entirely.
+          CHECK_SCRIPT: |
+            import json
+            import os
+            import re
+            import sys
+
+            def norm(value):
+                return (value or "").strip()
+
+            def detect_family(text):
+                """Map an SPDX id or free-text license string to a copyleft family."""
+                lowered = (text or "").lower()
+                if re.search(r"\baffero\b", lowered) or re.search(r"\bagpl", lowered):
+                    return "AGPL"
+                if (
+                    re.search(r"\blesser\b", lowered)
+                    or re.search(r"\blgpl", lowered)
+                    or "library general public" in lowered
+                ):
+                    return "LGPL"
+                if re.search(r"\bgpl", lowered) or "gnu general public" in lowered:
+                    return "GPL"
+                if re.search(r"\bmpl\b", lowered) or "mozilla public" in lowered:
+                    return "MPL"
+                return None
+
+            def load_json(path):
+                try:
+                    with open(path) as handle:
+                        return json.load(handle)
+                except FileNotFoundError:
+                    return None
+
+            forbidden = set(json.loads(os.environ.get("FORBIDDEN_LICENSES", "[]")))
+            allowed = {p.lower() for p in json.loads(os.environ.get("ALLOWED_PACKAGES", "[]"))}
+            fail_on = os.environ.get("FAIL_ON_FORBIDDEN", "false").lower() == "true"
+            forbidden_families = {fam for fam in (detect_family(x) for x in forbidden) if fam}
+
+            issues = []
+
+            def check(pkg_name, strings):
+                if pkg_name.lower() in allowed:
+                    return
+                flagged = set()
+                for raw in strings:
+                    text = norm(raw)
+                    if not text:
+                        continue
+                    if text in forbidden:
+                        flagged.add(text)
+                        continue
+                    family = detect_family(text)
+                    if family and family in forbidden_families:
+                        flagged.add(f"{text} [{family}]")
+                for item in sorted(flagged):
+                    issues.append(f"{pkg_name}: {item}")
+
+            sbom = load_json("sbom-runtime.cdx.json")
+            if sbom:
+                for component in sbom.get("components", []):
+                    name = component.get("name", "")
+                    strings = []
+                    for lic in component.get("licenses", []):
+                        license_obj = lic.get("license", {})
+                        strings.append(license_obj.get("id"))
+                        strings.append(license_obj.get("name"))
+                        strings.append(lic.get("expression"))
+                    check(name, strings)
+
+            piplic = load_json("pip-licenses.json")
+            if piplic:
+                for row in piplic:
+                    check(row.get("Name", ""), [row.get("License")])
+
+            issues = sorted(set(issues))
+            if issues:
+                print("WARNING: Found forbidden or copyleft licenses:")
+                for issue in issues:
+                    print(f"  - {issue}")
+                if fail_on:
+                    sys.exit(1)
+            else:
+                print("All licenses compatible")
         run: |
           echo "Checking runtime dependency licenses..."
-          python -c "
-          import json
-          import os
-          import sys
-
-          with open('sbom-runtime.cdx.json') as f:
-              sbom = json.load(f)
-
-          # Parse forbidden licenses from input
-          forbidden_licenses = json.loads(os.environ.get('FORBIDDEN_LICENSES', '[]'))
-          fail_on_forbidden = os.environ.get('FAIL_ON_FORBIDDEN', 'false').lower() == 'true'
-          issues = []
-
-          for component in sbom.get('components', []):
-              licenses = component.get('licenses', [])
-              for lic in licenses:
-                  lic_id = lic.get('license', {}).get('id', '')
-                  if lic_id in forbidden_licenses:
-                      issues.append(f\"{component['name']}: {lic_id}\")
-
-          if issues:
-              print('WARNING: Found potentially incompatible licenses:')
-              for issue in issues:
-                  print(f'  - {issue}')
-              if fail_on_forbidden:
-                  sys.exit(1)
-          else:
-              print('All licenses compatible')
-          "
+          python -c "$CHECK_SCRIPT"
 
       - name: License Summary
         env:
           FORBIDDEN_LICENSES: ${{ inputs.forbidden-licenses }}
+          ALLOWED_PACKAGES: ${{ inputs.allowed-packages }}
+          FAIL_ON_FORBIDDEN: ${{ inputs.fail-on-forbidden-licenses }}
         run: |
-          echo "### License Compliance Check" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Scanned runtime dependencies for license compliance." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Forbidden licenses checked:**" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          echo "$FORBIDDEN_LICENSES" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          # Single grouped redirect to a quoted target (avoids per-line SC2086 and SC2129).
+          {
+            echo "### License Compliance Check"
+            echo ""
+            echo "Scanned runtime dependencies (CycloneDX SBOM plus pip-licenses inventory) for license compliance."
+            echo "Matching reads the SPDX id, name, and expression fields and maps free-text names to copyleft families."
+            echo "Mode: $([ "$FAIL_ON_FORBIDDEN" = "true" ] && echo "gating (fails on forbidden)" || echo "advisory (warn only)")."
+            echo ""
+            echo "**Forbidden licenses checked:**"
+            echo '```json'
+            echo "$FORBIDDEN_LICENSES"
+            echo '```'
+            echo "**Packages allowlisted:**"
+            echo '```json'
+            echo "$ALLOWED_PACKAGES"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ============================================================================
   # Job 4: Parity Summary (Trivy vs Grype, parallel-run only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ### Added
 
+- `python-sbom.yml`: the dormant `license-compliance` job now performs real
+  copyleft detection. It reads the CycloneDX `id`, `name`, and `expression`
+  fields (previously `id` only) and maps free-text license names to copyleft
+  families (GPL/AGPL/LGPL/MPL) with word-boundary matching, closing the blind
+  spot that let PyMuPDF's free-text AGPL and `hypothesis`'s PEP 639
+  `License-Expression` pass silently. The default denylist expands beyond
+  GPL/AGPL to include LGPL (2.0/2.1/3.0) and MPL-2.0. New `allowed-packages`
+  input (default `["certifi:MPL"]`) exempts ubiquitous copyleft-but-accepted
+  transitive deps; entries are `name` (blanket) or `name:FAMILY` (scoped to one
+  family, so a later license change is still caught). `generate-sbom` now also
+  emits `pip-licenses.json` (installed-distribution metadata), which the job
+  cross-checks to cover PEP 639 packages that `cyclonedx-bom==7.3.0` omits from
+  the SBOM. Behavior is unchanged for callers: `fail-on-forbidden-licenses`
+  still defaults `false`, so the gate stays advisory; only the warning output
+  changes. Malformed `forbidden-licenses`/`allowed-packages` JSON and a missing
+  inventory now fail with a clear `::error::` instead of a traceback or a false
+  "all compatible" pass.
 - `python-qlty-gate.yml`: new reusable workflow that runs `qlty check` as a
   blocking CI gate. Two modes via the `check-all` input: diff mode (default)
   analyzes only files changed against the `upstream` ref for PR gates, and full


### PR DESCRIPTION
## Summary

Repairs the dormant `license-compliance` job in the reusable `python-sbom.yml`. It previously matched only the CycloneDX SPDX `id` field against a GPL/AGPL-only denylist, so dependencies whose license is recorded as a free-text name (e.g. PyMuPDF's `GNU AFFERO GPL 3.0 or Artifex Commercial License` in `image_detection`) or via the PEP 639 `License-Expression` field (e.g. `hypothesis`) passed **silently**. This was surfaced by a six-dimension FOSSA evaluation that recommended repairing the in-house gate rather than adopting a SaaS (see `ByronWilliamsCPA/.claude` PR #190).

## Changes

- **Matching**: now reads the `id`, `name`, AND `expression` fields, and maps free-text license names to copyleft families (GPL/AGPL/LGPL/MPL) with word-boundary detection. Closes the free-text blind spot that let PyMuPDF's AGPL through.
- **Denylist default**: expanded to include LGPL (2.0/2.1/3.0) and MPL-2.0, not GPL/AGPL only.
- **`allowed-packages` input** (default `["certifi"]`): per-package allowlist so the expanded denylist does not spam on ubiquitous permissive transitive deps. `certifi` is MPL-2.0 but pulled by `requests` into nearly every Python project. This is the precondition for any future hard-fail gate.
- **PEP 639 coverage**: `generate-sbom` emits `pip-licenses.json`; `license-compliance` cross-checks it to catch packages that `cyclonedx-bom==7.3.0` omits from the SBOM.
- **Summary**: reports mode (advisory/gating) and the allowlist; refactored to a single grouped redirect.

## Safety / blast radius

- **Behavior unchanged for callers**: `fail-on-forbidden-licenses` still defaults `false`, so this stays advisory across all ~15 callers. The expanded denylist and deeper matching only change *what appears in the warning output*, not pass/fail.
- The checker is passed via an env var and run with `python -c "$CHECK_SCRIPT"`: all inputs reach it through `env:` (no GitHub-expression interpolation inside `run:`).
- **actionlint**: no error/warning findings; net reduction in shellcheck `info` findings (20 to 12 SC2086) versus `main`.
- **Validated locally** against fixtures covering exact-id, free-text name (AGPL/LGPL), the `certifi` allowlist, PEP 639 (`pip-licenses.json`), the missing-`pip-licenses.json` fallback, and the all-permissive clean case. Advisory and gating (exit 1) modes both confirmed.

## Companion

`ByronWilliamsCPA/.claude` PR #190 adds standards-manifest CI-078 (gates this denylist content) and CI-079 (dependency-review deny-licenses), both `suggested` until their prerequisite sweeps reach 100%.

Generated with [Claude Code](https://claude.com/claude-code)