### PR TITLE
fix(templates): correct dependency-check tag comment from v1.1.0 to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ### Changed
 
+- `workflow-templates/python-security-analysis.yml`: corrected OWASP Dependency-Check pin comment from `v1.1.0` to `1.1.0` to match the upstream tag scheme (no `v` prefix), restoring Renovate digest tracking.
 - Node 20 deprecation sweep ahead of GitHub's 2026-06-16 forced cutover to
   Node 24. Audit result: every `actions/setup-python` (v6.2.0) and
   `astral-sh/setup-uv` (v8.2.0) pin in the live reusable workflows and

--- a/workflow-templates/python-security-analysis.yml
+++ b/workflow-templates/python-security-analysis.yml
@@ -376,7 +376,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Run OWASP Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@75ba02d6183445fe0761d26e836bde58b1560600  # v1.1.0
+        uses: dependency-check/Dependency-Check_Action@75ba02d6183445fe0761d26e836bde58b1560600  # 1.1.0
         with:
           project: 'Python Project'
           path: '.'


### PR DESCRIPTION
## Root cause

The `dependency-check/Dependency-Check_Action` repo uses tag names without a `v` prefix: `1.1.0` and `1.0.0`. The SHA pin in `workflow-templates/python-security-analysis.yml` used a comment of `# v1.1.0` (with `v`), which does not match any tag in that repo. Renovate's `github-tags` datasource uses the version comment to locate the current tag and derive a new digest. Because no tag `v1.1.0` exists, Renovate raised "Could not determine new digest for update" and stopped tracking this dependency.

The SHA `75ba02d6183445fe0761d26e836bde58b1560600` is correct and does correspond to the `1.1.0` commit.

## Fix

Changed the comment from `# v1.1.0` to `# 1.1.0` to match the upstream tag scheme. No SHA change needed.

## Scope check

`grep -rn dependency-check .github/workflows/` found no occurrence in the live reusable workflows; only the workflow template was affected.

Refs #62 (Renovate Dependency Dashboard; do not close)

Generated with [Claude Code](https://claude.com/claude-code)