### PR TITLE
ci: emit required checks on merge_group for queue readiness

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,6 +3,7 @@
 name: PR Validation
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, edited]
     branches:
@@ -12,13 +13,17 @@ on:
 permissions: {}
 
 concurrency:
-  group: pr-validation-${{ github.event.pull_request.number }}
+  group: pr-validation-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   title-check:
     name: PR Title Format
     runs-on: ubuntu-latest
+    # PR title/body live only in the pull_request event payload. On
+    # merge_group refs this job is skipped; the gate jobs below treat a
+    # skipped result as a pass so the merge queue is not blocked.
+    if: github.event_name == 'pull_request'
     timeout-minutes: 5
     permissions:
       pull-requests: read
@@ -46,6 +51,8 @@ jobs:
   body-check:
     name: PR Body Non-Empty
     runs-on: ubuntu-latest
+    # Skipped on merge_group refs (no pull_request payload); see title-check.
+    if: github.event_name == 'pull_request'
     timeout-minutes: 5
     permissions:
       pull-requests: read
@@ -85,7 +92,10 @@ jobs:
           TITLE_RESULT: ${{ needs.title-check.result }}
           BODY_RESULT: ${{ needs.body-check.result }}
         run: |
-          if [ "$TITLE_RESULT" != "success" ] || [ "$BODY_RESULT" != "success" ]; then
+          # On merge_group refs the PR-context checks are skipped; treat
+          # success and skipped as passing, fail only on a real failure.
+          if { [ "$TITLE_RESULT" != "success" ] && [ "$TITLE_RESULT" != "skipped" ]; } || \
+             { [ "$BODY_RESULT" != "success" ] && [ "$BODY_RESULT" != "skipped" ]; }; then
             echo "::error::PR validation checks failed: dependency and standards gate blocked."
             exit 1
           fi
@@ -113,7 +123,9 @@ jobs:
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
           echo "| PR Title Format | $TITLE_RESULT |" >> $GITHUB_STEP_SUMMARY
           echo "| PR Body Non-Empty | $BODY_RESULT |" >> $GITHUB_STEP_SUMMARY
-          if [ "$TITLE_RESULT" != "success" ] || [ "$BODY_RESULT" != "success" ]; then
+          # success or skipped both pass; skipped happens on merge_group refs.
+          if { [ "$TITLE_RESULT" != "success" ] && [ "$TITLE_RESULT" != "skipped" ]; } || \
+             { [ "$BODY_RESULT" != "success" ] && [ "$BODY_RESULT" != "skipped" ]; }; then
             echo "::error::One or more PR validation checks failed."
             exit 1
           fi

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -13,6 +13,7 @@
 name: REUSE Compliance
 
 on:
+  merge_group:
   pull_request:
     paths:
       - "**/*"

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -3,6 +3,7 @@
 name: Security Analysis
 
 on:
+  merge_group:
   push:
     branches: [main, master]
   pull_request:


### PR DESCRIPTION
## What

Adds `merge_group:` triggers to the three PR-required-check caller workflows so they report in the GitHub merge queue:

- `security-analysis.yml` (check: **Security Gate Validation**)
- `pr-validation.yml` (check: **Dependency & Standards Validation**)
- `reuse.yml` (check: **Check REUSE Compliance**)

This repo has no `ci.yml` / `CI Gate` (only 3 required checks), so only these three are in scope.

## Why

Per CI-040, every required-status-check workflow must emit on `merge_group` or the queue waits forever and times out after `check_response_timeout_minutes`. This is the **Step 1 prerequisite** for enabling the `merge_queue` rule (CI-062) on this repo. It mirrors the verified gleif canary, which is now running a green merge queue.

## How (mirrors gleif's verified pattern)

- `pr-validation.yml`: the PR-context jobs (`title-check`, `body-check`) are gated with `if: github.event_name == 'pull_request'` so they **skip** on merge_group refs (where `github.event.pull_request.*` is null). The two `always()` gate jobs (`Dependency & Standards Validation`, `PR Validation Gate`) now treat `skipped` as a pass, so the gate still **runs and reports SUCCESS** in the queue rather than being gated out. Concurrency group made null-safe with `|| github.ref`.
- `security-analysis.yml` / `reuse.yml`: jobs scan the repo (not PR-specific) and run unchanged on merge_group; only the trigger was added. `reuse.yml`'s concurrency group already uses `github.ref`.

## Sequencing

Step 2 (enabling the `merge_queue` ruleset rule) happens **only after this merges**, so the checks actually emit on `merge_group` before the queue expects them.

## Notes

- actionlint's embedded shellcheck reports pre-existing SC2086/SC2129 infos on the unmodified `$GITHUB_STEP_SUMMARY` echo lines; not introduced here and not gated by this repo's CI. Left out of scope.

Refs: docs/superpowers/plans/eventual-floating-pancake.md (merge-queue rollout, step 3)