### PR TITLE
refactor(sbom): extract license-compliance checker to scripts/check_licenses.py

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,15 @@
+# actionlint configuration.
+#
+# paths ignore patterns suppress false positives from actionlint's built-in
+# context type model when it lags GitHub's actual contexts.
+paths:
+  # job.workflow_sha and job.workflow_repository are documented GitHub
+  # contexts for reusable workflows (the commit SHA and repository of the
+  # workflow file that defines the current job; see "Reuse workflows" in the
+  # GitHub docs). actionlint's job context model (through at least 1.7.12)
+  # only knows {check_run_id, container, services, status} and flags them as
+  # undefined. Remove this exception once actionlint's context model catches
+  # up (https://github.com/rhysd/actionlint).
+  .github/workflows/python-sbom.yml:
+    ignore:
+      - 'property "(workflow_sha|workflow_repository)" is not defined in object type'

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -585,151 +585,32 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
+      # Checkout only scripts/check_licenses.py from this reusable workflow repo
+      # so the runner can invoke it directly. The SBOM artifacts were downloaded
+      # above into the working directory; the script reads them from there.
+      # All workflow inputs reach the script via env vars (injection-safe pattern).
+      - name: Checkout license checker script
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          repository: ByronWilliamsCPA/.github
+          sparse-checkout: |
+            scripts/check_licenses.py
+          sparse-checkout-cone-mode: false
+          path: _checker
+
       - name: Check licenses in runtime SBOM
         env:
+          # #CRITICAL: workflow inputs MUST reach the script via env vars only.
+          # Never interpolate inputs directly into run: commands; that opens a
+          # script-injection path if callers pass attacker-controlled strings.
+          # The env: block is the injection-safe boundary.
+          # #VERIFY: confirm on first run that advisory/gating behaviour is preserved.
           FORBIDDEN_LICENSES: ${{ inputs.forbidden-licenses }}
           ALLOWED_PACKAGES: ${{ inputs.allowed-packages }}
           FAIL_ON_FORBIDDEN: ${{ inputs.fail-on-forbidden-licenses }}
-          # The checker is passed through an env var and run with python -c "$CHECK_SCRIPT".
-          # All inputs reach it via env (no GitHub-expression interpolation inside run:),
-          # which avoids the heredoc-indentation trap and the workflow-injection class.
-          # Improvements over the prior id-only check:
-          #   - reads the CycloneDX id, name, AND expression fields, then maps free-text
-          #     license names to copyleft families (GPL/AGPL/LGPL/MPL), so a package whose
-          #     license is recorded as a name (for example PyMuPDF's
-          #     "GNU AFFERO GPL 3.0 or Artifex Commercial License") is no longer missed;
-          #   - honors a per-package allowlist (allowed-packages input);
-          #   - also reads pip-licenses.json to catch PEP 639 packages that
-          #     cyclonedx-bom 7.3.0 omits from the SBOM entirely.
-          CHECK_SCRIPT: |
-            import json
-            import os
-            import re
-            import sys
-
-            def norm(value):
-                return (value or "").strip()
-
-            def detect_family(text):
-                """Map an SPDX id or free-text license string to a copyleft family."""
-                lowered = (text or "").lower()
-                # A "<token>-compatible" phrasing (for example the historic
-                # "GPL-compatible" classifier) describes a permissive license's
-                # compatibility with copyleft, not a copyleft grant, so strip those
-                # qualifiers before detection to avoid a false positive.
-                lowered = re.sub(r"\b(?:a?gpl|lgpl|mpl)[- ]compatible\b", " ", lowered)
-                if re.search(r"\baffero\b", lowered) or re.search(r"\bagpl", lowered):
-                    return "AGPL"
-                if (
-                    re.search(r"\blesser\b", lowered)
-                    or re.search(r"\blgpl", lowered)
-                    or "library general public" in lowered
-                ):
-                    return "LGPL"
-                if re.search(r"\bgpl", lowered) or "gnu general public" in lowered:
-                    return "GPL"
-                if re.search(r"\bmpl\b", lowered) or "mozilla public" in lowered:
-                    return "MPL"
-                return None
-
-            def load_json(path):
-                try:
-                    with open(path) as handle:
-                        return json.load(handle)
-                except FileNotFoundError:
-                    return None
-
-            def load_list(var_name):
-                """Parse a JSON-array env var, failing loudly on malformed input."""
-                raw = os.environ.get(var_name, "[]")
-                try:
-                    value = json.loads(raw)
-                except json.JSONDecodeError as exc:
-                    sys.exit(f"::error::{var_name} is not valid JSON: {exc}")
-                if not isinstance(value, list):
-                    sys.exit(
-                        f"::error::{var_name} must be a JSON array, "
-                        f"got {type(value).__name__}"
-                    )
-                return value
-
-            forbidden = set(load_list("FORBIDDEN_LICENSES"))
-            fail_on = os.environ.get("FAIL_ON_FORBIDDEN", "false").lower() == "true"
-            forbidden_families = {fam for fam in (detect_family(x) for x in forbidden) if fam}
-
-            # Allowlist entries are "name" (exempt from every family) or "name:FAMILY"
-            # (exempt only that copyleft family, so a later license change is still
-            # caught). allowed[name] is None for a blanket exemption, else a set of
-            # families.
-            allowed = {}
-            for entry in load_list("ALLOWED_PACKAGES"):
-                name, _, family = str(entry).partition(":")
-                name = name.strip().lower()
-                family = family.strip().upper()
-                if not family:
-                    allowed[name] = None
-                elif allowed.get(name, set()) is not None:
-                    allowed.setdefault(name, set()).add(family)
-
-            issues = []
-            unset = object()
-
-            def check(pkg_name, strings):
-                exempt = allowed.get(pkg_name.lower(), unset)
-                if exempt is None:
-                    return  # blanket allowlist entry: skip every family
-                flagged = set()
-                for raw in strings:
-                    text = norm(raw)
-                    if not text:
-                        continue
-                    family = detect_family(text)
-                    exact = text in forbidden
-                    heuristic = family is not None and family in forbidden_families
-                    if not exact and not heuristic:
-                        continue
-                    if exempt is not unset and family in exempt:
-                        continue  # family-scoped exemption (for example certifi:MPL)
-                    flagged.add(text if exact else f"{text} [{family}]")
-                for item in sorted(flagged):
-                    issues.append(f"{pkg_name}: {item}")
-
-            sbom = load_json("sbom-runtime.cdx.json")
-            piplic = load_json("pip-licenses.json")
-            if sbom is None and piplic is None:
-                sys.exit(
-                    "::error::No license inventory found (neither "
-                    "sbom-runtime.cdx.json nor pip-licenses.json). Cannot verify "
-                    "dependency licenses; failing rather than reporting clean."
-                )
-
-            if sbom:
-                for component in sbom.get("components", []):
-                    name = component.get("name", "")
-                    strings = []
-                    for lic in component.get("licenses", []):
-                        license_obj = lic.get("license", {})
-                        strings.append(license_obj.get("id"))
-                        strings.append(license_obj.get("name"))
-                        strings.append(lic.get("expression"))
-                    check(name, strings)
-
-            if piplic:
-                for row in piplic:
-                    check(row.get("Name", ""), [row.get("License")])
-
-            issues = sorted(set(issues))
-            if issues:
-                print("WARNING: Found forbidden or copyleft licenses:")
-                for issue in issues:
-                    print(f"  - {issue}")
-                if fail_on:
-                    sys.exit(1)
-            else:
-                print("All licenses compatible")
         run: |
           echo "Checking runtime dependency licenses..."
-          python -c "$CHECK_SCRIPT"
+          python _checker/scripts/check_licenses.py
 
       - name: License Summary
         env:

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -587,16 +587,43 @@ jobs:
 
       # Checkout only scripts/check_licenses.py from this reusable workflow repo
       # so the runner can invoke it directly. The SBOM artifacts were downloaded
-      # above into the working directory; the script reads them from there.
+      # above into the runner workspace root (the CWD at invocation time); the
+      # script is checked out under _checker/ and reads its inputs from the CWD.
       # All workflow inputs reach the script via env vars (injection-safe pattern).
+      #
+      # #CRITICAL: ref MUST pin the script to the same commit as this workflow
+      # file. job.workflow_sha is the commit SHA of the reusable workflow file
+      # that defines this job, so a caller pinned to python-sbom.yml@<sha> gets
+      # exactly that commit's check_licenses.py (job.workflow_repository is the
+      # repo that workflow file lives in). Omitting ref would float to main
+      # HEAD at run time, breaking the SHA-pin guarantee and opening a TOCTOU
+      # window for every consumer. These job.* properties are newer than
+      # actionlint 1.7.x's context model; see .github/actionlint.yaml.
+      # #ASSUME: ByronWilliamsCPA/.github remains public; a private repo would
+      # require callers' tokens to carry contents: read on this repo.
+      # #VERIFY: on first caller run, confirm the checked-out script SHA matches
+      # the called workflow ref in the job log.
       - name: Checkout license checker script
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          repository: ByronWilliamsCPA/.github
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           sparse-checkout: |
             scripts/check_licenses.py
           sparse-checkout-cone-mode: false
           path: _checker
+
+      # sparse-checkout with cone-mode false exits 0 even when the requested
+      # path does not exist in the ref; fail loudly here instead of letting the
+      # python invocation die with a raw "can't open file" interpreter error.
+      - name: Verify license checker script is present
+        env:
+          CHECKER_REF: ${{ job.workflow_sha }}
+        run: |
+          if [ ! -f "_checker/scripts/check_licenses.py" ]; then
+            echo "::error::scripts/check_licenses.py not found after sparse checkout of ByronWilliamsCPA/.github@${CHECKER_REF}. Path mismatch or failed checkout."
+            exit 1
+          fi
 
       - name: Check licenses in runtime SBOM
         env:
@@ -604,6 +631,8 @@ jobs:
           # Never interpolate inputs directly into run: commands; that opens a
           # script-injection path if callers pass attacker-controlled strings.
           # The env: block is the injection-safe boundary.
+          # #ASSUME: the extracted script preserves the inline script's
+          # advisory/gating exit-code behaviour exactly.
           # #VERIFY: confirm on first run that advisory/gating behaviour is preserved.
           FORBIDDEN_LICENSES: ${{ inputs.forbidden-licenses }}
           ALLOWED_PACKAGES: ${{ inputs.allowed-packages }}

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -61,3 +61,25 @@ jobs:
         run: |
           find tests -maxdepth 1 -name '*.bats' -print0 \
             | xargs -0 ./tests/libs/bats-core/bin/bats
+
+  python:
+    name: Python Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+
+      - name: Run pytest
+        run: uvx --with pytest pytest tests/python/ -v

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -66,6 +66,9 @@ jobs:
     name: Python Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # #ASSUME: contents: read is sufficient; the job only checks out and runs
+    # local tests, no secrets, artifacts, or id-token needed.
+    # #VERIFY: revisit if a step is added that publishes results or comments.
     permissions:
       contents: read
 
@@ -78,8 +81,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
       - name: Install UV
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
 
       - name: Run pytest
-        run: uvx --with pytest pytest tests/python/ -v
+        # pytest is pinned to an exact version (SonarCloud S8544: unpinned
+        # installs resolve to whatever PyPI serves at run time).
+        run: uvx --with 'pytest==9.0.3' pytest tests/python/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,19 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 - `python-release.yml`: move PSR step before build so `dist/` carries the bumped version. PSR with `commit: "false"` stamps the bump into the working tree and tags the pre-bump commit, so a post-PSR same-commit tag checkout with a version guard now protects the uncommitted bump that `uv build` reads (fixes #204).
 
-### Refactored
-
-- `python-sbom.yml`: extracted the `license-compliance` inline Python checker to `scripts/check_licenses.py` (importable module with typed API) and added a pytest suite (`tests/python/`) covering all nine issue-#193 acceptance cases; the workflow step now invokes the script via `python _checker/scripts/check_licenses.py` with inputs still passed via `env:`.
-
 ### Changed
 
+- `python-sbom.yml`: extracted the `license-compliance` inline Python checker
+  to `scripts/check_licenses.py` (importable module with typed API) and added
+  a pytest suite (`tests/python/`) covering all nine issue-#193 acceptance
+  cases; the workflow step now invokes the script via
+  `python _checker/scripts/check_licenses.py` with inputs still passed via
+  `env:`. The checkout of the script is pinned to `job.workflow_sha` (the
+  reusable workflow's own commit) so callers pinning `python-sbom.yml@<sha>`
+  get exactly that commit's checker. The script now validates inventory file
+  shape, reports corrupt or unreadable files with `::error::` annotations,
+  and surfaces advisory-mode findings as `::warning::` annotations instead
+  of bare log lines.
 - `workflow-templates/python-security-analysis.yml`: corrected OWASP Dependency-Check pin comment from `v1.1.0` to `1.1.0` to match the upstream tag scheme (no `v` prefix), restoring Renovate digest tracking.
 - Node 20 deprecation sweep ahead of GitHub's 2026-06-16 forced cutover to
   Node 24. Audit result: every `actions/setup-python` (v6.2.0) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 - `python-release.yml`: move PSR step before build so `dist/` carries the bumped version. PSR with `commit: "false"` stamps the bump into the working tree and tags the pre-bump commit, so a post-PSR same-commit tag checkout with a version guard now protects the uncommitted bump that `uv build` reads (fixes #204).
 
+### Refactored
+
+- `python-sbom.yml`: extracted the `license-compliance` inline Python checker to `scripts/check_licenses.py` (importable module with typed API) and added a pytest suite (`tests/python/`) covering all nine issue-#193 acceptance cases; the workflow step now invokes the script via `python _checker/scripts/check_licenses.py` with inputs still passed via `env:`.
+
 ### Changed
 
 - `workflow-templates/python-security-analysis.yml`: corrected OWASP Dependency-Check pin comment from `v1.1.0` to `1.1.0` to match the upstream tag scheme (no `v` prefix), restoring Renovate digest tracking.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "basic",
+  "extraPaths": ["scripts"],
+  "venvPath": ".",
+  "include": ["scripts", "tests/python"]
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,8 @@
 {
   "pythonVersion": "3.12",
-  "typeCheckingMode": "basic",
+  "typeCheckingMode": "strict",
   "extraPaths": ["scripts"],
   "venvPath": ".",
+  "venv": ".venv",
   "include": ["scripts", "tests/python"]
 }

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -1,0 +1,246 @@
+"""License compliance checker for Python dependency inventories.
+
+Reads CycloneDX SBOM (sbom-runtime.cdx.json) and/or pip-licenses inventory
+(pip-licenses.json) from the current working directory, cross-checks them
+against a configurable list of forbidden SPDX license IDs, and reports or
+fails on any match.
+
+All inputs are read from environment variables so that GitHub Actions workflow
+expressions never interpolate into the script body (injection-safe pattern).
+
+Environment variables:
+    FORBIDDEN_LICENSES: JSON array of forbidden SPDX license IDs.
+    ALLOWED_PACKAGES:   JSON array of allowlist entries.  Each entry is either
+                        a bare package name (exempt from every copyleft family)
+                        or "name:FAMILY" (exempt only that family).
+    FAIL_ON_FORBIDDEN:  "true" to exit 1 when forbidden licenses are found;
+                        any other value is advisory (warn only).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import TypedDict, cast
+
+
+class LicenseObj(TypedDict, total=False):
+    id: str
+    name: str
+
+
+class LicenseEntry(TypedDict, total=False):
+    license: LicenseObj
+    expression: str
+
+
+class SbomComponent(TypedDict, total=False):
+    name: str
+    licenses: list[LicenseEntry]
+
+
+class Sbom(TypedDict, total=False):
+    components: list[SbomComponent]
+
+
+class PipLicenseRow(TypedDict, total=False):
+    Name: str
+    License: str
+
+
+def norm(value: str | None) -> str:
+    """Strip and normalise a potentially-None string."""
+    return (value or "").strip()
+
+
+def detect_family(text: str | None) -> str | None:
+    """Map an SPDX id or free-text license string to a copyleft family.
+
+    Returns one of "AGPL", "LGPL", "GPL", "MPL", or None for permissive
+    licenses.  A "<token>-compatible" phrasing (for example the historic
+    "GPL-compatible" classifier) describes a permissive license's compatibility
+    with copyleft, not a copyleft grant, so those qualifiers are stripped
+    before detection to avoid false positives.
+    """
+    lowered = (text or "").lower()
+    lowered = re.sub(r"\b(?:a?gpl|lgpl|mpl)[- ]compatible\b", " ", lowered)
+    if re.search(r"\baffero\b", lowered) or re.search(r"\bagpl", lowered):
+        return "AGPL"
+    if (
+        re.search(r"\blesser\b", lowered)
+        or re.search(r"\blgpl", lowered)
+        or "library general public" in lowered
+    ):
+        return "LGPL"
+    if re.search(r"\bgpl", lowered) or "gnu general public" in lowered:
+        return "GPL"
+    if re.search(r"\bmpl\b", lowered) or "mozilla public" in lowered:
+        return "MPL"
+    return None
+
+
+def load_sbom(path: str) -> Sbom | None:
+    """Load a CycloneDX SBOM JSON file, returning None if absent."""
+    try:
+        with open(path) as handle:
+            return cast("Sbom", json.load(handle))
+    except FileNotFoundError:
+        return None
+
+
+def load_pip_licenses(path: str) -> list[PipLicenseRow] | None:
+    """Load a pip-licenses JSON file, returning None if absent."""
+    try:
+        with open(path) as handle:
+            return cast("list[PipLicenseRow]", json.load(handle))
+    except FileNotFoundError:
+        return None
+
+
+def load_list(var_name: str) -> list[str]:
+    """Parse a JSON-array environment variable, exiting loudly on bad input."""
+    raw = os.environ.get(var_name, "[]")
+    try:
+        parsed = cast("object", json.loads(raw))
+    except json.JSONDecodeError as exc:
+        sys.exit(f"::error::{var_name} is not valid JSON: {exc}")
+    if not isinstance(parsed, list):
+        sys.exit(
+            f"::error::{var_name} must be a JSON array, got {type(parsed).__name__}"
+        )
+    return [str(item) for item in cast("list[object]", parsed)]
+
+
+def build_allowlist(entries: list[str]) -> dict[str, set[str] | None]:
+    """Build the package allowlist from the ALLOWED_PACKAGES list.
+
+    Returns a dict mapping lowercase package name to either:
+      - None: blanket exemption (all copyleft families exempt)
+      - set[str]: the specific copyleft families that are exempt
+    """
+    allowed: dict[str, set[str] | None] = {}
+    for entry in entries:
+        name, _, family = entry.partition(":")
+        name = name.strip().lower()
+        family = family.strip().upper()
+        if not family:
+            allowed[name] = None
+        else:
+            existing = allowed.get(name)
+            if existing is None and name in allowed:
+                # Already blanket-exempt; keep it
+                pass
+            elif existing is None:
+                allowed[name] = {family}
+            else:
+                existing.add(family)
+    return allowed
+
+
+_UNSET: object = object()
+
+
+def check_package(
+    pkg_name: str,
+    strings: list[str | None],
+    forbidden: set[str],
+    forbidden_families: set[str],
+    allowed: dict[str, set[str] | None],
+) -> list[str]:
+    """Return a list of issue strings for a single package.
+
+    An empty list means the package is compatible.
+    """
+    exempt = allowed.get(pkg_name.lower(), _UNSET)
+    if exempt is None:
+        return []  # blanket allowlist entry: skip every family
+
+    flagged: set[str] = set()
+    for raw in strings:
+        text = norm(raw)
+        if not text:
+            continue
+        family = detect_family(text)
+        exact = text in forbidden
+        heuristic = family is not None and family in forbidden_families
+        if not exact and not heuristic:
+            continue
+        if exempt is not _UNSET and isinstance(exempt, set) and family in exempt:
+            continue  # family-scoped exemption (for example certifi:MPL)
+        flagged.add(text if exact else f"{text} [{family}]")
+
+    return [f"{pkg_name}: {item}" for item in sorted(flagged)]
+
+
+def run_check(
+    sbom: Sbom | None,
+    piplic: list[PipLicenseRow] | None,
+    forbidden: set[str],
+    forbidden_families: set[str],
+    allowed: dict[str, set[str] | None],
+) -> list[str]:
+    """Return sorted, deduplicated issues across both inventory sources."""
+    issues: list[str] = []
+
+    if sbom:
+        for component in sbom.get("components", []):
+            name = component.get("name", "")
+            strings: list[str | None] = []
+            for lic in component.get("licenses", []):
+                license_obj = lic.get("license", {})
+                strings.append(license_obj.get("id"))
+                strings.append(license_obj.get("name"))
+                strings.append(lic.get("expression"))
+            issues.extend(
+                check_package(name, strings, forbidden, forbidden_families, allowed)
+            )
+
+    if piplic:
+        for row in piplic:
+            issues.extend(
+                check_package(
+                    row.get("Name", ""),
+                    [row.get("License")],
+                    forbidden,
+                    forbidden_families,
+                    allowed,
+                )
+            )
+
+    return sorted(set(issues))
+
+
+def main() -> None:
+    """Entry point: read env vars, load inventories, run check, and exit."""
+    forbidden = set(load_list("FORBIDDEN_LICENSES"))
+    fail_on = os.environ.get("FAIL_ON_FORBIDDEN", "false").lower() == "true"
+    forbidden_families = {fam for fam in (detect_family(x) for x in forbidden) if fam}
+    allowed = build_allowlist(load_list("ALLOWED_PACKAGES"))
+
+    sbom = load_sbom("sbom-runtime.cdx.json")
+    piplic = load_pip_licenses("pip-licenses.json")
+
+    if sbom is None and piplic is None:
+        msg = (
+            "::error::No license inventory found (neither"
+            " sbom-runtime.cdx.json nor pip-licenses.json). Cannot verify"
+            " dependency licenses; failing rather than reporting clean."
+        )
+        sys.exit(msg)
+
+    issues = run_check(sbom, piplic, forbidden, forbidden_families, allowed)
+
+    if issues:
+        print("WARNING: Found forbidden or copyleft licenses:")
+        for issue in issues:
+            print(f"  - {issue}")
+        if fail_on:
+            sys.exit(1)
+    else:
+        print("All licenses compatible")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -2,19 +2,23 @@
 
 Reads CycloneDX SBOM (sbom-runtime.cdx.json) and/or pip-licenses inventory
 (pip-licenses.json) from the current working directory, cross-checks them
-against a configurable list of forbidden SPDX license IDs, and reports or
-fails on any match.
+against a configurable list of forbidden licenses, and reports or fails on
+any match.
 
 All inputs are read from environment variables so that GitHub Actions workflow
 expressions never interpolate into the script body (injection-safe pattern).
 
 Environment variables:
-    FORBIDDEN_LICENSES: JSON array of forbidden SPDX license IDs.
+    FORBIDDEN_LICENSES: JSON array of forbidden license identifiers. SPDX IDs
+                        (for example "AGPL-3.0-only") are preferred, but
+                        free-text strings are also accepted; every entry is
+                        matched both exactly and via the copyleft-family
+                        heuristic in detect_family().
     ALLOWED_PACKAGES:   JSON array of allowlist entries.  Each entry is either
                         a bare package name (exempt from every copyleft family)
                         or "name:FAMILY" (exempt only that family).
-    FAIL_ON_FORBIDDEN:  "true" to exit 1 when forbidden licenses are found;
-                        any other value is advisory (warn only).
+    FAIL_ON_FORBIDDEN:  "true" or "1" to exit 1 when forbidden licenses are
+                        found; any other value is advisory (warn only).
 """
 
 from __future__ import annotations
@@ -50,6 +54,22 @@ class PipLicenseRow(TypedDict, total=False):
     License: str
 
 
+# Allowlist three-state semantics (see build_allowlist):
+#   key absent        -> package not allowlisted; check normally
+#   value None        -> blanket exemption (every copyleft family exempt)
+#   value set[str]    -> only the named copyleft families are exempt
+Allowlist = dict[str, set[str] | None]
+
+
+def _oneline(exc: BaseException) -> str:
+    """Flatten an exception message to one line.
+
+    GitHub Actions ``::error::`` annotations are truncated at the first
+    newline; JSONDecodeError messages can embed the offending document.
+    """
+    return str(exc).replace("\n", " ")
+
+
 def norm(value: str | None) -> str:
     """Strip and normalise a potentially-None string."""
     return (value or "").strip()
@@ -81,22 +101,57 @@ def detect_family(text: str | None) -> str | None:
     return None
 
 
-def load_sbom(path: str) -> Sbom | None:
-    """Load a CycloneDX SBOM JSON file, returning None if absent."""
+def _load_json_file(path: str) -> object | None:
+    """Load a JSON file, returning None if absent and exiting loudly otherwise.
+
+    A missing file is a valid state (the caller decides whether at least one
+    inventory is required), but a file that exists and cannot be read or
+    parsed is always a hard error: silently skipping it would let a corrupt
+    artifact produce a false "all licenses compatible" result.
+    """
     try:
         with open(path) as handle:
-            return cast("Sbom", json.load(handle))
+            return cast("object", json.load(handle))
     except FileNotFoundError:
         return None
+    except json.JSONDecodeError as exc:
+        sys.exit(f"::error::{path} is not valid JSON: {_oneline(exc)}")
+    except OSError as exc:
+        sys.exit(f"::error::Cannot read {path}: {_oneline(exc)}")
+
+
+def load_sbom(path: str) -> Sbom | None:
+    """Load a CycloneDX SBOM JSON file, returning None if absent.
+
+    Exits with a ``::error::`` annotation if the file exists but is not valid
+    JSON, is unreadable, or does not have the expected object shape.
+    """
+    data = _load_json_file(path)
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        sys.exit(f"::error::{path} must be a JSON object, got {type(data).__name__}")
+    components = cast("dict[str, object]", data).get("components", [])
+    if not isinstance(components, list):
+        sys.exit(
+            f"::error::{path}: 'components' must be a list,"
+            f" got {type(components).__name__}"
+        )
+    return cast("Sbom", data)
 
 
 def load_pip_licenses(path: str) -> list[PipLicenseRow] | None:
-    """Load a pip-licenses JSON file, returning None if absent."""
-    try:
-        with open(path) as handle:
-            return cast("list[PipLicenseRow]", json.load(handle))
-    except FileNotFoundError:
+    """Load a pip-licenses JSON file, returning None if absent.
+
+    Exits with a ``::error::`` annotation if the file exists but is not valid
+    JSON, is unreadable, or is not a JSON array.
+    """
+    data = _load_json_file(path)
+    if data is None:
         return None
+    if not isinstance(data, list):
+        sys.exit(f"::error::{path} must be a JSON array, got {type(data).__name__}")
+    return cast("list[PipLicenseRow]", data)
 
 
 def load_list(var_name: str) -> list[str]:
@@ -105,7 +160,7 @@ def load_list(var_name: str) -> list[str]:
     try:
         parsed = cast("object", json.loads(raw))
     except json.JSONDecodeError as exc:
-        sys.exit(f"::error::{var_name} is not valid JSON: {exc}")
+        sys.exit(f"::error::{var_name} is not valid JSON: {_oneline(exc)}")
     if not isinstance(parsed, list):
         sys.exit(
             f"::error::{var_name} must be a JSON array, got {type(parsed).__name__}"
@@ -113,14 +168,19 @@ def load_list(var_name: str) -> list[str]:
     return [str(item) for item in cast("list[object]", parsed)]
 
 
-def build_allowlist(entries: list[str]) -> dict[str, set[str] | None]:
+def build_allowlist(entries: list[str]) -> Allowlist:
     """Build the package allowlist from the ALLOWED_PACKAGES list.
 
     Returns a dict mapping lowercase package name to either:
       - None: blanket exemption (all copyleft families exempt)
       - set[str]: the specific copyleft families that are exempt
+
+    Note the two distinct meanings of None when reading the result: a stored
+    None value means blanket exemption, while dict.get() returning None for an
+    absent key means "not allowlisted at all".  Callers must check key
+    membership before interpreting a None value (see check_package).
     """
-    allowed: dict[str, set[str] | None] = {}
+    allowed: Allowlist = {}
     for entry in entries:
         name, _, family = entry.partition(":")
         name = name.strip().lower()
@@ -130,7 +190,8 @@ def build_allowlist(entries: list[str]) -> dict[str, set[str] | None]:
         else:
             existing = allowed.get(name)
             if existing is None and name in allowed:
-                # Already blanket-exempt; keep it
+                # Key already stored as None (blanket-exempt); a family-scoped
+                # entry cannot downgrade a blanket exemption.
                 pass
             elif existing is None:
                 allowed[name] = {family}
@@ -139,23 +200,24 @@ def build_allowlist(entries: list[str]) -> dict[str, set[str] | None]:
     return allowed
 
 
-_UNSET: object = object()
-
-
 def check_package(
     pkg_name: str,
     strings: list[str | None],
     forbidden: set[str],
     forbidden_families: set[str],
-    allowed: dict[str, set[str] | None],
+    allowed: Allowlist,
 ) -> list[str]:
     """Return a list of issue strings for a single package.
 
-    An empty list means the package is compatible.
+    An empty list means the package is either clean (no forbidden licenses)
+    or explicitly allowlisted; the two cases are indistinguishable here.
     """
-    exempt = allowed.get(pkg_name.lower(), _UNSET)
-    if exempt is None:
+    key = pkg_name.lower()
+    if key in allowed and allowed[key] is None:
         return []  # blanket allowlist entry: skip every family
+
+    # None here means "not allowlisted" (the blanket case returned above).
+    exempt_families = allowed.get(key)
 
     flagged: set[str] = set()
     for raw in strings:
@@ -167,7 +229,7 @@ def check_package(
         heuristic = family is not None and family in forbidden_families
         if not exact and not heuristic:
             continue
-        if exempt is not _UNSET and isinstance(exempt, set) and family in exempt:
+        if exempt_families is not None and family in exempt_families:
             continue  # family-scoped exemption (for example certifi:MPL)
         flagged.add(text if exact else f"{text} [{family}]")
 
@@ -179,7 +241,7 @@ def run_check(
     piplic: list[PipLicenseRow] | None,
     forbidden: set[str],
     forbidden_families: set[str],
-    allowed: dict[str, set[str] | None],
+    allowed: Allowlist,
 ) -> list[str]:
     """Return sorted, deduplicated issues across both inventory sources."""
     issues: list[str] = []
@@ -187,6 +249,11 @@ def run_check(
     if sbom:
         for component in sbom.get("components", []):
             name = component.get("name", "")
+            if not name:
+                print(
+                    "::warning::SBOM component with empty or missing name;"
+                    " its license entries are attributed to ''."
+                )
             strings: list[str | None] = []
             for lic in component.get("licenses", []):
                 license_obj = lic.get("license", {})
@@ -215,7 +282,10 @@ def run_check(
 def main() -> None:
     """Entry point: read env vars, load inventories, run check, and exit."""
     forbidden = set(load_list("FORBIDDEN_LICENSES"))
-    fail_on = os.environ.get("FAIL_ON_FORBIDDEN", "false").lower() == "true"
+    fail_on = os.environ.get("FAIL_ON_FORBIDDEN", "false").strip().lower() in {
+        "true",
+        "1",
+    }
     forbidden_families = {fam for fam in (detect_family(x) for x in forbidden) if fam}
     allowed = build_allowlist(load_list("ALLOWED_PACKAGES"))
 
@@ -230,12 +300,23 @@ def main() -> None:
         )
         sys.exit(msg)
 
-    issues = run_check(sbom, piplic, forbidden, forbidden_families, allowed)
+    try:
+        issues = run_check(sbom, piplic, forbidden, forbidden_families, allowed)
+    except (AttributeError, TypeError) as exc:
+        # Root shapes are validated at load time, but deeper malformations
+        # (for example a string where CycloneDX requires a license object)
+        # surface here.  Exit loudly: a mid-scan crash must never read as a
+        # partial "clean" result.
+        sys.exit(f"::error::Malformed license inventory structure: {_oneline(exc)}")
 
     if issues:
-        print("WARNING: Found forbidden or copyleft licenses:")
+        # ::warning:: / ::error:: prefixes surface each finding as a GitHub
+        # Actions annotation; bare print() output is hidden inside the
+        # collapsed step log, which made advisory-mode findings invisible.
+        level = "error" if fail_on else "warning"
+        print(f"::{level}::Found forbidden or copyleft licenses:")
         for issue in issues:
-            print(f"  - {issue}")
+            print(f"::{level}::{issue}")
         if fail_on:
             sys.exit(1)
     else:

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration: make scripts/ importable without a package install.
+
+This repo has no Python package or build system; the license checker lives at
+scripts/check_licenses.py as a standalone module.  Inserting the scripts/
+directory here (before test collection imports the test modules) keeps the
+sys.path manipulation out of the test files themselves.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))

--- a/tests/python/test_check_licenses.py
+++ b/tests/python/test_check_licenses.py
@@ -1,6 +1,10 @@
 """Tests for scripts/check_licenses.py.
 
-Covers the nine cases enumerated in issue #193:
+Covers the nine cases enumerated in issue #193 (scenario groups 1-9 below)
+plus the input-hardening behaviours added in review: corrupt or wrong-shape
+inventory files, allowlist entry ordering, mixed exempt/non-exempt licenses
+on one component, and numeric gating values.
+
 1. Exact SPDX id match (e.g. AGPL-3.0-only)
 2. Free-text family mapping (e.g. PyMuPDF "GNU AFFERO GPL 3.0 ..." -> AGPL;
    "GNU Lesser General Public License v3" -> LGPL)
@@ -17,19 +21,17 @@ from __future__ import annotations
 
 import json
 import os
-import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import pytest
 
-# Add scripts/ to sys.path so we can import check_licenses without a package.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
-
-import check_licenses  # noqa: E402
+import check_licenses
 
 if TYPE_CHECKING:
-    from check_licenses import Sbom
+    from pathlib import Path
+
+    from check_licenses import PipLicenseRow, Sbom
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -59,7 +61,7 @@ _DEFAULT_FORBIDDEN_FAMILIES = {
 
 def make_sbom(*components: dict[str, object]) -> "Sbom":
     """Build a minimal CycloneDX-shaped SBOM dict for testing."""
-    return {"components": list(components)}  # type: ignore[return-value]
+    return cast("Sbom", {"components": list(components)})
 
 
 def sbom_component(name: str, licenses: list[dict[str, object]]) -> dict[str, object]:
@@ -89,11 +91,28 @@ def run_check(
         allowed = {}
     return check_licenses.run_check(
         sbom,
-        piplic,  # type: ignore[arg-type]
+        cast("list[PipLicenseRow] | None", piplic),
         forbidden,
         forbidden_families,
         allowed,
     )
+
+
+def write_sbom(tmp_path: "Path", data: dict[str, object]) -> None:
+    """Write an SBOM JSON file into tmp_path under the expected filename."""
+    (tmp_path / "sbom-runtime.cdx.json").write_text(json.dumps(data))
+
+
+_GATING_ENV = {
+    "FORBIDDEN_LICENSES": json.dumps(_DEFAULT_FORBIDDEN),
+    "ALLOWED_PACKAGES": "[]",
+}
+
+_GPL_SBOM: dict[str, object] = {
+    "components": [
+        {"name": "evil-pkg", "licenses": [{"license": {"id": "GPL-3.0-only"}}]}
+    ]
+}
 
 
 # ---------------------------------------------------------------------------
@@ -157,8 +176,25 @@ def test_scoped_allowlist_does_not_exempt_certifi_agpl() -> None:
     assert issues == ["certifi: AGPL-3.0-only"]
 
 
+def test_scoped_allowlist_with_mixed_licenses_flags_only_non_exempt() -> None:
+    """One component with both an exempt-family and a non-exempt license.
+
+    Guards against a regression where a scoped exemption on one license
+    silently suppresses findings for the component's other licenses.
+    """
+    allowed = check_licenses.build_allowlist(["certifi:MPL"])
+    sbom = make_sbom(
+        sbom_component(
+            "certifi",
+            [sbom_license_id("MPL-2.0"), sbom_license_id("AGPL-3.0-only")],
+        )
+    )
+    issues = run_check(sbom, None, allowed=allowed)
+    assert issues == ["certifi: AGPL-3.0-only"]
+
+
 # ---------------------------------------------------------------------------
-# Test 4: Blanket allowlist back-compat
+# Test 4: Blanket allowlist back-compat (and entry ordering)
 # ---------------------------------------------------------------------------
 
 
@@ -168,6 +204,18 @@ def test_blanket_allowlist_exempts_all_families() -> None:
     sbom = make_sbom(sbom_component("somepkg", [sbom_license_id("GPL-3.0-only")]))
     issues = run_check(sbom, None, allowed=allowed)
     assert issues == []
+
+
+def test_blanket_then_family_keeps_blanket() -> None:
+    """A family entry after a bare-name entry cannot downgrade the blanket."""
+    allowed = check_licenses.build_allowlist(["certifi", "certifi:MPL"])
+    assert allowed == {"certifi": None}
+
+
+def test_family_then_blanket_upgrades_to_blanket() -> None:
+    """A bare-name entry after a family entry upgrades to blanket exemption."""
+    allowed = check_licenses.build_allowlist(["certifi:MPL", "certifi"])
+    assert allowed == {"certifi": None}
 
 
 # ---------------------------------------------------------------------------
@@ -198,16 +246,17 @@ def test_agpl_compatible_not_flagged() -> None:
 
 def test_pip_licenses_catches_pep639_package() -> None:
     """A package absent from the SBOM but present in pip-licenses.json is flagged."""
-    piplic = [{"Name": "hypothesis", "License": "AGPL-3.0-only"}]
-    # Pass None for sbom to simulate the package being absent from the SBOM.
-    issues = run_check(None, piplic)  # type: ignore[arg-type]
+    piplic: list[dict[str, object]] = [
+        {"Name": "hypothesis", "License": "AGPL-3.0-only"}
+    ]
+    issues = run_check(None, piplic)
     assert issues == ["hypothesis: AGPL-3.0-only"]
 
 
 def test_pip_licenses_permissive_not_flagged() -> None:
     """A package in pip-licenses.json with a permissive license is not flagged."""
-    piplic = [{"Name": "requests", "License": "Apache-2.0"}]
-    issues = run_check(None, piplic)  # type: ignore[arg-type]
+    piplic: list[dict[str, object]] = [{"Name": "requests", "License": "Apache-2.0"}]
+    issues = run_check(None, piplic)
     assert issues == []
 
 
@@ -217,31 +266,23 @@ def test_pip_licenses_permissive_not_flagged() -> None:
 
 
 def test_both_inventories_missing_exits_with_error(
-    tmp_path: pytest.TempPathFactory,
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When both sbom and pip-licenses are absent, main() exits non-zero with ::error::."""
-    env = {
-        "FORBIDDEN_LICENSES": json.dumps(_DEFAULT_FORBIDDEN),
-        "ALLOWED_PACKAGES": "[]",
-        "FAIL_ON_FORBIDDEN": "false",
-    }
+    """When both sbom and pip-licenses are absent, main() exits with ::error::."""
+    monkeypatch.chdir(tmp_path)
+    env = {**_GATING_ENV, "FAIL_ON_FORBIDDEN": "false"}
     with patch.dict(os.environ, env, clear=False):
-        import os as _os
+        with pytest.raises(SystemExit) as exc_info:
+            check_licenses.main()
 
-        original_cwd = _os.getcwd()
-        _os.chdir(tmp_path)  # type: ignore[arg-type]
-        try:
-            with pytest.raises(SystemExit) as exc_info:
-                check_licenses.main()
-        finally:
-            _os.chdir(original_cwd)
-
-    assert exc_info.value.code != 0
-    assert "::error::" in str(exc_info.value.code)
+    # sys.exit(str) stores the message string in .code (the process exit
+    # status becomes 1); assert on the message content explicitly.
+    assert isinstance(exc_info.value.code, str)
+    assert "::error::" in exc_info.value.code
 
 
 # ---------------------------------------------------------------------------
-# Test 8: Malformed JSON input
+# Test 8: Malformed JSON input (env vars and inventory files)
 # ---------------------------------------------------------------------------
 
 
@@ -269,64 +310,94 @@ def test_malformed_allowed_packages_exits_with_error() -> None:
     assert "::error::ALLOWED_PACKAGES" in str(exc_info.value.code)
 
 
+def test_corrupt_sbom_json_exits_with_error(tmp_path: "Path") -> None:
+    """An SBOM file that exists but is not valid JSON exits with ::error::."""
+    path = tmp_path / "sbom-runtime.cdx.json"
+    path.write_text("{not valid json")
+    with pytest.raises(SystemExit) as exc_info:
+        check_licenses.load_sbom(str(path))
+    assert "::error::" in str(exc_info.value.code)
+
+
+def test_corrupt_pip_licenses_json_exits_with_error(tmp_path: "Path") -> None:
+    """A pip-licenses file that exists but is not valid JSON exits with ::error::."""
+    path = tmp_path / "pip-licenses.json"
+    path.write_text("[truncated")
+    with pytest.raises(SystemExit) as exc_info:
+        check_licenses.load_pip_licenses(str(path))
+    assert "::error::" in str(exc_info.value.code)
+
+
+def test_array_root_sbom_exits_with_error(tmp_path: "Path") -> None:
+    """An SBOM whose root is a JSON array (wrong shape) exits with ::error::."""
+    path = tmp_path / "sbom-runtime.cdx.json"
+    path.write_text("[]")
+    with pytest.raises(SystemExit) as exc_info:
+        check_licenses.load_sbom(str(path))
+    assert "::error::" in str(exc_info.value.code)
+    assert "JSON object" in str(exc_info.value.code)
+
+
+def test_components_not_list_exits_with_error(tmp_path: "Path") -> None:
+    """An SBOM whose 'components' value is not a list exits with ::error::."""
+    path = tmp_path / "sbom-runtime.cdx.json"
+    path.write_text('{"components": "oops"}')
+    with pytest.raises(SystemExit) as exc_info:
+        check_licenses.load_sbom(str(path))
+    assert "::error::" in str(exc_info.value.code)
+    assert "must be a list" in str(exc_info.value.code)
+
+
+def test_dict_root_pip_licenses_exits_with_error(tmp_path: "Path") -> None:
+    """A pip-licenses file whose root is an object (not array) exits with ::error::."""
+    path = tmp_path / "pip-licenses.json"
+    path.write_text('{"Name": "x"}')
+    with pytest.raises(SystemExit) as exc_info:
+        check_licenses.load_pip_licenses(str(path))
+    assert "::error::" in str(exc_info.value.code)
+    assert "JSON array" in str(exc_info.value.code)
+
+
 # ---------------------------------------------------------------------------
 # Test 9: Gating mode exits 1
 # ---------------------------------------------------------------------------
 
 
-def test_gating_mode_exits_1_on_forbidden(tmp_path: pytest.TempPathFactory) -> None:
+def test_gating_mode_exits_1_on_forbidden(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
+) -> None:
     """With FAIL_ON_FORBIDDEN=true, a forbidden license causes sys.exit(1)."""
-    sbom_data: dict[str, object] = {
-        "components": [
-            {"name": "evil-pkg", "licenses": [{"license": {"id": "GPL-3.0-only"}}]}
-        ]
-    }
-    sbom_path = tmp_path / "sbom-runtime.cdx.json"  # type: ignore[operator]
-    sbom_path.write_text(json.dumps(sbom_data))  # type: ignore[union-attr]
-
-    env = {
-        "FORBIDDEN_LICENSES": json.dumps(_DEFAULT_FORBIDDEN),
-        "ALLOWED_PACKAGES": "[]",
-        "FAIL_ON_FORBIDDEN": "true",
-    }
+    write_sbom(tmp_path, _GPL_SBOM)
+    monkeypatch.chdir(tmp_path)
+    env = {**_GATING_ENV, "FAIL_ON_FORBIDDEN": "true"}
     with patch.dict(os.environ, env, clear=False):
-        import os as _os
+        with pytest.raises(SystemExit) as exc_info:
+            check_licenses.main()
 
-        original_cwd = _os.getcwd()
-        _os.chdir(tmp_path)  # type: ignore[arg-type]
-        try:
-            with pytest.raises(SystemExit) as exc_info:
-                check_licenses.main()
-        finally:
-            _os.chdir(original_cwd)
+    assert exc_info.value.code == 1
+
+
+def test_gating_mode_exits_1_with_numeric_true(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FAIL_ON_FORBIDDEN=1 also enables gating (boolean-ish caller values)."""
+    write_sbom(tmp_path, _GPL_SBOM)
+    monkeypatch.chdir(tmp_path)
+    env = {**_GATING_ENV, "FAIL_ON_FORBIDDEN": "1"}
+    with patch.dict(os.environ, env, clear=False):
+        with pytest.raises(SystemExit) as exc_info:
+            check_licenses.main()
 
     assert exc_info.value.code == 1
 
 
 def test_advisory_mode_does_not_exit_on_forbidden(
-    tmp_path: pytest.TempPathFactory,
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """With FAIL_ON_FORBIDDEN=false, a forbidden license warns but does not exit 1."""
-    sbom_data: dict[str, object] = {
-        "components": [
-            {"name": "evil-pkg", "licenses": [{"license": {"id": "GPL-3.0-only"}}]}
-        ]
-    }
-    sbom_path = tmp_path / "sbom-runtime.cdx.json"  # type: ignore[operator]
-    sbom_path.write_text(json.dumps(sbom_data))  # type: ignore[union-attr]
-
-    env = {
-        "FORBIDDEN_LICENSES": json.dumps(_DEFAULT_FORBIDDEN),
-        "ALLOWED_PACKAGES": "[]",
-        "FAIL_ON_FORBIDDEN": "false",
-    }
+    write_sbom(tmp_path, _GPL_SBOM)
+    monkeypatch.chdir(tmp_path)
+    env = {**_GATING_ENV, "FAIL_ON_FORBIDDEN": "false"}
     with patch.dict(os.environ, env, clear=False):
-        import os as _os
-
-        original_cwd = _os.getcwd()
-        _os.chdir(tmp_path)  # type: ignore[arg-type]
-        try:
-            # Should NOT raise; advisory mode just prints the warning.
-            check_licenses.main()
-        finally:
-            _os.chdir(original_cwd)
+        # Should NOT raise; advisory mode just prints the warnings.
+        check_licenses.main()

--- a/tests/python/test_check_licenses.py
+++ b/tests/python/test_check_licenses.py
@@ -1,0 +1,332 @@
+"""Tests for scripts/check_licenses.py.
+
+Covers the nine cases enumerated in issue #193:
+1. Exact SPDX id match (e.g. AGPL-3.0-only)
+2. Free-text family mapping (e.g. PyMuPDF "GNU AFFERO GPL 3.0 ..." -> AGPL;
+   "GNU Lesser General Public License v3" -> LGPL)
+3. Scoped allowlist: certifi:MPL exempts certifi's MPL but not certifi's AGPL
+4. Blanket allowlist back-compat: a bare name entry exempts all families
+5. <token>-compatible suppression (e.g. GPL-compatible not flagged)
+6. PEP 639 coverage via pip-licenses.json (package absent from the SBOM)
+7. Both-inventories-missing fails with ::error::
+8. Malformed FORBIDDEN_LICENSES / ALLOWED_PACKAGES JSON fails with ::error::
+9. Gating mode (fail-on-forbidden-licenses: true) exits 1 on a forbidden license
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+# Add scripts/ to sys.path so we can import check_licenses without a package.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+
+import check_licenses  # noqa: E402
+
+if TYPE_CHECKING:
+    from check_licenses import Sbom
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_FORBIDDEN = [
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+    "GPL-3.0-only",
+    "GPL-3.0-or-later",
+    "AGPL-3.0-only",
+    "AGPL-3.0-or-later",
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    "LGPL-2.1-only",
+    "LGPL-2.1-or-later",
+    "LGPL-3.0-only",
+    "LGPL-3.0-or-later",
+    "MPL-2.0",
+]
+
+_DEFAULT_FORBIDDEN_SET = set(_DEFAULT_FORBIDDEN)
+_DEFAULT_FORBIDDEN_FAMILIES = {
+    fam for fam in (check_licenses.detect_family(x) for x in _DEFAULT_FORBIDDEN) if fam
+}
+
+
+def make_sbom(*components: dict[str, object]) -> "Sbom":
+    """Build a minimal CycloneDX-shaped SBOM dict for testing."""
+    return {"components": list(components)}  # type: ignore[return-value]
+
+
+def sbom_component(name: str, licenses: list[dict[str, object]]) -> dict[str, object]:
+    """Construct a single CycloneDX component dict."""
+    return {"name": name, "licenses": licenses}
+
+
+def sbom_license_id(spdx_id: str) -> dict[str, object]:
+    """License entry using the CycloneDX ``id`` field."""
+    return {"license": {"id": spdx_id}}
+
+
+def sbom_license_name(name: str) -> dict[str, object]:
+    """License entry using the CycloneDX ``name`` field (free-text)."""
+    return {"license": {"name": name}}
+
+
+def run_check(
+    sbom: "Sbom | None",
+    piplic: list[dict[str, object]] | None,
+    forbidden: set[str] = _DEFAULT_FORBIDDEN_SET,
+    forbidden_families: set[str] = _DEFAULT_FORBIDDEN_FAMILIES,
+    allowed: dict[str, set[str] | None] | None = None,
+) -> list[str]:
+    """Thin wrapper around check_licenses.run_check with sensible defaults."""
+    if allowed is None:
+        allowed = {}
+    return check_licenses.run_check(
+        sbom,
+        piplic,  # type: ignore[arg-type]
+        forbidden,
+        forbidden_families,
+        allowed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Exact SPDX id match
+# ---------------------------------------------------------------------------
+
+
+def test_exact_spdx_id_match_flagged() -> None:
+    """A component whose license id is in the forbidden list is reported."""
+    sbom = make_sbom(sbom_component("bad-pkg", [sbom_license_id("AGPL-3.0-only")]))
+    issues = run_check(sbom, None)
+    assert issues == ["bad-pkg: AGPL-3.0-only"]
+
+
+def test_exact_spdx_id_mit_not_flagged() -> None:
+    """A component with MIT license id is not reported."""
+    sbom = make_sbom(sbom_component("good-pkg", [sbom_license_id("MIT")]))
+    issues = run_check(sbom, None)
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Free-text family mapping
+# ---------------------------------------------------------------------------
+
+
+def test_free_text_agpl_mapped_and_flagged() -> None:
+    """PyMuPDF-style free-text AGPL string is mapped to AGPL family and flagged."""
+    name = "GNU AFFERO GPL 3.0 or Artifex Commercial License"
+    sbom = make_sbom(sbom_component("pymupdf", [sbom_license_name(name)]))
+    issues = run_check(sbom, None)
+    assert issues == [f"pymupdf: {name} [AGPL]"]
+
+
+def test_free_text_lgpl_mapped_and_flagged() -> None:
+    """GNU Lesser General Public License v3 is mapped to LGPL and flagged."""
+    name = "GNU Lesser General Public License v3"
+    sbom = make_sbom(sbom_component("lgpl-pkg", [sbom_license_name(name)]))
+    issues = run_check(sbom, None)
+    assert issues == [f"lgpl-pkg: {name} [LGPL]"]
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Scoped allowlist (certifi:MPL)
+# ---------------------------------------------------------------------------
+
+
+def test_scoped_allowlist_mpl_exempts_certifi_mpl() -> None:
+    """certifi:MPL exempts certifi from MPL but not from other families."""
+    allowed = check_licenses.build_allowlist(["certifi:MPL"])
+    sbom = make_sbom(sbom_component("certifi", [sbom_license_id("MPL-2.0")]))
+    issues = run_check(sbom, None, allowed=allowed)
+    assert issues == []
+
+
+def test_scoped_allowlist_does_not_exempt_certifi_agpl() -> None:
+    """certifi:MPL does NOT exempt certifi if it were to declare AGPL."""
+    allowed = check_licenses.build_allowlist(["certifi:MPL"])
+    sbom = make_sbom(sbom_component("certifi", [sbom_license_id("AGPL-3.0-only")]))
+    issues = run_check(sbom, None, allowed=allowed)
+    assert issues == ["certifi: AGPL-3.0-only"]
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Blanket allowlist back-compat
+# ---------------------------------------------------------------------------
+
+
+def test_blanket_allowlist_exempts_all_families() -> None:
+    """A bare package name in the allowlist skips every copyleft family."""
+    allowed = check_licenses.build_allowlist(["somepkg"])
+    sbom = make_sbom(sbom_component("somepkg", [sbom_license_id("GPL-3.0-only")]))
+    issues = run_check(sbom, None, allowed=allowed)
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# Test 5: <token>-compatible suppression
+# ---------------------------------------------------------------------------
+
+
+def test_gpl_compatible_classifier_not_flagged() -> None:
+    """A 'GPL-compatible' string describes a permissive license; it is NOT flagged."""
+    name = "GPL-compatible Open Source License"
+    sbom = make_sbom(sbom_component("compat-pkg", [sbom_license_name(name)]))
+    issues = run_check(sbom, None)
+    assert issues == []
+
+
+def test_agpl_compatible_not_flagged() -> None:
+    """An 'AGPL-compatible' phrase is not a copyleft grant and must not be flagged."""
+    name = "AGPL-compatible permissive license"
+    sbom = make_sbom(sbom_component("permissive-pkg", [sbom_license_name(name)]))
+    issues = run_check(sbom, None)
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# Test 6: PEP 639 coverage via pip-licenses.json
+# ---------------------------------------------------------------------------
+
+
+def test_pip_licenses_catches_pep639_package() -> None:
+    """A package absent from the SBOM but present in pip-licenses.json is flagged."""
+    piplic = [{"Name": "hypothesis", "License": "AGPL-3.0-only"}]
+    # Pass None for sbom to simulate the package being absent from the SBOM.
+    issues = run_check(None, piplic)  # type: ignore[arg-type]
+    assert issues == ["hypothesis: AGPL-3.0-only"]
+
+
+def test_pip_licenses_permissive_not_flagged() -> None:
+    """A package in pip-licenses.json with a permissive license is not flagged."""
+    piplic = [{"Name": "requests", "License": "Apache-2.0"}]
+    issues = run_check(None, piplic)  # type: ignore[arg-type]
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Both inventories missing
+# ---------------------------------------------------------------------------
+
+
+def test_both_inventories_missing_exits_with_error(
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    """When both sbom and pip-licenses are absent, main() exits non-zero with ::error::."""
+    env = {
+        "FORBIDDEN_LICENSES": json.dumps(_DEFAULT_FORBIDDEN),
+        "ALLOWED_PACKAGES": "[]",
+        "FAIL_ON_FORBIDDEN": "false",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        import os as _os
+
+        original_cwd = _os.getcwd()
+        _os.chdir(tmp_path)  # type: ignore[arg-type]
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                check_licenses.main()
+        finally:
+            _os.chdir(original_cwd)
+
+    assert exc_info.value.code != 0
+    assert "::error::" in str(exc_info.value.code)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Malformed JSON input
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_forbidden_licenses_exits_with_error() -> None:
+    """A non-JSON FORBIDDEN_LICENSES value causes sys.exit with ::error::."""
+    with patch.dict(os.environ, {"FORBIDDEN_LICENSES": "not-json"}):
+        with pytest.raises(SystemExit) as exc_info:
+            check_licenses.load_list("FORBIDDEN_LICENSES")
+    assert "::error::FORBIDDEN_LICENSES" in str(exc_info.value.code)
+
+
+def test_forbidden_licenses_not_array_exits_with_error() -> None:
+    """FORBIDDEN_LICENSES set to a JSON object (not array) causes sys.exit."""
+    with patch.dict(os.environ, {"FORBIDDEN_LICENSES": '{"key": "value"}'}):
+        with pytest.raises(SystemExit) as exc_info:
+            check_licenses.load_list("FORBIDDEN_LICENSES")
+    assert "::error::FORBIDDEN_LICENSES" in str(exc_info.value.code)
+
+
+def test_malformed_allowed_packages_exits_with_error() -> None:
+    """A non-JSON ALLOWED_PACKAGES value causes sys.exit with ::error::."""
+    with patch.dict(os.environ, {"ALLOWED_PACKAGES": "bad[json"}):
+        with pytest.raises(SystemExit) as exc_info:
+            check_licenses.load_list("ALLOWED_PACKAGES")
+    assert "::error::ALLOWED_PACKAGES" in str(exc_info.value.code)
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Gating mode exits 1
+# ---------------------------------------------------------------------------
+
+
+def test_gating_mode_exits_1_on_forbidden(tmp_path: pytest.TempPathFactory) -> None:
+    """With FAIL_ON_FORBIDDEN=true, a forbidden license causes sys.exit(1)."""
+    sbom_data: dict[str, object] = {
+        "components": [
+            {"name": "evil-pkg", "licenses": [{"license": {"id": "GPL-3.0-only"}}]}
+        ]
+    }
+    sbom_path = tmp_path / "sbom-runtime.cdx.json"  # type: ignore[operator]
+    sbom_path.write_text(json.dumps(sbom_data))  # type: ignore[union-attr]
+
+    env = {
+        "FORBIDDEN_LICENSES": json.dumps(_DEFAULT_FORBIDDEN),
+        "ALLOWED_PACKAGES": "[]",
+        "FAIL_ON_FORBIDDEN": "true",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        import os as _os
+
+        original_cwd = _os.getcwd()
+        _os.chdir(tmp_path)  # type: ignore[arg-type]
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                check_licenses.main()
+        finally:
+            _os.chdir(original_cwd)
+
+    assert exc_info.value.code == 1
+
+
+def test_advisory_mode_does_not_exit_on_forbidden(
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    """With FAIL_ON_FORBIDDEN=false, a forbidden license warns but does not exit 1."""
+    sbom_data: dict[str, object] = {
+        "components": [
+            {"name": "evil-pkg", "licenses": [{"license": {"id": "GPL-3.0-only"}}]}
+        ]
+    }
+    sbom_path = tmp_path / "sbom-runtime.cdx.json"  # type: ignore[operator]
+    sbom_path.write_text(json.dumps(sbom_data))  # type: ignore[union-attr]
+
+    env = {
+        "FORBIDDEN_LICENSES": json.dumps(_DEFAULT_FORBIDDEN),
+        "ALLOWED_PACKAGES": "[]",
+        "FAIL_ON_FORBIDDEN": "false",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        import os as _os
+
+        original_cwd = _os.getcwd()
+        _os.chdir(tmp_path)  # type: ignore[arg-type]
+        try:
+            # Should NOT raise; advisory mode just prints the warning.
+            check_licenses.main()
+        finally:
+            _os.chdir(original_cwd)


### PR DESCRIPTION
## Summary

- Moves the ~130-line inline `CHECK_SCRIPT` block scalar from `python-sbom.yml` to `scripts/check_licenses.py`, an importable Python module with typed API and `main()` entry point.
- Adds `tests/python/test_check_licenses.py` with 17 pytest tests covering all nine issue-#193 acceptance cases.
- Extends `shell-tests.yml` with a `python:` job that runs `uvx pytest tests/python/` in CI.
- Preserves the injection-safe env-var pattern: all workflow inputs still reach the script through `env:`.

## Acceptance criteria mapping

| Criterion | What was done |
|-----------|---------------|
| `scripts/check_licenses.py` exists and passes ruff + basedpyright (strict) | Module passes `uvx ruff check`, `uvx ruff format --check`, and `uvx basedpyright` with 0 errors, 0 warnings |
| Workflow step invokes the script; CI for `python-sbom.yml` stays green | Step replaced with `Checkout license checker script` (sparse-checkout) + `python _checker/scripts/check_licenses.py`; same env vars, same logic |
| Test suite covers all nine cases and runs in CI | 17 tests, all pass; `shell-tests.yml` gains a `python:` job |
| Behavior unchanged for callers: `fail-on-forbidden-licenses` still defaults `false` | `FAIL_ON_FORBIDDEN` env var default in `main()` is `false`; workflow input default unchanged |
| CHANGELOG `[Unreleased]` entry | One-line entry added under `### Refactored` |

## Test plan

- [x] `uvx pytest tests/python/test_check_licenses.py -v` locally: 17 passed
- [x] `uvx ruff check scripts/check_licenses.py`: All checks passed
- [x] `uvx basedpyright scripts/check_licenses.py`: 0 errors, 0 warnings, 0 notes
- [x] `pre-commit run --all-files`: all hooks passed (including no-em-dash, yamllint, markdownlint)
- [x] Commit signed with GPG

Closes #193

Generated with [Claude Code](https://claude.com/claude-code)