### PR TITLE
ci: resolve Node 20 deprecation ahead of GitHub's 2026-06-16 cutover

### DIFF
--- a/.github/workflows/python-codecov.yml
+++ b/.github/workflows/python-codecov.yml
@@ -10,7 +10,7 @@
 #     test:
 #       steps:
 #         - run: pytest --cov --cov-report=xml
-#         - uses: actions/upload-artifact@v7
+#         - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
 #           with:
 #             name: coverage-reports
 #             path: coverage.xml

--- a/.github/workflows/python-codecov.yml
+++ b/.github/workflows/python-codecov.yml
@@ -10,7 +10,7 @@
 #     test:
 #       steps:
 #         - run: pytest --cov --cov-report=xml
-#         - uses: actions/upload-artifact@v4
+#         - uses: actions/upload-artifact@v7
 #           with:
 #             name: coverage-reports
 #             path: coverage.xml

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -154,6 +154,11 @@ jobs:
           echo "🔒 Using OIDC Trusted Publishing (no secrets needed)"
 
       - name: Publish to PyPI
+        # #VERIFY: v1.14.0 internally pins actions/setup-python v5.6.0 (node20).
+        # Upstream already bumped to setup-python v6.2.0 (node24) on unstable/v1;
+        # re-pin here when the next release ships. After GitHub's 2026-06-16
+        # cutover, node20 actions execute on node24 automatically, so until then
+        # this surfaces as a deprecation warning only, not a failure.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           print-hash: true
@@ -205,6 +210,7 @@ jobs:
           echo "🔒 Using OIDC Trusted Publishing (no secrets needed)"
 
       - name: Publish to TestPyPI
+        # #VERIFY: see node20 note on the PyPI publish step above.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ## [Unreleased]
 
+### Changed
+
+- Node 20 deprecation sweep ahead of GitHub's 2026-06-16 forced cutover to
+  Node 24. Audit result: every `actions/setup-python` (v6.2.0) and
+  `astral-sh/setup-uv` (v8.2.0) pin in the live reusable workflows and
+  `workflow-templates/` already declares `node24`, as do all other SHA-pinned
+  JavaScript actions in `.github/workflows/`. The remaining node20 surfaces
+  were stale documentation examples and one third-party internal pin, fixed as
+  follows: `QLTY_INTEGRATION.md` examples bumped from `setup-python` v5.5.0 and
+  `checkout` v4.2.2 (both node20) to the v6.2.0 / v6.0.3 SHAs used by the live
+  workflows; `USAGE_EXAMPLES.md` legacy snippet bumped from `@v4` tags to
+  `@v6`; `examples/fuzzing-migration-example.md` bumped `harden-runner` v2.10.1
+  and `checkout` v4.2.2 to the current v2.19.4 / v6.0.3 SHAs; the
+  `python-codecov.yml` usage comment now shows `upload-artifact@v7`. Known
+  residual: `pypa/gh-action-pypi-publish` v1.14.0 (latest release) internally
+  pins `actions/setup-python` v5.6.0 (node20); upstream has already bumped to
+  v6.2.0 on its `unstable/v1` branch, and the publish workflows carry a
+  `#VERIFY` note to re-pin when the next release ships. This emits a
+  deprecation warning only; after the cutover GitHub runs node20 actions on
+  node24 automatically.
+
 ### Added
 
 - `python-sbom.yml`: the dormant `license-compliance` job now performs real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
   were stale documentation examples and one third-party internal pin, fixed as
   follows: `QLTY_INTEGRATION.md` examples bumped from `setup-python` v5.5.0 and
   `checkout` v4.2.2 (both node20) to the v6.2.0 / v6.0.3 SHAs used by the live
-  workflows; `USAGE_EXAMPLES.md` legacy snippet bumped from `@v4` tags to
-  `@v6`; `examples/fuzzing-migration-example.md` bumped `harden-runner` v2.10.1
+  workflows; `USAGE_EXAMPLES.md` legacy snippet bumped from `@v4` tags to the
+  same SHA-pinned v6.0.3 / v6.2.0 references;
+  `examples/fuzzing-migration-example.md` bumped `harden-runner` v2.10.1
   and `checkout` v4.2.2 to the current v2.19.4 / v6.0.3 SHAs; the
-  `python-codecov.yml` usage comment now shows `upload-artifact@v7`. Known
+  `python-codecov.yml` usage comment now shows `upload-artifact` v7.0.1,
+  SHA-pinned. Known
   residual: `pypa/gh-action-pypi-publish` v1.14.0 (latest release) internally
   pins `actions/setup-python` v5.6.0 (node20); upstream has already bumped to
   v6.2.0 on its `unstable/v1` branch, and the publish workflows carry a

--- a/QLTY_INTEGRATION.md
+++ b/QLTY_INTEGRATION.md
@@ -153,12 +153,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0  # Full history for better analysis
 
       - name: Set up Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -240,12 +240,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -501,7 +501,7 @@ jobs:
   quality-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate Qlty Report
         env:

--- a/QLTY_INTEGRATION.md
+++ b/QLTY_INTEGRATION.md
@@ -501,7 +501,7 @@ jobs:
   quality-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Generate Qlty Report
         env:

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -467,8 +467,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: pip install -e '.[dev]'

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -467,8 +467,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
       - run: pip install -e '.[dev]'

--- a/examples/fuzzing-migration-example.md
+++ b/examples/fuzzing-migration-example.md
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Build Fuzzers
         id: build

--- a/workflow-templates/python-publish-pypi.yml
+++ b/workflow-templates/python-publish-pypi.yml
@@ -106,6 +106,11 @@ jobs:
           ls -lh dist/
 
       - name: Publish to PyPI
+        # #VERIFY: v1.14.0 internally pins actions/setup-python v5.6.0 (node20).
+        # Upstream already bumped to setup-python v6.2.0 (node24) on unstable/v1;
+        # re-pin here when the next release ships. After GitHub's 2026-06-16
+        # cutover, node20 actions execute on node24 automatically, so until then
+        # this surfaces as a deprecation warning only, not a failure.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           print-hash: true
@@ -148,6 +153,7 @@ jobs:
           ls -lh dist/
 
       - name: Publish to TestPyPI
+        # #VERIFY: see node20 note on the PyPI publish step above.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Audit of every pinned action in .github/workflows and workflow-templates
confirms actions/setup-python (v6.2.0) and astral-sh/setup-uv (v8.2.0)
already declare node24, as do all other SHA-pinned JS actions, including
at the v1 tag consumers pin. Remaining node20 surfaces fixed:

- QLTY_INTEGRATION.md: bump example pins from setup-python v5.5.0 and
  checkout v4.2.2 (node20) to the v6.2.0 / v6.0.3 SHAs used in live
  workflows; bump a floating checkout@v4 example to @v6
- USAGE_EXAMPLES.md: bump legacy snippet from checkout@v4 and
  setup-python@v4 to @v6
- examples/fuzzing-migration-example.md: bump harden-runner v2.10.1 and
  checkout v4.2.2 (node20) to current v2.19.4 / v6.0.3 SHAs
- python-codecov.yml: usage comment now shows upload-artifact@v7

Known residual: pypa/gh-action-pypi-publish v1.14.0 (latest release)
internally pins actions/setup-python v5.6.0 (node20). Upstream already
bumped to v6.2.0 on unstable/v1; publish workflows and template carry a
#VERIFY note to re-pin when the next release ships. Warning-only: after
the cutover GitHub executes node20 actions on node24 automatically.

https://claude.ai/code/session_019FXXvdStELZSqP1q8Lxz8g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow examples, templates, and integration guides to use newer GitHub Actions versions with updated references for improved compatibility.
  * Added clarifying notes about upcoming GitHub Actions infrastructure changes and their impact on existing workflows.

* **Chores**
  * Updated changelog with maintenance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->