### PR TITLE
fix(ci): checkout submodules in baseline-review reusable workflow

### DIFF
--- a/.github/workflows/claude-baseline-review.yml
+++ b/.github/workflows/claude-baseline-review.yml
@@ -85,6 +85,12 @@ jobs:
           # the gh CLI, not local git history.
           fetch-depth: 1
           persist-credentials: false
+          # #CRITICAL: caller repos symlink files under .claude/ (e.g.
+          # .claude/commands/review-pr.md) into .submodules/. Without submodule
+          # checkout those symlinks dangle and claude-code-action aborts with
+          # `ENOENT ... statx '.claude/commands/review-pr.md'`. Recursive
+          # checkout resolves them. Submodules are public, so no extra token.
+          submodules: recursive
 
       - name: Run baseline triage review
         uses: anthropics/claude-code-action@ebcdfe6dc6bb7511eb63e59e07df256dbcf59a2e  # v1.0.145


### PR DESCRIPTION
## Summary

The Claude Baseline Review reusable workflow checks out with `fetch-depth: 1` and `persist-credentials: false` but no `submodules:` key, so submodule checkout defaults to **off**. Caller repos symlink files under `.claude/` into `.submodules/` (e.g. in `ByronWilliamsCPA/.claude`, `.claude/commands/review-pr.md` -> `.submodules/anthropics-plugins/plugins/pr-review-toolkit/commands/review-pr.md`). With submodules absent on the runner, those symlinks dangle and `claude-code-action` aborts at startup:

```
##[error]Action failed with error: ENOENT: no such file or directory, statx '.claude/commands/review-pr.md'
##[error]Process completed with exit code 1.
```

This caused `review / Baseline Triage Review` to fail on every PR in `.claude` (observed on [.claude#215 run](https://github.com/ByronWilliamsCPA/.claude/actions/runs/27847693980/job/82420279676)).

## Why it is not a secret problem

`ANTHROPIC_API_KEY` (org-level in `ByronWilliamsCPA`, forwarded by the caller's explicit `secrets:` block) is pulled correctly: the run log shows `anthropic_api_key: ***`, which GitHub renders only for a non-empty registered secret. The action downloads, installs the SDK, and configures git auth successfully before failing on the dangling symlink.

## Change

Add `submodules: recursive` to the checkout step. Submodules here are public (anthropics-plugins, reference-library, etc.), so no additional checkout token is required.

## Follow-up

After this merges, the caller in `ByronWilliamsCPA/.claude/.github/workflows/claude-baseline-review.yml` must re-pin `uses:` from the pre-merge SHA (`e5e6951`) to the new merge SHA for the fix to take effect there (the caller comment already notes this re-pin TODO).

Generated with [Claude Code](https://claude.com/claude-code)