### PR TITLE
fix(sbom): join Trivy/Grype parity by package key and repair nightly feed (#152)

### DIFF
--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -732,7 +732,7 @@ jobs:
 
       # Checkout only scripts/compare_scanner_parity.py from this reusable
       # workflow repo, pinned to the same commit as this workflow file. See the
-      # license-checker job for the full rationale on job.workflow_sha pinning
+      # license-compliance job for the full rationale on job.workflow_sha pinning
       # (it preserves the SHA-pin guarantee and avoids a TOCTOU window).
       - name: Checkout parity comparison script
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -743,6 +743,9 @@ jobs:
             scripts/compare_scanner_parity.py
           sparse-checkout-cone-mode: false
           path: _checker
+          # This checkout only reads one script; do not leave the auth token in
+          # _checker/.git/config where it could be picked up by later steps.
+          persist-credentials: false
 
       # sparse-checkout with cone-mode false exits 0 even when the requested
       # path does not exist in the ref; fail loudly instead of a raw python

--- a/.github/workflows/python-sbom.yml
+++ b/.github/workflows/python-sbom.yml
@@ -678,21 +678,29 @@ jobs:
   # and defeat the purpose of the 30-day parity window.
   #
   # SARIF artifacts are uploaded by scan-runtime (`trivy-sarif`) and
-  # scan-runtime-grype (`grype-sarif`). This job downloads both, extracts the
-  # rule IDs (CVE-* identifiers), and emits a set-diff to the step summary.
+  # scan-runtime-grype (`grype-sarif`). This job downloads both and runs
+  # scripts/compare_scanner_parity.py, which joins findings by the affected
+  # artifact (ecosystem, PEP 503 package name, version), NOT by advisory ID.
+  #
+  # #CRITICAL: the two scanners use different advisory namespaces (Trivy emits
+  # CVE-* rule IDs, Grype emits GHSA-* rule IDs) for the same vulnerability, so
+  # a raw rule-ID set-diff reports false divergence. The package-key join is the
+  # only comparison that reflects true detection parity. The script also reads
+  # SARIF by content rather than filename, because the Grype artifact downloads
+  # without a .sarif extension.
   #
   # #EDGE: if either scan job is cancelled or its SARIF artifact is missing
-  # (e.g., the scan action genuinely crashed), the corresponding side of the
-  # comparison reports "no SARIF available" and the job notes the gap in the
-  # summary rather than failing.
+  # (e.g., the scan action genuinely crashed), the corresponding side reports
+  # zero SARIF files parsed and the verdict notes the gap rather than failing.
   # ============================================================================
   parity-summary:
     name: Trivy vs Grype Parity Summary
     needs: [scan-runtime, scan-runtime-grype]
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
-    timeout-minutes: 2
+    permissions:
+      contents: read  # sparse-checkout of the comparison script from this repo
+    timeout-minutes: 5
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
@@ -717,109 +725,46 @@ jobs:
           name: grype-sarif
           path: grype-sarif
 
-      - name: Compare findings and write parity summary
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      # Checkout only scripts/compare_scanner_parity.py from this reusable
+      # workflow repo, pinned to the same commit as this workflow file. See the
+      # license-checker job for the full rationale on job.workflow_sha pinning
+      # (it preserves the SHA-pin guarantee and avoids a TOCTOU window).
+      - name: Checkout parity comparison script
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: |
+            scripts/compare_scanner_parity.py
+          sparse-checkout-cone-mode: false
+          path: _checker
+
+      # sparse-checkout with cone-mode false exits 0 even when the requested
+      # path does not exist in the ref; fail loudly instead of a raw python
+      # "can't open file" error.
+      - name: Verify parity comparison script is present
         env:
+          CHECKER_REF: ${{ job.workflow_sha }}
+        run: |
+          if [ ! -f "_checker/scripts/compare_scanner_parity.py" ]; then
+            echo "::error::scripts/compare_scanner_parity.py not found after sparse checkout of ByronWilliamsCPA/.github@${CHECKER_REF}. Path mismatch or failed checkout."
+            exit 1
+          fi
+
+      - name: Compare findings and write parity summary
+        # The script joins findings by affected artifact (ecosystem, package,
+        # version), not by advisory ID, and reads SARIF by content. It is
+        # advisory: it always exits 0 and never gates the build. All inputs
+        # reach it via env vars (the injection-safe boundary).
+        env:
+          TRIVY_SARIF_DIR: trivy-sarif
+          GRYPE_SARIF_DIR: grype-sarif
           TRIVY_RESULT: ${{ needs.scan-runtime.result }}
           GRYPE_RESULT: ${{ needs.scan-runtime-grype.result }}
         run: |
-          set -euo pipefail
-
-          # Extract sorted, unique rule IDs from a SARIF file directory.
-          # SARIF rule IDs for Trivy and Grype are CVE-* identifiers, which
-          # is the granularity we want for parity comparison.
-          # Writes to a file at $1, empty if no SARIF was found.
-          extract_ids() {
-            local sarif_dir="$1"
-            local out_file="$2"
-            : > "$out_file"
-            if [ ! -d "$sarif_dir" ]; then
-              return 0
-            fi
-            # Both Trivy and Grype produce one .sarif file per scan
-            find "$sarif_dir" -type f -name '*.sarif' -print0 \
-              | xargs -0 -r jq -r '.runs[]?.results[]?.ruleId // empty' \
-              | sort -u > "$out_file"
-          }
-
-          extract_ids trivy-sarif trivy-ids.txt
-          extract_ids grype-sarif grype-ids.txt
-
-          trivy_count=$(wc -l < trivy-ids.txt | tr -d ' ')
-          grype_count=$(wc -l < grype-ids.txt | tr -d ' ')
-
-          # Findings only in one scanner (set differences).
-          comm -23 trivy-ids.txt grype-ids.txt > trivy-only.txt
-          comm -13 trivy-ids.txt grype-ids.txt > grype-only.txt
-          comm -12 trivy-ids.txt grype-ids.txt > both.txt
-
-          trivy_only_count=$(wc -l < trivy-only.txt | tr -d ' ')
-          grype_only_count=$(wc -l < grype-only.txt | tr -d ' ')
-          both_count=$(wc -l < both.txt | tr -d ' ')
-
-          trivy_artifact_status="present"
-          if [ ! -s trivy-ids.txt ] && [ "$TRIVY_RESULT" != "success" ]; then
-            trivy_artifact_status="missing (Trivy job result: $TRIVY_RESULT)"
-          elif [ ! -s trivy-ids.txt ]; then
-            trivy_artifact_status="empty (no findings, or SARIF not produced)"
-          fi
-
-          grype_artifact_status="present"
-          if [ ! -s grype-ids.txt ] && [ "$GRYPE_RESULT" != "success" ]; then
-            grype_artifact_status="missing (Grype job result: $GRYPE_RESULT)"
-          elif [ ! -s grype-ids.txt ]; then
-            grype_artifact_status="empty (no findings, or SARIF not produced)"
-          fi
-
-          {
-            echo "### Trivy vs Grype Finding Parity (issue #152)"
-            echo ""
-            echo "Compares CVE-level findings extracted from each scanner's SARIF output."
-            echo ""
-            echo "| Scanner          | Job result        | SARIF status              | Findings |"
-            echo "|------------------|-------------------|---------------------------|----------|"
-            echo "| Trivy (gating)   | $TRIVY_RESULT     | $trivy_artifact_status    | $trivy_count |"
-            echo "| Grype (advisory) | $GRYPE_RESULT     | $grype_artifact_status    | $grype_count |"
-            echo ""
-            if [ "$trivy_count" -eq 0 ] && [ "$grype_count" -eq 0 ]; then
-              if [ "$TRIVY_RESULT" = "success" ] && [ "$GRYPE_RESULT" = "success" ]; then
-                echo "Both scanners completed and reported zero findings. Parity confirmed."
-              else
-                echo "**Parity inconclusive:** at least one scanner did not produce SARIF."
-                echo "Review the failed job logs before drawing conclusions."
-              fi
-            elif [ "$trivy_only_count" -eq 0 ] && [ "$grype_only_count" -eq 0 ]; then
-              echo "**Finding sets match exactly.** $both_count CVE(s) detected by both scanners."
-            else
-              echo "**Finding-set divergence detected.**"
-              echo ""
-              echo "| Bucket                  | Count |"
-              echo "|-------------------------|-------|"
-              echo "| Detected by both        | $both_count |"
-              echo "| Trivy only (missed by Grype) | $trivy_only_count |"
-              echo "| Grype only (missed by Trivy) | $grype_only_count |"
-              if [ "$trivy_only_count" -gt 0 ]; then
-                echo ""
-                echo "<details><summary>CVEs found by Trivy only</summary>"
-                echo ""
-                echo '```'
-                head -50 trivy-only.txt
-                if [ "$trivy_only_count" -gt 50 ]; then
-                  echo "... ($((trivy_only_count - 50)) more)"
-                fi
-                echo '```'
-                echo "</details>"
-              fi
-              if [ "$grype_only_count" -gt 0 ]; then
-                echo ""
-                echo "<details><summary>CVEs found by Grype only</summary>"
-                echo ""
-                echo '```'
-                head -50 grype-only.txt
-                if [ "$grype_only_count" -gt 50 ]; then
-                  echo "... ($((grype_only_count - 50)) more)"
-                fi
-                echo '```'
-                echo "</details>"
-              fi
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          python _checker/scripts/compare_scanner_parity.py

--- a/.github/workflows/sbom-nightly.yml
+++ b/.github/workflows/sbom-nightly.yml
@@ -46,21 +46,31 @@ on:
         required: false
         default: 'true'
 
-# #CRITICAL: permissions are set to empty at the workflow level; the
-# reusable workflow (python-sbom.yml) grants its own per-job permissions.
-# Reusable workflows run with the permissions of the CALLEE, not the caller,
-# when the callee defines its own permissions blocks. This means this
-# workflow does not need elevated permissions even though the child jobs
-# write to security-events.
-# #VERIFY: confirm that upload-sarif succeeds in the first nightly run by
-# checking the Security > Code scanning alerts tab for nightly-triggered
-# entries distinct from PR-triggered ones (different ref/sha on the alert).
+# Workflow-level default is no permissions; the calling job below grants the
+# minimum the reusable workflow needs.
+#
+# #CRITICAL: a called (reusable) workflow runs with a GITHUB_TOKEN bounded by
+# the CALLER job's permissions. The caller sets the ceiling; a callee job that
+# requests a scope the caller did not grant fails at startup (startup_failure),
+# before any job runs. This is the opposite of the earlier assumption that the
+# callee's own per-job permissions blocks are self-sufficient. The reusable's
+# scan jobs declare security-events: write to upload SARIF, so this caller must
+# grant contents: read + security-events: write on the sbom job, matching the
+# python-standard-stack.yml caller. Setting permissions: {} here (as before)
+# made every scheduled run startup_failure.
+# #VERIFY: confirm the next scheduled run's conclusion is no longer
+# startup_failure (gh run list --workflow=sbom-nightly.yml), and that
+# upload-sarif succeeds (Security > Code scanning alerts shows nightly-triggered
+# entries on a distinct ref/sha from PR-triggered ones).
 permissions: {}
 
 jobs:
   sbom:
     # #ASSUME: when triggered via schedule, inputs.* is empty; the || fallbacks
     # below supply the production defaults. workflow_dispatch overrides them.
+    permissions:
+      contents: read
+      security-events: write  # ceiling for the reusable's SARIF-upload jobs
     uses: ./.github/workflows/python-sbom.yml
     with:
       python-version: ${{ inputs.python-version || '3.12' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,33 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ### Fixed
 
+- `sbom-nightly.yml`: grant `contents: read` and `security-events: write` on the
+  calling job. The caller previously set `permissions: {}`, which is below the
+  ceiling the reusable `python-sbom.yml` SARIF-upload jobs require, so every
+  scheduled run failed with `startup_failure` (since 2026-05-30) before any job
+  executed and the nightly parity feed gathered no data. Corrected the
+  accompanying RAD comment: a called workflow's token is bounded by the caller's
+  permissions, not the callee's own per-job blocks (refs #152).
+- `python-sbom.yml`: the `parity-summary` job compared raw SARIF rule IDs, so
+  Trivy's CVE-namespace IDs and Grype's GHSA-namespace IDs for the same
+  vulnerability registered as total divergence; it also globbed `*.sarif`, which
+  missed the Grype artifact (downloaded without a `.sarif` extension), reading
+  Grype findings as zero. Both defects masked true detection parity (refs #152).
 - `python-release.yml`: move PSR step before build so `dist/` carries the bumped version. PSR with `commit: "false"` stamps the bump into the working tree and tags the pre-bump commit, so a post-PSR same-commit tag checkout with a version guard now protects the uncommitted bump that `uv build` reads (fixes #204).
 
 ### Changed
 
+- `python-sbom.yml`: rewrote the `parity-summary` (issue #152) comparison to
+  join Trivy and Grype findings by affected artifact (ecosystem, PEP 503 package
+  name, version) instead of raw advisory ID, so the same vulnerability reported
+  under a CVE ID by Trivy and a GHSA ID by Grype is correctly counted as parity,
+  not divergence. The logic is extracted to `scripts/compare_scanner_parity.py`
+  (typed, env-var driven, mirrors `check_licenses.py`) with a 15-case pytest
+  suite; the job sparse-checks out the script pinned to `job.workflow_sha`. The
+  script reads SARIF by content rather than filename and prints a
+  machine-readable `parity pkg_both=... pkg_trivy_only=... pkg_grype_only=...`
+  line to stdout so results are aggregatable from run logs, not locked in the
+  step summary.
 - `python-sbom.yml`: extracted the `license-compliance` inline Python checker
   to `scripts/check_licenses.py` (importable module with typed API) and added
   a pytest suite (`tests/python/`) covering all nine issue-#193 acceptance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
   vulnerability registered as total divergence; it also globbed `*.sarif`, which
   missed the Grype artifact (downloaded without a `.sarif` extension), reading
   Grype findings as zero. Both defects masked true detection parity (refs #152).
+- `scripts/compare_scanner_parity.py`: made SARIF data loss observable so it
+  cannot masquerade as a clean result. A failed parse, an unrecognized JSON
+  shape, or a result that yields no parseable artifact (the signature of a
+  scanner output-format change) is now counted, surfaced as a report warning and
+  in the machine-readable line, and downgrades a zero-finding verdict from
+  "parity at zero" to "inconclusive". Also guarded against a phantom empty-version
+  Trivy finding and a `GITHUB_STEP_SUMMARY` write failure breaking the exit-0
+  contract (refs #152).
 - `python-release.yml`: move PSR step before build so `dist/` carries the bumped version. PSR with `commit: "false"` stamps the bump into the working tree and tags the pre-bump commit, so a post-PSR same-commit tag checkout with a version guard now protects the uncommitted bump that `uv build` reads (fixes #204).
 
 ### Changed
@@ -47,12 +55,13 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
   name, version) instead of raw advisory ID, so the same vulnerability reported
   under a CVE ID by Trivy and a GHSA ID by Grype is correctly counted as parity,
   not divergence. The logic is extracted to `scripts/compare_scanner_parity.py`
-  (typed, env-var driven, mirrors `check_licenses.py`) with a 15-case pytest
+  (typed, env-var driven, mirrors `check_licenses.py`) with a 23-case pytest
   suite; the job sparse-checks out the script pinned to `job.workflow_sha`. The
   script reads SARIF by content rather than filename and prints a
   machine-readable `parity pkg_both=... pkg_trivy_only=... pkg_grype_only=...`
-  line to stdout so results are aggregatable from run logs, not locked in the
-  step summary.
+  line (plus per-scanner `*_files_failed` and `*_dropped` data-loss counts) to
+  stdout so results are aggregatable from run logs, not locked in the step
+  summary.
 - `python-sbom.yml`: extracted the `license-compliance` inline Python checker
   to `scripts/check_licenses.py` (importable module with typed API) and added
   a pytest suite (`tests/python/`) covering all nine issue-#193 acceptance

--- a/scripts/compare_scanner_parity.py
+++ b/scripts/compare_scanner_parity.py
@@ -1,0 +1,333 @@
+"""Trivy vs Grype SARIF parity comparison for the issue #152 parallel run.
+
+Compares the findings of two vulnerability scanners that ingest the same
+CycloneDX SBOM. The comparison joins findings by the affected artifact
+(ecosystem, PEP 503-normalized package name, version), NOT by advisory ID.
+
+Why the join key matters: Trivy emits CVE-namespace rule IDs and Grype emits
+GHSA-namespace rule IDs for the same underlying vulnerability. A naive set-diff
+of raw rule IDs therefore reports total divergence even when both scanners flag
+the identical package at the identical version. The stable join key is the
+affected artifact, so that is what this script compares. Advisory-ID divergence
+between the two namespaces is expected and is not a parity failure.
+
+Findings are extracted defensively from each scanner's SARIF shape:
+    - Grype (anchore/scan-action): package URLs in rule.properties.purls
+      (or result.properties.purls), e.g. "pkg:pypi/python-dotenv@1.2.1".
+    - Trivy (aquasecurity/trivy-action): "<ecosystem>: <name>@<version>" in
+      each result's location message text, e.g. "Python: Pygments@2.19.2".
+
+SARIF files are located by content (any file in the directory that parses as
+JSON with a "runs" key), not by extension, because the Grype artifact downloads
+as a file with no .sarif suffix.
+
+All inputs are read from environment variables so GitHub Actions workflow
+expressions never interpolate into the script body (injection-safe pattern).
+
+Environment variables:
+    TRIVY_SARIF_DIR: directory holding the Trivy SARIF (default "trivy-sarif").
+    GRYPE_SARIF_DIR: directory holding the Grype SARIF (default "grype-sarif").
+    TRIVY_RESULT:    Trivy scan job result for status reporting (default
+                     "unknown").
+    GRYPE_RESULT:    Grype scan job result for status reporting (default
+                     "unknown").
+    GITHUB_STEP_SUMMARY: if set, the markdown report is appended to this file;
+                     the report is also printed to stdout for log durability.
+
+The comparison is advisory: the script always exits 0. It never gates a build.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import TypedDict
+
+# Ecosystems some scanners spell differently from the PURL "type". Map to the
+# PURL type so the two scanners' findings join.
+_ECOSYSTEM_ALIASES = {"python": "pypi"}
+
+# PEP 503: a name is normalized by lowercasing and collapsing runs of -, _, .
+# into a single -.
+_PEP503_SEPARATORS = re.compile(r"[-_.]+")
+
+# Trivy location message: "<ecosystem>: <name>@<version>".
+_TRIVY_LOCATION = re.compile(r"^\s*(?P<eco>[^:]+):\s*(?P<name>.+)@(?P<ver>[^@]+?)\s*$")
+
+
+class Finding(TypedDict):
+    """A single scanner finding reduced to its affected artifact."""
+
+    ecosystem: str
+    name: str
+    version: str
+    advisory_id: str
+
+
+def normalize_pypi_name(name: str) -> str:
+    """Normalize a PyPI distribution name per PEP 503."""
+    return _PEP503_SEPARATORS.sub("-", name.strip().lower()).strip("-")
+
+
+def _normalize_ecosystem(ecosystem: str) -> str:
+    eco = ecosystem.strip().lower()
+    return _ECOSYSTEM_ALIASES.get(eco, eco)
+
+
+def _normalize_artifact(
+    ecosystem: str, name: str, version: str
+) -> tuple[str, str, str]:
+    eco = _normalize_ecosystem(ecosystem)
+    norm_name = normalize_pypi_name(name) if eco == "pypi" else name.strip().lower()
+    return eco, norm_name, version.strip()
+
+
+def parse_purl(purl: str) -> tuple[str, str, str] | None:
+    """Parse a package URL into a normalized (ecosystem, name, version) tuple.
+
+    Returns None if the string is not a versioned PURL.
+    """
+    if not purl.startswith("pkg:"):
+        return None
+    body = purl[len("pkg:") :].split("#", 1)[0].split("?", 1)[0]
+    if "@" not in body:
+        return None
+    coordinates, version = body.rsplit("@", 1)
+    if not version.strip():
+        return None
+    segments = [seg for seg in coordinates.split("/") if seg]
+    if len(segments) < 2:
+        return None
+    ecosystem, name = segments[0], segments[-1]
+    if not ecosystem or not name:
+        return None
+    return _normalize_artifact(ecosystem, name, version)
+
+
+def _parse_trivy_location(text: str) -> tuple[str, str, str] | None:
+    match = _TRIVY_LOCATION.match(text)
+    if match is None:
+        return None
+    return _normalize_artifact(match["eco"], match["name"], match["ver"])
+
+
+def _purls_for_result(result: dict, rule: dict) -> list[str]:
+    purls = (result.get("properties") or {}).get("purls")
+    if not purls:
+        purls = (rule.get("properties") or {}).get("purls")
+    return list(purls or [])
+
+
+def extract_findings(sarif: dict) -> list[Finding]:
+    """Extract artifact-level findings from one SARIF document."""
+    findings: list[Finding] = []
+    for run in sarif.get("runs", []):
+        rules = {
+            rule.get("id"): rule
+            for rule in run.get("tool", {}).get("driver", {}).get("rules", [])
+            if isinstance(rule, dict)
+        }
+        for result in run.get("results", []):
+            advisory = str(result.get("ruleId", ""))
+            rule = rules.get(advisory, {})
+            artifacts = [
+                parsed
+                for purl in _purls_for_result(result, rule)
+                if (parsed := parse_purl(purl)) is not None
+            ]
+            if not artifacts:
+                for location in result.get("locations", []):
+                    text = (location.get("message") or {}).get("text", "")
+                    parsed = _parse_trivy_location(text)
+                    if parsed is not None:
+                        artifacts.append(parsed)
+            for ecosystem, name, version in artifacts:
+                findings.append(
+                    Finding(
+                        ecosystem=ecosystem,
+                        name=name,
+                        version=version,
+                        advisory_id=advisory,
+                    )
+                )
+    return findings
+
+
+def load_findings_from_dir(path: str) -> tuple[list[Finding], int]:
+    """Load findings from every SARIF document under a directory.
+
+    A SARIF document is any file that parses as JSON with a "runs" key,
+    regardless of extension. Returns the findings and the count of SARIF
+    documents parsed (0 distinguishes "directory missing or no SARIF" from
+    "SARIF present but empty").
+    """
+    if not os.path.isdir(path):
+        return [], 0
+    findings: list[Finding] = []
+    files_parsed = 0
+    for root, _dirs, names in os.walk(path):
+        for name in sorted(names):
+            file_path = os.path.join(root, name)
+            try:
+                with open(file_path, encoding="utf-8") as handle:
+                    data = json.load(handle)
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+                continue
+            if not isinstance(data, dict) or "runs" not in data:
+                continue
+            files_parsed += 1
+            findings.extend(extract_findings(data))
+    return findings, files_parsed
+
+
+def package_key(finding: Finding) -> tuple[str, str, str]:
+    """The artifact join key: (ecosystem, normalized name, version)."""
+    return finding["ecosystem"], finding["name"], finding["version"]
+
+
+class Comparison(TypedDict):
+    both: int
+    trivy_only: int
+    grype_only: int
+    both_keys: list[tuple[str, str, str]]
+    trivy_only_keys: list[tuple[str, str, str]]
+    grype_only_keys: list[tuple[str, str, str]]
+    trivy_pkgs: int
+    grype_pkgs: int
+
+
+def compare(trivy: list[Finding], grype: list[Finding]) -> Comparison:
+    """Compare two finding lists by artifact key."""
+    trivy_keys = {package_key(f) for f in trivy}
+    grype_keys = {package_key(f) for f in grype}
+    both = trivy_keys & grype_keys
+    trivy_only = trivy_keys - grype_keys
+    grype_only = grype_keys - trivy_keys
+    return Comparison(
+        both=len(both),
+        trivy_only=len(trivy_only),
+        grype_only=len(grype_only),
+        both_keys=sorted(both),
+        trivy_only_keys=sorted(trivy_only),
+        grype_only_keys=sorted(grype_only),
+        trivy_pkgs=len(trivy_keys),
+        grype_pkgs=len(grype_keys),
+    )
+
+
+def _format_key(key: tuple[str, str, str]) -> str:
+    ecosystem, name, version = key
+    return f"{ecosystem}/{name}@{version}"
+
+
+def _details_block(title: str, keys: list[tuple[str, str, str]]) -> list[str]:
+    if not keys:
+        return []
+    lines = ["", f"<details><summary>{title} ({len(keys)})</summary>", "", "```"]
+    lines.extend(_format_key(k) for k in keys[:50])
+    if len(keys) > 50:
+        lines.append(f"... ({len(keys) - 50} more)")
+    lines.extend(["```", "</details>"])
+    return lines
+
+
+def _verdict(comparison: Comparison, trivy_result: str, grype_result: str) -> str:
+    if comparison["trivy_pkgs"] == 0 and comparison["grype_pkgs"] == 0:
+        if trivy_result == "success" and grype_result == "success":
+            return "Both scanners reported zero package-level findings. Parity at zero."
+        return (
+            "**Parity inconclusive:** at least one scanner did not produce SARIF. "
+            "Review the scan job logs before drawing conclusions."
+        )
+    if comparison["trivy_only"] == 0 and comparison["grype_only"] == 0:
+        return (
+            f"**Package-level parity confirmed.** All {comparison['both']} affected "
+            "package-versions were detected by both scanners."
+        )
+    return (
+        "**Package-level divergence detected.** The scanners disagree on the set of "
+        "affected package-versions; review the buckets below."
+    )
+
+
+def render_markdown(
+    comparison: Comparison,
+    trivy_files: int,
+    grype_files: int,
+    trivy_result: str,
+    grype_result: str,
+) -> str:
+    """Render the parity report as GitHub-flavored markdown."""
+    lines = [
+        "### Trivy vs Grype Parity (issue #152)",
+        "",
+        "Package-level comparison: findings are joined by (ecosystem, package, "
+        "version), not by advisory ID. Trivy reports CVE IDs and Grype reports "
+        "GHSA IDs for the same vulnerability, so comparing raw IDs reports false "
+        "divergence. Advisory-ID differences between the two namespaces are "
+        "expected and are not a parity failure.",
+        "",
+        "| Scanner | Job result | SARIF files | Packages flagged |",
+        "|---------|------------|-------------|------------------|",
+        f"| Trivy (gating) | {trivy_result} | {trivy_files} | {comparison['trivy_pkgs']} |",
+        f"| Grype (advisory) | {grype_result} | {grype_files} | {comparison['grype_pkgs']} |",
+        "",
+        "| Bucket | Count |",
+        "|--------|-------|",
+        f"| Detected by both | {comparison['both']} |",
+        f"| Trivy only (missed by Grype) | {comparison['trivy_only']} |",
+        f"| Grype only (missed by Trivy) | {comparison['grype_only']} |",
+        "",
+        _verdict(comparison, trivy_result, grype_result),
+    ]
+    lines.extend(_details_block("Detected by both", comparison["both_keys"]))
+    lines.extend(
+        _details_block("Trivy only (missed by Grype)", comparison["trivy_only_keys"])
+    )
+    lines.extend(
+        _details_block("Grype only (missed by Trivy)", comparison["grype_only_keys"])
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """Entry point: compare, write the report, emit a machine-readable line."""
+    trivy_dir = os.environ.get("TRIVY_SARIF_DIR", "trivy-sarif")
+    grype_dir = os.environ.get("GRYPE_SARIF_DIR", "grype-sarif")
+    trivy_result = os.environ.get("TRIVY_RESULT", "unknown")
+    grype_result = os.environ.get("GRYPE_RESULT", "unknown")
+
+    trivy_findings, trivy_files = load_findings_from_dir(trivy_dir)
+    grype_findings, grype_files = load_findings_from_dir(grype_dir)
+    comparison = compare(trivy_findings, grype_findings)
+
+    report = render_markdown(
+        comparison, trivy_files, grype_files, trivy_result, grype_result
+    )
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report)
+    # Always print the report for log durability; the step summary is not
+    # retrievable via the API for later aggregation.
+    print(report)
+
+    # Single machine-readable line for log scraping and cross-PR aggregation.
+    print(
+        "parity "
+        f"pkg_both={comparison['both']} "
+        f"pkg_trivy_only={comparison['trivy_only']} "
+        f"pkg_grype_only={comparison['grype_only']} "
+        f"trivy_pkgs={comparison['trivy_pkgs']} "
+        f"grype_pkgs={comparison['grype_pkgs']} "
+        f"trivy_files={trivy_files} "
+        f"grype_files={grype_files}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_scanner_parity.py
+++ b/scripts/compare_scanner_parity.py
@@ -110,7 +110,13 @@ def _parse_trivy_location(text: str) -> tuple[str, str, str] | None:
     match = _TRIVY_LOCATION.match(text)
     if match is None:
         return None
-    return _normalize_artifact(match["eco"], match["name"], match["ver"])
+    artifact = _normalize_artifact(match["eco"], match["name"], match["ver"])
+    # Guard against an empty version (e.g. "Python: requests@   "), mirroring
+    # parse_purl. A version of "" can never join against a real scanner finding
+    # and would otherwise inflate the trivy-only bucket with a phantom entry.
+    if not artifact[2]:
+        return None
+    return artifact
 
 
 def _purls_for_result(result: dict, rule: dict) -> list[str]:
@@ -120,9 +126,43 @@ def _purls_for_result(result: dict, rule: dict) -> list[str]:
     return list(purls or [])
 
 
-def extract_findings(sarif: dict) -> list[Finding]:
-    """Extract artifact-level findings from one SARIF document."""
+def _artifacts_for_result(result: dict, rule: dict) -> list[tuple[str, str, str]]:
+    """Resolve one result's affected artifacts.
+
+    PURLs (Grype) take precedence; the Trivy location-message text is the
+    fallback. Returns an empty list when neither shape yields a parseable
+    artifact, which the caller treats as a dropped result.
+    """
+    artifacts = [
+        parsed
+        for purl in _purls_for_result(result, rule)
+        if (parsed := parse_purl(purl)) is not None
+    ]
+    if artifacts:
+        return artifacts
+    return [
+        parsed
+        for location in result.get("locations", [])
+        if (
+            parsed := _parse_trivy_location(
+                (location.get("message") or {}).get("text", "")
+            )
+        )
+        is not None
+    ]
+
+
+def extract_findings(sarif: dict) -> tuple[list[Finding], int]:
+    """Extract artifact-level findings from one SARIF document.
+
+    Returns the findings and the count of results that carried a ruleId but
+    yielded no parseable artifact (neither a PURL nor a Trivy location matched).
+    A nonzero drop count on an otherwise well-formed SARIF is the signature of a
+    scanner output-format change; it is surfaced as a parity warning so a silent
+    under-count cannot masquerade as a clean result.
+    """
     findings: list[Finding] = []
+    dropped = 0
     for run in sarif.get("runs", []):
         rules = {
             rule.get("id"): rule
@@ -131,55 +171,74 @@ def extract_findings(sarif: dict) -> list[Finding]:
         }
         for result in run.get("results", []):
             advisory = str(result.get("ruleId", ""))
-            rule = rules.get(advisory, {})
-            artifacts = [
-                parsed
-                for purl in _purls_for_result(result, rule)
-                if (parsed := parse_purl(purl)) is not None
-            ]
+            artifacts = _artifacts_for_result(result, rules.get(advisory, {}))
             if not artifacts:
-                for location in result.get("locations", []):
-                    text = (location.get("message") or {}).get("text", "")
-                    parsed = _parse_trivy_location(text)
-                    if parsed is not None:
-                        artifacts.append(parsed)
-            for ecosystem, name, version in artifacts:
-                findings.append(
-                    Finding(
-                        ecosystem=ecosystem,
-                        name=name,
-                        version=version,
-                        advisory_id=advisory,
-                    )
+                dropped += 1
+                continue
+            findings.extend(
+                Finding(
+                    ecosystem=ecosystem,
+                    name=name,
+                    version=version,
+                    advisory_id=advisory,
                 )
-    return findings
+                for ecosystem, name, version in artifacts
+            )
+    return findings, dropped
 
 
-def load_findings_from_dir(path: str) -> tuple[list[Finding], int]:
+class LoadResult(TypedDict):
+    """Findings plus the data-loss signals gathered while loading a directory.
+
+    The counters exist so a silently lost SARIF cannot be reported as a clean
+    zero. files_failed and non_sarif_json distinguish "no SARIF present" from
+    "SARIF present but unreadable/unrecognized"; dropped_results flags a
+    well-formed SARIF whose results no longer match the expected purl/location
+    shape (a scanner output-format change).
+    """
+
+    findings: list[Finding]
+    files_parsed: int  # valid SARIF documents (a dict with a "runs" key)
+    files_failed: int  # files that did not parse as JSON (corrupt/truncated)
+    non_sarif_json: int  # valid JSON lacking a "runs" key (unexpected shape)
+    dropped_results: int  # results yielding no parseable artifact
+
+
+def load_findings_from_dir(path: str) -> LoadResult:
     """Load findings from every SARIF document under a directory.
 
     A SARIF document is any file that parses as JSON with a "runs" key,
-    regardless of extension. Returns the findings and the count of SARIF
-    documents parsed (0 distinguishes "directory missing or no SARIF" from
-    "SARIF present but empty").
+    regardless of extension. Alongside the findings, returns counters that make
+    data loss observable: files_parsed (0 distinguishes "directory missing or no
+    SARIF" from "SARIF present but empty"), files_failed, non_sarif_json, and
+    dropped_results.
     """
-    if not os.path.isdir(path):
-        return [], 0
     findings: list[Finding] = []
-    files_parsed = 0
-    for root, _dirs, names in os.walk(path):
-        for name in sorted(names):
-            file_path = os.path.join(root, name)
-            try:
-                with open(file_path, encoding="utf-8") as handle:
-                    data = json.load(handle)
-            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
-                continue
-            if not isinstance(data, dict) or "runs" not in data:
-                continue
-            files_parsed += 1
-            findings.extend(extract_findings(data))
-    return findings, files_parsed
+    files_parsed = files_failed = non_sarif_json = dropped_results = 0
+    if os.path.isdir(path):
+        for root, _dirs, names in os.walk(path):
+            for name in sorted(names):
+                file_path = os.path.join(root, name)
+                try:
+                    with open(file_path, encoding="utf-8") as handle:
+                        data = json.load(handle)
+                except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+                    files_failed += 1
+                    continue
+                if not isinstance(data, dict) or "runs" not in data:
+                    non_sarif_json += 1
+                    continue
+                files_parsed += 1
+                file_findings, dropped = extract_findings(data)
+                findings.extend(file_findings)
+                dropped_results += dropped
+    return LoadResult(
+        findings=findings,
+        files_parsed=files_parsed,
+        files_failed=files_failed,
+        non_sarif_json=non_sarif_json,
+        dropped_results=dropped_results,
+    )
 
 
 def package_key(finding: Finding) -> tuple[str, str, str]:
@@ -233,8 +292,34 @@ def _details_block(title: str, keys: list[tuple[str, str, str]]) -> list[str]:
     return lines
 
 
-def _verdict(comparison: Comparison, trivy_result: str, grype_result: str) -> str:
+def _parse_warning_count(trivy: LoadResult, grype: LoadResult) -> int:
+    """Total data-loss signals across both scanners (parse/shape/drop)."""
+    return sum(
+        side[key]
+        for side in (trivy, grype)
+        for key in ("files_failed", "non_sarif_json", "dropped_results")
+    )
+
+
+def _verdict(
+    comparison: Comparison,
+    trivy: LoadResult,
+    grype: LoadResult,
+    trivy_result: str,
+    grype_result: str,
+) -> str:
     if comparison["trivy_pkgs"] == 0 and comparison["grype_pkgs"] == 0:
+        # A zero-zero result is only trustworthy when nothing was lost in
+        # loading. Parse failures, unrecognized JSON, or dropped results mean
+        # the zero may be data loss, not a true empty scan, so do not declare
+        # parity at zero on the strength of the scan job result alone.
+        if _parse_warning_count(trivy, grype):
+            return (
+                "**Parity inconclusive:** both scanners reported zero packages, but "
+                "parse warnings were recorded (see the warning above). The zero counts "
+                "may reflect lost or unrecognized SARIF data rather than a true empty "
+                "result. Review the scan job logs before drawing conclusions."
+            )
         if trivy_result == "success" and grype_result == "success":
             return "Both scanners reported zero package-level findings. Parity at zero."
         return (
@@ -252,10 +337,27 @@ def _verdict(comparison: Comparison, trivy_result: str, grype_result: str) -> st
     )
 
 
+def _warning_line(trivy: LoadResult, grype: LoadResult) -> list[str]:
+    """A visible warning block when any SARIF data was lost during loading."""
+    if not _parse_warning_count(trivy, grype):
+        return []
+    failed = trivy["files_failed"] + grype["files_failed"]
+    non_sarif = trivy["non_sarif_json"] + grype["non_sarif_json"]
+    dropped = trivy["dropped_results"] + grype["dropped_results"]
+    return [
+        "",
+        f"> **Warning:** {failed} file(s) failed to parse, {non_sarif} JSON file(s) "
+        f"lacked a SARIF `runs` key, and {dropped} result(s) produced no parseable "
+        "artifact. These were excluded, so the counts above may understate true "
+        "findings. A corrupted artifact or a scanner output-format change is the "
+        "most likely cause; review the scan job logs.",
+    ]
+
+
 def render_markdown(
     comparison: Comparison,
-    trivy_files: int,
-    grype_files: int,
+    trivy: LoadResult,
+    grype: LoadResult,
     trivy_result: str,
     grype_result: str,
 ) -> str:
@@ -271,16 +373,17 @@ def render_markdown(
         "",
         "| Scanner | Job result | SARIF files | Packages flagged |",
         "|---------|------------|-------------|------------------|",
-        f"| Trivy (gating) | {trivy_result} | {trivy_files} | {comparison['trivy_pkgs']} |",
-        f"| Grype (advisory) | {grype_result} | {grype_files} | {comparison['grype_pkgs']} |",
+        f"| Trivy (gating) | {trivy_result} | {trivy['files_parsed']} | {comparison['trivy_pkgs']} |",
+        f"| Grype (advisory) | {grype_result} | {grype['files_parsed']} | {comparison['grype_pkgs']} |",
         "",
         "| Bucket | Count |",
         "|--------|-------|",
         f"| Detected by both | {comparison['both']} |",
         f"| Trivy only (missed by Grype) | {comparison['trivy_only']} |",
         f"| Grype only (missed by Trivy) | {comparison['grype_only']} |",
+        *_warning_line(trivy, grype),
         "",
-        _verdict(comparison, trivy_result, grype_result),
+        _verdict(comparison, trivy, grype, trivy_result, grype_result),
     ]
     lines.extend(_details_block("Detected by both", comparison["both_keys"]))
     lines.extend(
@@ -299,23 +402,32 @@ def main() -> int:
     trivy_result = os.environ.get("TRIVY_RESULT", "unknown")
     grype_result = os.environ.get("GRYPE_RESULT", "unknown")
 
-    trivy_findings, trivy_files = load_findings_from_dir(trivy_dir)
-    grype_findings, grype_files = load_findings_from_dir(grype_dir)
-    comparison = compare(trivy_findings, grype_findings)
+    trivy = load_findings_from_dir(trivy_dir)
+    grype = load_findings_from_dir(grype_dir)
+    comparison = compare(trivy["findings"], grype["findings"])
 
-    report = render_markdown(
-        comparison, trivy_files, grype_files, trivy_result, grype_result
-    )
+    report = render_markdown(comparison, trivy, grype, trivy_result, grype_result)
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
-        with open(summary_path, "a", encoding="utf-8") as handle:
-            handle.write(report)
+        # Guard the summary write: a failure here must not crash the advisory
+        # tool (it always exits 0) or skip the stdout fallback below.
+        try:
+            with open(summary_path, "a", encoding="utf-8") as handle:
+                handle.write(report)
+        except OSError as exc:
+            print(
+                f"Warning: could not write GITHUB_STEP_SUMMARY ({exc}); "
+                "report is in the step log only.",
+                file=sys.stderr,
+            )
     # Always print the report for log durability; the step summary is not
     # retrievable via the API for later aggregation.
     print(report)
 
     # Single machine-readable line for log scraping and cross-PR aggregation.
+    # The *_files_failed and *_dropped fields let an aggregator detect data
+    # loss without parsing the markdown report.
     print(
         "parity "
         f"pkg_both={comparison['both']} "
@@ -323,8 +435,12 @@ def main() -> int:
         f"pkg_grype_only={comparison['grype_only']} "
         f"trivy_pkgs={comparison['trivy_pkgs']} "
         f"grype_pkgs={comparison['grype_pkgs']} "
-        f"trivy_files={trivy_files} "
-        f"grype_files={grype_files}"
+        f"trivy_files={trivy['files_parsed']} "
+        f"grype_files={grype['files_parsed']} "
+        f"trivy_files_failed={trivy['files_failed']} "
+        f"grype_files_failed={grype['files_failed']} "
+        f"trivy_dropped={trivy['dropped_results']} "
+        f"grype_dropped={grype['dropped_results']}"
     )
     return 0
 

--- a/tests/python/test_compare_scanner_parity.py
+++ b/tests/python/test_compare_scanner_parity.py
@@ -1,0 +1,265 @@
+"""Tests for scripts/compare_scanner_parity.py.
+
+The script compares Trivy and Grype SARIF output for the issue #152 parallel
+run. The central behaviour under test is that findings are joined by the
+affected artifact (ecosystem, PEP 503-normalized package name, version) rather
+than by raw advisory ID, because Trivy emits CVE-namespace IDs and Grype emits
+GHSA-namespace IDs for the same vulnerability. Comparing raw IDs reports false
+divergence; comparing package keys reports true parity.
+
+Coverage:
+1. PEP 503 name normalization
+2. PURL parsing (pypi, with qualifiers/subpath, non-pypi namespaced)
+3. Trivy-style extraction from locations[].message.text
+4. Grype-style extraction from rule.properties.purls
+5. Cross-tool parity: same package under CVE vs GHSA collapses to one (the fix)
+6. Genuine divergence: different packages are reported as only-in-one
+7. Both empty: parity at zero
+8. SARIF files are read by content, not filename extension (Grype "output")
+9. Markdown rendering and machine-readable stdout line via main()
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import compare_scanner_parity as csp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers: build minimal SARIF documents in each scanner's shape
+# ---------------------------------------------------------------------------
+
+
+def trivy_sarif(findings: list[tuple[str, str, str, str]]) -> dict:
+    """findings: list of (rule_id, ecosystem, name, version).
+
+    Mirrors aquasecurity/trivy-action SARIF: the package@version lives in the
+    result location message text as "<ecosystem>: <name>@<version>".
+    """
+    results = [
+        {
+            "ruleId": rid,
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": eco, "uriBaseId": "ROOTPATH"},
+                        "region": {"startLine": 1, "startColumn": 1},
+                    },
+                    "message": {"text": f"{eco}: {name}@{ver}"},
+                }
+            ],
+        }
+        for rid, eco, name, ver in findings
+    ]
+    return {
+        "runs": [
+            {"tool": {"driver": {"name": "Trivy", "rules": []}}, "results": results}
+        ]
+    }
+
+
+def grype_sarif(findings: list[tuple[str, str, str, str]]) -> dict:
+    """findings: list of (rule_id, ecosystem, name, version).
+
+    Mirrors anchore/scan-action SARIF: the package URL lives in the rule's
+    properties.purls as "pkg:<ecosystem>/<name>@<version>".
+    """
+    rules = [
+        {"id": rid, "properties": {"purls": [f"pkg:{eco}/{name}@{ver}"]}}
+        for rid, eco, name, ver in findings
+    ]
+    results = [{"ruleId": rid} for rid, _, _, _ in findings]
+    return {
+        "runs": [
+            {"tool": {"driver": {"name": "Grype", "rules": rules}}, "results": results}
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Name normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_name_lowercases() -> None:
+    assert csp.normalize_pypi_name("Pygments") == "pygments"
+
+
+def test_normalize_name_collapses_separators() -> None:
+    # PEP 503: runs of -, _, . collapse to a single -
+    assert csp.normalize_pypi_name("python_dotenv") == "python-dotenv"
+    assert csp.normalize_pypi_name("A.B__c") == "a-b-c"
+
+
+# ---------------------------------------------------------------------------
+# 2. PURL parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_purl_pypi() -> None:
+    assert csp.parse_purl("pkg:pypi/python-dotenv@1.2.1") == (
+        "pypi",
+        "python-dotenv",
+        "1.2.1",
+    )
+
+
+def test_parse_purl_strips_qualifiers_and_subpath() -> None:
+    assert csp.parse_purl("pkg:pypi/foo@1.0?arch=src#sub") == ("pypi", "foo", "1.0")
+
+
+def test_parse_purl_normalizes_pypi_name() -> None:
+    assert csp.parse_purl("pkg:pypi/Py_Yaml@6.0") == ("pypi", "py-yaml", "6.0")
+
+
+def test_parse_purl_non_pypi_namespaced() -> None:
+    # name is the final segment; ecosystem preserved
+    assert csp.parse_purl("pkg:deb/debian/bash@5.1") == ("deb", "bash", "5.1")
+
+
+def test_parse_purl_invalid_returns_none() -> None:
+    assert csp.parse_purl("not-a-purl") is None
+    assert csp.parse_purl("pkg:pypi/noversion") is None
+
+
+# ---------------------------------------------------------------------------
+# 3 & 4. Per-tool extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_trivy_from_location_message() -> None:
+    sarif = trivy_sarif([("CVE-2026-4539", "Python", "Pygments", "2.19.2")])
+    keys = {csp.package_key(f) for f in csp.extract_findings(sarif)}
+    assert keys == {("pypi", "pygments", "2.19.2")}
+
+
+def test_extract_grype_from_purls() -> None:
+    sarif = grype_sarif([("GHSA-5239-wwwm-4pmq", "pypi", "Pygments", "2.19.2")])
+    keys = {csp.package_key(f) for f in csp.extract_findings(sarif)}
+    assert keys == {("pypi", "pygments", "2.19.2")}
+
+
+# ---------------------------------------------------------------------------
+# 5. The core fix: same package, different advisory namespace -> parity
+# ---------------------------------------------------------------------------
+
+
+def test_cross_tool_same_package_is_parity_not_divergence() -> None:
+    trivy = csp.extract_findings(
+        trivy_sarif(
+            [
+                ("CVE-2026-4539", "Python", "Pygments", "2.19.2"),
+                ("CVE-2026-28684", "Python", "python-dotenv", "1.2.1"),
+            ]
+        )
+    )
+    grype = csp.extract_findings(
+        grype_sarif(
+            [
+                ("GHSA-5239-wwwm-4pmq", "pypi", "Pygments", "2.19.2"),
+                ("GHSA-mf9w-mj56-hr94", "pypi", "python-dotenv", "1.2.1"),
+            ]
+        )
+    )
+    result = csp.compare(trivy, grype)
+    assert result["both"] == 2
+    assert result["trivy_only"] == 0
+    assert result["grype_only"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Genuine divergence
+# ---------------------------------------------------------------------------
+
+
+def test_genuine_divergence_reported() -> None:
+    trivy = csp.extract_findings(
+        trivy_sarif([("CVE-1", "Python", "requests", "2.0.0")])
+    )
+    grype = csp.extract_findings(grype_sarif([("GHSA-2", "pypi", "urllib3", "1.0.0")]))
+    result = csp.compare(trivy, grype)
+    assert result["both"] == 0
+    assert result["trivy_only"] == 1
+    assert result["grype_only"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 7 & 8. Directory loading: content-based, extension-agnostic
+# ---------------------------------------------------------------------------
+
+
+def test_load_dir_reads_files_without_sarif_extension(tmp_path: Path) -> None:
+    # Grype's artifact downloads as a file literally named "output"
+    d = tmp_path / "grype"
+    d.mkdir()
+    (d / "output").write_text(
+        json.dumps(grype_sarif([("GHSA-x", "pypi", "Pygments", "2.19.2")]))
+    )
+    findings, files = csp.load_findings_from_dir(str(d))
+    assert files == 1
+    assert {csp.package_key(f) for f in findings} == {("pypi", "pygments", "2.19.2")}
+
+
+def test_load_dir_missing_returns_empty(tmp_path: Path) -> None:
+    findings, files = csp.load_findings_from_dir(str(tmp_path / "does-not-exist"))
+    assert findings == []
+    assert files == 0
+
+
+def test_load_dir_ignores_non_json(tmp_path: Path) -> None:
+    d = tmp_path / "trivy"
+    d.mkdir()
+    (d / "note.txt").write_text("not json")
+    (d / "trivy.sarif").write_text(
+        json.dumps(trivy_sarif([("CVE-9", "Python", "flask", "3.0.0")]))
+    )
+    findings, files = csp.load_findings_from_dir(str(d))
+    assert files == 1
+    assert {csp.package_key(f) for f in findings} == {("pypi", "flask", "3.0.0")}
+
+
+# ---------------------------------------------------------------------------
+# 9. main(): markdown to step summary + machine-readable stdout
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_summary_and_machine_line(tmp_path: Path, capsys) -> None:  # noqa: ANN001
+    tdir = tmp_path / "trivy-sarif"
+    gdir = tmp_path / "grype-sarif"
+    tdir.mkdir()
+    gdir.mkdir()
+    (tdir / "t.sarif").write_text(
+        json.dumps(trivy_sarif([("CVE-2026-4539", "Python", "Pygments", "2.19.2")]))
+    )
+    (gdir / "output").write_text(
+        json.dumps(grype_sarif([("GHSA-5239-wwwm-4pmq", "pypi", "Pygments", "2.19.2")]))
+    )
+    summary = tmp_path / "summary.md"
+    env = {
+        "TRIVY_SARIF_DIR": str(tdir),
+        "GRYPE_SARIF_DIR": str(gdir),
+        "TRIVY_RESULT": "success",
+        "GRYPE_RESULT": "success",
+        "GITHUB_STEP_SUMMARY": str(summary),
+    }
+    with patch.dict(os.environ, env, clear=False):
+        rc = csp.main()
+    assert rc == 0
+
+    body = summary.read_text()
+    # package-level parity is the headline; the one shared package collapses
+    assert "Package-level" in body or "package" in body.lower()
+    assert "Pygments" in body or "pygments" in body
+
+    out = capsys.readouterr().out
+    # machine-readable line for log/API aggregation
+    assert "parity" in out.lower()
+    assert "pkg_both=1" in out
+    assert "pkg_trivy_only=0" in out
+    assert "pkg_grype_only=0" in out

--- a/tests/python/test_compare_scanner_parity.py
+++ b/tests/python/test_compare_scanner_parity.py
@@ -17,6 +17,12 @@ Coverage:
 7. Both empty: parity at zero
 8. SARIF files are read by content, not filename extension (Grype "output")
 9. Markdown rendering and machine-readable stdout line via main()
+10. Ecosystem alias (Python -> pypi) pinned directly so cross-tool parity
+    cannot pass vacuously
+11. Data-loss observability: empty-version drop, no-artifact drop, failed-file
+    and non-SARIF-JSON counts
+12. Verdict branches: parity-at-zero, inconclusive-on-parse-warning,
+    inconclusive-when-scanner-absent, divergence via render_markdown
 """
 
 from __future__ import annotations
@@ -135,14 +141,16 @@ def test_parse_purl_invalid_returns_none() -> None:
 
 def test_extract_trivy_from_location_message() -> None:
     sarif = trivy_sarif([("CVE-2026-4539", "Python", "Pygments", "2.19.2")])
-    keys = {csp.package_key(f) for f in csp.extract_findings(sarif)}
-    assert keys == {("pypi", "pygments", "2.19.2")}
+    findings, dropped = csp.extract_findings(sarif)
+    assert {csp.package_key(f) for f in findings} == {("pypi", "pygments", "2.19.2")}
+    assert dropped == 0
 
 
 def test_extract_grype_from_purls() -> None:
     sarif = grype_sarif([("GHSA-5239-wwwm-4pmq", "pypi", "Pygments", "2.19.2")])
-    keys = {csp.package_key(f) for f in csp.extract_findings(sarif)}
-    assert keys == {("pypi", "pygments", "2.19.2")}
+    findings, dropped = csp.extract_findings(sarif)
+    assert {csp.package_key(f) for f in findings} == {("pypi", "pygments", "2.19.2")}
+    assert dropped == 0
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +159,7 @@ def test_extract_grype_from_purls() -> None:
 
 
 def test_cross_tool_same_package_is_parity_not_divergence() -> None:
-    trivy = csp.extract_findings(
+    trivy, _ = csp.extract_findings(
         trivy_sarif(
             [
                 ("CVE-2026-4539", "Python", "Pygments", "2.19.2"),
@@ -159,7 +167,7 @@ def test_cross_tool_same_package_is_parity_not_divergence() -> None:
             ]
         )
     )
-    grype = csp.extract_findings(
+    grype, _ = csp.extract_findings(
         grype_sarif(
             [
                 ("GHSA-5239-wwwm-4pmq", "pypi", "Pygments", "2.19.2"),
@@ -173,20 +181,71 @@ def test_cross_tool_same_package_is_parity_not_divergence() -> None:
     assert result["grype_only"] == 0
 
 
+def test_ecosystem_alias_maps_python_to_pypi() -> None:
+    # The core fix depends on this alias: Trivy spells the ecosystem "Python"
+    # while Grype emits the PURL type "pypi". Without the alias the same package
+    # would land in two different keys and read as divergence. Pinning the alias
+    # directly means the cross-tool parity test above cannot pass vacuously.
+    assert csp._normalize_ecosystem("Python") == "pypi"
+    assert csp._normalize_ecosystem("pypi") == "pypi"
+
+
 # ---------------------------------------------------------------------------
 # 6. Genuine divergence
 # ---------------------------------------------------------------------------
 
 
 def test_genuine_divergence_reported() -> None:
-    trivy = csp.extract_findings(
+    trivy, _ = csp.extract_findings(
         trivy_sarif([("CVE-1", "Python", "requests", "2.0.0")])
     )
-    grype = csp.extract_findings(grype_sarif([("GHSA-2", "pypi", "urllib3", "1.0.0")]))
+    grype, _ = csp.extract_findings(
+        grype_sarif([("GHSA-2", "pypi", "urllib3", "1.0.0")])
+    )
     result = csp.compare(trivy, grype)
     assert result["both"] == 0
     assert result["trivy_only"] == 1
     assert result["grype_only"] == 1
+
+
+def test_extract_empty_version_location_is_dropped_not_phantom() -> None:
+    # A Trivy location with an empty version ("Python: requests@   ") must not
+    # become a phantom finding with version="" that inflates the trivy-only
+    # bucket; it is dropped and counted instead.
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "Trivy", "rules": []}},
+                "results": [
+                    {
+                        "ruleId": "CVE-EMPTY",
+                        "locations": [{"message": {"text": "Python: requests@   "}}],
+                    }
+                ],
+            }
+        ]
+    }
+    assert csp._parse_trivy_location("Python: requests@   ") is None
+    findings, dropped = csp.extract_findings(sarif)
+    assert findings == []
+    assert dropped == 1
+
+
+def test_extract_counts_results_with_no_parseable_artifact() -> None:
+    # A result carrying a ruleId but neither a PURL nor a parseable location is
+    # the signature of a scanner output-format change. It is dropped and the
+    # drop is counted so a silent under-count is visible downstream.
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "Grype", "rules": []}},
+                "results": [{"ruleId": "GHSA-shape-change", "properties": {}}],
+            }
+        ]
+    }
+    findings, dropped = csp.extract_findings(sarif)
+    assert findings == []
+    assert dropped == 1
 
 
 # ---------------------------------------------------------------------------
@@ -201,27 +260,52 @@ def test_load_dir_reads_files_without_sarif_extension(tmp_path: Path) -> None:
     (d / "output").write_text(
         json.dumps(grype_sarif([("GHSA-x", "pypi", "Pygments", "2.19.2")]))
     )
-    findings, files = csp.load_findings_from_dir(str(d))
-    assert files == 1
-    assert {csp.package_key(f) for f in findings} == {("pypi", "pygments", "2.19.2")}
+    result = csp.load_findings_from_dir(str(d))
+    assert result["files_parsed"] == 1
+    assert result["files_failed"] == 0
+    assert {csp.package_key(f) for f in result["findings"]} == {
+        ("pypi", "pygments", "2.19.2")
+    }
 
 
 def test_load_dir_missing_returns_empty(tmp_path: Path) -> None:
-    findings, files = csp.load_findings_from_dir(str(tmp_path / "does-not-exist"))
-    assert findings == []
-    assert files == 0
+    result = csp.load_findings_from_dir(str(tmp_path / "does-not-exist"))
+    assert result["findings"] == []
+    assert result["files_parsed"] == 0
+    assert result["files_failed"] == 0
 
 
-def test_load_dir_ignores_non_json(tmp_path: Path) -> None:
+def test_load_dir_reads_valid_sarif_and_counts_unparseable_sibling(
+    tmp_path: Path,
+) -> None:
+    # A non-JSON sibling does not pollute findings or corrupt the valid SARIF
+    # read, but it is counted as files_failed rather than silently ignored, so
+    # a corrupted/truncated artifact cannot vanish without a trace.
     d = tmp_path / "trivy"
     d.mkdir()
     (d / "note.txt").write_text("not json")
     (d / "trivy.sarif").write_text(
         json.dumps(trivy_sarif([("CVE-9", "Python", "flask", "3.0.0")]))
     )
-    findings, files = csp.load_findings_from_dir(str(d))
-    assert files == 1
-    assert {csp.package_key(f) for f in findings} == {("pypi", "flask", "3.0.0")}
+    result = csp.load_findings_from_dir(str(d))
+    assert result["files_parsed"] == 1
+    assert result["files_failed"] == 1
+    assert {csp.package_key(f) for f in result["findings"]} == {
+        ("pypi", "flask", "3.0.0")
+    }
+
+
+def test_load_dir_counts_non_sarif_json(tmp_path: Path) -> None:
+    # Valid JSON that lacks a "runs" key (e.g. a future enveloped SARIF shape)
+    # is counted separately so the divergence between "no SARIF" and
+    # "unrecognized SARIF" is visible.
+    d = tmp_path / "grype"
+    d.mkdir()
+    (d / "enveloped.json").write_text(json.dumps({"schema": "x", "sarif": {}}))
+    result = csp.load_findings_from_dir(str(d))
+    assert result["files_parsed"] == 0
+    assert result["non_sarif_json"] == 1
+    assert result["findings"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -253,9 +337,12 @@ def test_main_writes_summary_and_machine_line(tmp_path: Path, capsys) -> None:  
     assert rc == 0
 
     body = summary.read_text()
-    # package-level parity is the headline; the one shared package collapses
-    assert "Package-level" in body or "package" in body.lower()
-    assert "Pygments" in body or "pygments" in body
+    # Assert the exact verdict, not just the presence of the word "package"
+    # (which also appears in the table headers): a broken verdict must fail.
+    assert "**Package-level parity confirmed.**" in body
+    assert "pygments" in body.lower()
+    # A clean run records no parse warnings.
+    assert "**Warning:**" not in body
 
     out = capsys.readouterr().out
     # machine-readable line for log/API aggregation
@@ -263,3 +350,70 @@ def test_main_writes_summary_and_machine_line(tmp_path: Path, capsys) -> None:  
     assert "pkg_both=1" in out
     assert "pkg_trivy_only=0" in out
     assert "pkg_grype_only=0" in out
+    assert "trivy_files_failed=0" in out
+    assert "grype_files_failed=0" in out
+
+
+# ---------------------------------------------------------------------------
+# 10. Verdict branches and parse-warning gating
+# ---------------------------------------------------------------------------
+
+
+def _load_result(
+    findings: list[csp.Finding],
+    *,
+    files_parsed: int = 1,
+    files_failed: int = 0,
+    non_sarif_json: int = 0,
+    dropped_results: int = 0,
+) -> csp.LoadResult:
+    return csp.LoadResult(
+        findings=findings,
+        files_parsed=files_parsed,
+        files_failed=files_failed,
+        non_sarif_json=non_sarif_json,
+        dropped_results=dropped_results,
+    )
+
+
+def test_verdict_parity_at_zero_when_clean() -> None:
+    empty = _load_result([], files_parsed=1)
+    comparison = csp.compare([], [])
+    verdict = csp._verdict(comparison, empty, empty, "success", "success")
+    assert "Parity at zero" in verdict
+
+
+def test_verdict_inconclusive_on_parse_warning_despite_success() -> None:
+    # Both scanners "succeeded" and report zero packages, but a SARIF failed to
+    # parse. The zero must NOT be reported as parity at zero: this is the
+    # false-green case the observability counters exist to prevent.
+    clean = _load_result([], files_parsed=1)
+    lossy = _load_result([], files_parsed=0, files_failed=1)
+    comparison = csp.compare([], [])
+    verdict = csp._verdict(comparison, lossy, clean, "success", "success")
+    assert "inconclusive" in verdict.lower()
+    assert "Parity at zero" not in verdict
+
+
+def test_verdict_inconclusive_when_scanner_did_not_run() -> None:
+    empty = _load_result([], files_parsed=0)
+    comparison = csp.compare([], [])
+    verdict = csp._verdict(comparison, empty, empty, "failure", "success")
+    assert "inconclusive" in verdict.lower()
+
+
+def test_render_markdown_reports_divergence_and_warning() -> None:
+    trivy_findings, _ = csp.extract_findings(
+        trivy_sarif([("CVE-1", "Python", "requests", "2.0.0")])
+    )
+    grype_findings, _ = csp.extract_findings(
+        grype_sarif([("GHSA-2", "pypi", "urllib3", "1.0.0")])
+    )
+    comparison = csp.compare(trivy_findings, grype_findings)
+    trivy = _load_result(trivy_findings, files_parsed=1, dropped_results=2)
+    grype = _load_result(grype_findings, files_parsed=1)
+    report = csp.render_markdown(comparison, trivy, grype, "success", "success")
+    assert "**Package-level divergence detected.**" in report
+    # The dropped results surface as a visible warning block.
+    assert "**Warning:**" in report
+    assert "2 result(s) produced no parseable artifact" in report


### PR DESCRIPTION
## Summary

Running the issue #152 parity review surfaced that the parallel-run window was not measuring parity correctly. This PR fixes the instrumentation so a real comparison can be gathered before any Trivy cutover.

### Problems fixed

1. **False-divergence metric.** The `parity-summary` job set-diffed raw SARIF rule IDs. Trivy emits CVE-namespace IDs and Grype emits GHSA-namespace IDs for the same vulnerability, so identical detections registered as total divergence. Proof from `python-libs`: both scanners flagged the same two packages/versions/severities, but the job reported `both=0, Trivy-only=2, Grype-only=2`.
2. **Grype artifact never read.** The job globbed `*.sarif`; the Grype artifact downloads without a `.sarif` extension, so Grype findings read as zero regardless.
3. **Nightly feed dead.** `sbom-nightly.yml` set `permissions: {}`, below the ceiling the reusable's SARIF-upload jobs need, so every scheduled run was `startup_failure` since 2026-05-30 and gathered no data.

### Changes

- `scripts/compare_scanner_parity.py` (new): joins findings by `(ecosystem, PEP 503 package name, version)` instead of advisory ID; reads SARIF by content; emits a machine-readable `parity pkg_both=...` line to stdout for aggregation. Typed and env-var driven, mirroring `scripts/check_licenses.py`.
- `tests/python/test_compare_scanner_parity.py` (new): 15 cases including the CVE-vs-GHSA parity case and the extension-less-file case.
- `python-sbom.yml`: `parity-summary` rewritten to sparse-checkout and run the script (pinned to `job.workflow_sha`); `contents: read` granted; header comment corrected.
- `sbom-nightly.yml`: `contents: read` + `security-events: write` on the calling job; corrected RAD comment on caller/callee permission inheritance.

### Validation

- Ran the new comparator against the real `python-libs` SARIFs: now reports **package-level parity confirmed, both=2** (previously false divergence).
- 41 pytest pass; ruff lint clean; actionlint introduces zero new issues; pre-commit clean.

### Note on the cutover gate

The migration thesis holds on the one real data point (Grype matched Trivy exactly), but the 2026-06-25 gate should not be treated as met: the parity signal was not actually being measured. After this lands, the fleet needs rolling to a Grype-containing version and a fresh short window observed against the corrected metric.

Refs #152.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SBOM nightly workflow startup failures by configuring proper job permissions.
  * Corrected vulnerability scanner comparison logic to accurately match findings across different scanners instead of treating namespace differences as divergence.

* **Tests**
  * Added comprehensive test coverage for scanner parity comparison functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->