### PR TITLE
feat(ci): make baseline review a reusable workflow for fleet rollout

### DIFF
--- a/.github/workflows/claude-baseline-review-pr.yml
+++ b/.github/workflows/claude-baseline-review-pr.yml
@@ -1,0 +1,45 @@
+# ============================================================================
+# Claude Baseline Review -- this repo's caller
+# ============================================================================
+# Thin caller that runs the reusable Tier 0 baseline reviewer on this repo's
+# own PRs. The reviewer logic, security posture, and prompt live in the
+# reusable (.github/workflows/claude-baseline-review.yml); this file only
+# supplies the trigger, the permission ceiling, and this repo's framing.
+#
+# #CRITICAL: a called (reusable) workflow runs with a token bounded by the
+# CALLER job's permissions. The four scopes below are the ceiling the reusable
+# needs (id-token for the Claude App OIDC exchange); omitting any one fails the
+# run at startup.
+# ============================================================================
+name: Claude Baseline Review (PR)
+
+on:
+  pull_request:
+    # edited is included so a human editing the PR body re-classifies; the
+    # reusable skips bot-initiated edited events (CodeRabbit) internally.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    uses: ./.github/workflows/claude-baseline-review.yml
+    with:
+      repo-description: >-
+        an org-level .github repo containing reusable GitHub Actions workflows,
+        workflow templates, operator shell scripts, and community health files.
+      sensitive-paths: '.github/workflows/, workflow-templates/, scripts/'
+      escalation-guidance: |
+        - Changes under .github/workflows/ or workflow-templates/ that touch
+          permissions:, secrets, id-token, on: triggers, or add or change
+          workflow_call inputs.
+        - Changes under scripts/ that perform writes via gh api, handle
+          secrets, or transfer/delete resources.
+    secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/claude-baseline-review.yml
+++ b/.github/workflows/claude-baseline-review.yml
@@ -1,40 +1,67 @@
 # ============================================================================
-# Claude Baseline PR Review (Tier 0)
+# Claude Baseline PR Review (Tier 0) -- reusable workflow
 # ============================================================================
-# Lightweight universal triage review that runs on every non-draft PR.
-# It classifies the PR (renovate-deps, pattern-series, docs-only,
-# config-tweak, substantive), runs class-appropriate spot checks (including
-# tag-to-SHA verification on Renovate action bumps), folds in Copilot and
-# CodeRabbit status, and posts a single sticky verdict comment:
-# BASELINE-OK or ESCALATE. On ESCALATE it applies the needs-deep-review
-# label, which queues the PR for the full /pr-review skill (Tier 1).
+# Lightweight universal triage review for a single PR. Classifies the PR
+# (renovate-deps, pattern-series, docs-only, config-tweak, substantive), runs
+# class-appropriate spot checks (including tag-to-SHA verification on Renovate
+# action bumps), folds in Copilot and CodeRabbit status, and posts a single
+# sticky verdict comment: BASELINE-OK or ESCALATE. On ESCALATE it applies the
+# needs-deep-review label, which queues the PR for the full /pr-review skill
+# (Tier 1).
 #
-# The verdict is advisory: this job does not fail the PR on ESCALATE. It
-# fails only on operational errors (auth, action failure).
+# The verdict is advisory: this job does not fail the PR on ESCALATE. It fails
+# only on operational errors (auth, action failure).
 #
-# SETUP REQUIREMENTS (one-time):
-#   - Repository secret ANTHROPIC_API_KEY (Claude API key).
-#   - Claude GitHub App installed on the repository, used for OIDC token
+# REUSABLE: this is a workflow_call reusable consumed by a thin per-repo caller
+# that triggers on pull_request. Each caller supplies repo-specific framing via
+# inputs so one shared prompt serves every repo and is tuned in one place. The
+# repo-local caller in this repo is
+# .github/workflows/claude-baseline-review-pr.yml; consuming repos add their own
+# caller pinning this reusable by SHA (the .claude and homelab-infra repos are
+# the first consumers).
+#
+# SETUP REQUIREMENTS (per consuming repo):
+#   - ANTHROPIC_API_KEY secret (org-level, visibility all, already satisfies
+#     every repo) passed through by the caller (secrets: inherit).
+#   - Claude GitHub App installed on the consuming repo, used for OIDC token
 #     exchange. Alternative: pass a github_token input instead.
 #
 # COST PROFILE:
 #   Average duration: 2-5 minutes (capped by --max-turns 30 and
 #   timeout-minutes: 15)
 #   Model: Sonnet 4.6 (repo default tier per .claude/CLAUDE.md)
-#   Recommended for: every PR (that is the point of a universal baseline)
 # ============================================================================
 name: Claude Baseline Review
 
 on:
-  pull_request:
-    # #EDGE: edited is included because classification reads the PR body
-    # (precedent-PR citations) and title. labeled/unlabeled are deliberately
-    # excluded: this workflow applies the needs-deep-review label itself via
-    # an app token, and app-token events trigger workflows, so reacting to
-    # label events would self-trigger a loop.
-    types: [opened, synchronize, reopened, ready_for_review, edited]
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      repo-description:
+        description: >-
+          One or two sentences describing the consuming repository, injected
+          into the reviewer prompt as context so classification reflects what
+          the repo actually contains.
+        required: true
+        type: string
+      sensitive-paths:
+        description: >-
+          Comma or space separated path prefixes whose modification forces the
+          substantive class (and therefore the full spot checks). Example for a
+          workflow library: ".github/workflows/, workflow-templates/, scripts/".
+        required: true
+        type: string
+      escalation-guidance:
+        description: >-
+          Repo-specific escalation triggers, appended verbatim to the universal
+          trigger list in the prompt. Plain text; describe the change types that
+          must force a deep review in this repo (for example, edits to executable
+          hooks, permission/deny config, or secret handling).
+        required: true
+        type: string
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Claude API key for the baseline reviewer.'
+        required: true
 
 # #CRITICAL: deny-all default; the single job below requests only what it
 # needs. Keep workflow-level permissions empty.
@@ -52,9 +79,17 @@ jobs:
     # available to pull_request runs from forks; without the gate the job
     # would fail at startup on every fork PR and add noise. Same-repo PRs
     # are the only traffic in this solo-maintainer org today.
+    # #CRITICAL: the trailing clause skips bot-initiated `edited` events. The
+    # claude-code-action OIDC app-token exchange aborts when the initiating
+    # actor is a bot, and CodeRabbit edits the PR body (an `edited` event with
+    # sender.type == Bot) on most PRs, which would fail the check on every run.
+    # Renovate in this org runs as a User PAT (not a bot), so its opened and
+    # synchronize events are NOT skipped by this clause and are still reviewed.
+    # Human edits (action == edited, sender == User) also still re-classify.
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'edited' || github.event.sender.type != 'Bot')
     timeout-minutes: 15
     permissions:
       # #CRITICAL: contents: read is for checkout only; this reviewer never
@@ -92,20 +127,22 @@ jobs:
           # #CRITICAL: secret reference; ANTHROPIC_API_KEY must exist as a
           # repository or organization secret or this step fails at startup.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # #EDGE: only repository and PR number are interpolated into the
-          # prompt; both come from trusted event context. PR title, body,
-          # diff, and comments are attacker-influenced on fork PRs and are
-          # fetched by the agent as data, never interpolated here.
+          # #EDGE: only github.repository, the PR number, and caller-supplied
+          # inputs are interpolated into the prompt. github.repository and the
+          # PR number come from trusted event context; the inputs come from the
+          # caller workflow file (repo-author-controlled, on the default
+          # branch), not from PR event data. PR title, body, diff, and comments
+          # are attacker-influenced on fork PRs and are fetched by the agent as
+          # data, never interpolated here.
           prompt: |
             REPO: ${{ github.repository }}
             PR_NUMBER: ${{ github.event.pull_request.number }}
 
-            You are the Tier 0 baseline reviewer for this repository, an
-            org-level .github repo containing reusable GitHub Actions
-            workflows, workflow templates, operator shell scripts, and
-            community health files. Read .claude/CLAUDE.md first and follow
-            its writing rules in everything you post (in particular: never
-            use em-dashes).
+            You are the Tier 0 baseline reviewer for this repository:
+            ${{ inputs.repo-description }}
+            Read the repository's CLAUDE.md (at the repo root, and
+            .claude/CLAUDE.md if present) first and follow its writing rules in
+            everything you post (in particular: never use em-dashes).
 
             A deeper Tier 1 review pipeline (the pr-review skill) exists but
             is expensive. Your job: give every PR a fast, class-appropriate
@@ -138,14 +175,14 @@ jobs:
             - config-tweak: only tool config (renovate.json, .yamllint,
               .claude/settings.json, labels, dotfiles), no workflow logic.
             - substantive: everything else.
-            PRECEDENCE: if the PR changes any file under .github/workflows/,
-            workflow-templates/, or scripts/, it CANNOT be renovate-deps,
-            docs-only, or config-tweak; classify it substantive (or
-            pattern-series only if it cites a matching precedent). This
-            guarantees the substantive spot checks and the STEP 4
-            deterministic triggers are evaluated against the full diff for any
-            PR that touches workflow logic or operator scripts, even a pin
-            bump that edits a workflow uses: line.
+            PRECEDENCE: if the PR changes any file under these
+            repo-sensitive paths: ${{ inputs.sensitive-paths }} -- it CANNOT be
+            renovate-deps, docs-only, or config-tweak; classify it substantive
+            (or pattern-series only if it cites a matching precedent). This
+            guarantees the substantive spot checks and the STEP 4 deterministic
+            triggers are evaluated against the full diff for any PR that touches
+            this repo's security-sensitive surface, even a pin bump that edits a
+            single line.
 
             STEP 3: CLASS-APPROPRIATE CHECKS (do only these; no full review):
             - renovate-deps: for EVERY changed action pin, verify the tag
@@ -170,18 +207,16 @@ jobs:
               permission scope widening, secret handling changes, and PR
               description claims that the diff does not support.
 
-            STEP 4: ESCALATION DECISION. ESCALATE if ANY of:
-            1. Changes under .github/workflows/ or workflow-templates/ that
-               touch permissions:, secrets, id-token, on: triggers, or add
-               or change workflow_call inputs.
-            2. Changes under scripts/ that perform writes via gh api,
-               handle secrets, or transfer/delete resources.
-            3. breaking-change label, or ! in the conventional-commit title.
-            4. More than 500 changed lines, excluding lockfiles,
-               checksums.txt, and generated files.
-            5. Any renovate-deps tag/SHA mismatch, or a major action update.
-            6. Your judgment: security-sensitive or architectural
-               implications a one-pass review cannot clear.
+            STEP 4: ESCALATION DECISION. ESCALATE if ANY of the following.
+            Repo-specific triggers:
+            ${{ inputs.escalation-guidance }}
+            Universal triggers:
+            - breaking-change label, or ! in the conventional-commit title.
+            - More than 500 changed lines, excluding lockfiles,
+              checksums.txt, and generated files.
+            - Any renovate-deps tag/SHA mismatch, or a major action update.
+            - Your judgment: security-sensitive or architectural
+              implications a one-pass review cannot clear.
             Do NOT escalate solely for: docs-only changes, pattern-series
             PRs that match their precedent, or patch/minor pin bumps that
             verify clean.

--- a/.github/workflows/claude-baseline-review.yml
+++ b/.github/workflows/claude-baseline-review.yml
@@ -120,6 +120,12 @@ jobs:
           # the gh CLI, not local git history.
           fetch-depth: 1
           persist-credentials: false
+          # #CRITICAL: caller repos symlink files under .claude/ (e.g.
+          # .claude/commands/review-pr.md) into .submodules/. Without submodule
+          # checkout those symlinks dangle and claude-code-action aborts with
+          # `ENOENT ... statx '.claude/commands/review-pr.md'`. Recursive
+          # checkout resolves them. Submodules are public, so no extra token.
+          submodules: recursive
 
       - name: Run baseline triage review
         uses: anthropics/claude-code-action@ebcdfe6dc6bb7511eb63e59e07df256dbcf59a2e  # v1.0.145

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ### Changed
 
+- `claude-baseline-review.yml`: converted the Tier 0 baseline reviewer from a
+  repo-local `pull_request` workflow into a `workflow_call` reusable. Repo-specific
+  framing (`repo-description`, `sensitive-paths`, `escalation-guidance`) is now
+  supplied by a thin per-repo caller, so the shared prompt is tuned in one place.
+  This repo calls it via the new `claude-baseline-review-pr.yml`. Also added a
+  guard that skips bot-initiated `edited` events (CodeRabbit body edits), which
+  were failing the `claude-code-action` OIDC exchange on every PR; Renovate runs
+  as a User in this org and is unaffected. First downstream consumers: the
+  `.claude` and `homelab-infra` repos (issue: tiered-pr-review Phase 3 eval cohort).
 - `python-sbom.yml`: rewrote the `parity-summary` (issue #152) comparison to
   join Trivy and Grype findings by affected artifact (ecosystem, PEP 503 package
   name, version) instead of raw advisory ID, so the same vulnerability reported

--- a/docs/architecture/tiered-pr-review.md
+++ b/docs/architecture/tiered-pr-review.md
@@ -183,6 +183,20 @@ other.
 | 3 | Promote to a `workflow_call` reusable consumed by fleet repos | Same conventions as the other `python-*` reusables; templates plus docs |
 | 4 | Replace the prompt-encoded baseline with a skill-native baseline mode invoked headlessly from CI | `.claude` repo packaged as a plugin marketplace; skill gains a non-interactive mode |
 
+### Status (2026-06-19): Phase 3 started as a scoped evaluation cohort
+
+`claude-baseline-review.yml` has been converted from a repo-local
+`pull_request` workflow into a `workflow_call` reusable. Repo-specific framing
+(`repo-description`, `sensitive-paths`, `escalation-guidance`) is now supplied
+by thin per-repo callers, so the shared prompt is tuned in one place. The
+`.github` repo calls it via `claude-baseline-review-pr.yml`; `.claude` and
+`homelab-infra` were added as the first downstream consumers to gather precision
+data faster than `.github`'s PR volume alone allows. This is a deliberate
+narrow expansion of Phase 1 evaluation, not the full fleet rollout: the Phase 2
+threshold-tuning gate still governs going wider. The conversion also folded in a
+guard that skips bot-initiated `edited` events (CodeRabbit body edits), which
+were failing the `claude-code-action` OIDC exchange on every PR.
+
 ## 8. Setup prerequisites (phase 1)
 
 1. Repository (or org) secret `ANTHROPIC_API_KEY`.


### PR DESCRIPTION
## Summary

Converts the Tier 0 baseline reviewer (`claude-baseline-review.yml`) from a repo-local `pull_request` workflow into a `workflow_call` reusable, so other org repos can consume it without duplicating the ~230-line prompt. This starts Phase 3 of the [tiered-pr-review rollout](docs/architecture/tiered-pr-review.md) as a scoped evaluation cohort.

### What changed

- **`claude-baseline-review.yml`** is now a reusable (`on: workflow_call`) with three inputs that carry the repo-specific framing: `repo-description`, `sensitive-paths`, `escalation-guidance`. The classify/check/escalate/report structure and security posture are unchanged and shared.
- **`claude-baseline-review-pr.yml`** (new) is this repo's thin caller: `on: pull_request`, grants the permission ceiling (`contents: read`, `pull-requests: write`, `issues: write`, `id-token: write`), and passes this repo's framing.
- **Bot-edit guard**: the reusable now skips bot-initiated `edited` events. CodeRabbit edits the PR body on most PRs, and the `claude-code-action` OIDC exchange aborts on a bot actor, which was failing the check on every PR. Renovate runs as a User PAT in this org, so its events are unaffected and still reviewed.

### Downstream consumers

`.claude` and `homelab-infra` get thin callers (separate PRs) pinning this reusable by SHA, to gather precision data faster than this repo's PR volume alone. Per the rollout plan, this is a deliberate narrow expansion of Phase 1 evaluation, not the full fleet rollout; the Phase 2 tuning gate still governs going wider.

### Prerequisite

The Claude GitHub App's repository access must include `.claude` and `homelab-infra` (org secret `ANTHROPIC_API_KEY` is already org-wide). Until then those callers fail at startup, advisory, so harmless.

### Validation

- actionlint clean on both workflows; pre-commit (yamllint, markdownlint, detect-secrets, no-em-dash) clean.
- The reusable preserves the SHA-pinned actions, narrow tool allowlist, and `persist-credentials: false` from the original.

Refs the tiered-pr-review architecture doc (Section 7, Phase 3).

Generated with [Claude Code](https://claude.com/claude-code)