### PR TITLE
fix(release): run cyclonedx-py through uv run

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -348,7 +348,7 @@ jobs:
           echo "Generating Software Bill of Materials..."
           uv pip install --no-build 'cyclonedx-bom==7.3.0'
           uv export --format requirements-txt --output-file requirements-all.txt --no-hashes
-          cyclonedx-py requirements requirements-all.txt --of json --output-file dist/sbom.json
+          uv run cyclonedx-py requirements requirements-all.txt --of json --output-file dist/sbom.json
           rm -f requirements-all.txt
           echo "SBOM generated: dist/sbom.json"
 


### PR DESCRIPTION
The Generate SBOM step in python-release.yml installs cyclonedx-bom into the project venv via `uv pip install`, then invokes `cyclonedx-py` bare. The runner shell does not have `.venv/bin` on PATH, so callers fail with exit 127 (`cyclonedx-py: command not found`). First observed in ByronWilliamsCPA/Unify run 27294123184 after switching its release to the workflow_run trigger.

`uv run` resolves the entry point from the synced environment.

Generated with [Claude Code](https://claude.com/claude-code)