### PR TITLE
feat(ci): add Snyk reusable workflow layer (SAST, IaC, AI-BOM)

### DIFF
--- a/.github/workflows/python-snyk-iac.yml
+++ b/.github/workflows/python-snyk-iac.yml
@@ -132,12 +132,15 @@ jobs:
           echo "has-k8s=$has_k8s" >> "$GITHUB_OUTPUT"
           [ "$has_k8s" = "true" ] || echo "::notice::No YAML files in k8s-dirs; Kubernetes scan skipped."
 
-          # Docker Compose: probe compose-dirs for docker-compose*.yml files.
+          # Docker Compose: probe compose-dirs for all canonical Docker Compose v2
+          # filenames: compose.yaml, compose.yml, docker-compose*.yaml, docker-compose*.yml.
           has_compose=false
           if [ -n "$COMPOSE_DIRS" ]; then
             IFS=' ' read -ra dirs <<< "$COMPOSE_DIRS"
             for dir in "${dirs[@]}"; do
-              if find "$dir" -maxdepth 5 -name 'docker-compose*.yml' \
+              if find "$dir" -maxdepth 5 \
+                  \( -name 'compose.yaml' -o -name 'compose.yml' \
+                     -o -name 'docker-compose*.yaml' -o -name 'docker-compose*.yml' \) \
                   -print -quit 2>/dev/null | grep -q .; then
                 has_compose=true
                 break
@@ -146,7 +149,7 @@ jobs:
           fi
           echo "has-compose=$has_compose" >> "$GITHUB_OUTPUT"
           [ "$has_compose" = "true" ] || \
-            echo "::notice::No docker-compose*.yml files in compose-dirs; Compose scan skipped."
+            echo "::notice::No Compose files found in compose-dirs; Compose scan skipped."
 
   snyk-terraform:
     name: Snyk IaC (Terraform)
@@ -338,6 +341,7 @@ jobs:
           R_TERRAFORM: ${{ needs.snyk-terraform.result }}
           R_K8S: ${{ needs.snyk-kubernetes.result }}
           R_COMPOSE: ${{ needs.snyk-compose.result }}
+        shell: bash
         run: |
           echo "Terraform: $R_TERRAFORM | Kubernetes: $R_K8S | Compose: $R_COMPOSE"
           is_ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }

--- a/.github/workflows/python-snyk-iac.yml
+++ b/.github/workflows/python-snyk-iac.yml
@@ -1,0 +1,349 @@
+# Python Snyk IaC (Reusable)
+# Snyk Infrastructure-as-Code scanning layer: Terraform, Kubernetes manifests,
+# and Docker Compose. Token-gated; no-ops cleanly when SNYK_TOKEN is absent
+# or when no IaC files are present in the configured directories.
+#
+# Usage from downstream repos:
+#   jobs:
+#     snyk-iac:
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-snyk-iac.yml@v1
+#       permissions:
+#         contents: read
+#         security-events: write   # required for SARIF upload
+#       with:
+#         terraform-dirs: 'infra'
+#         k8s-dirs: 'k8s manifests'  # space-separated; empty = skip
+#         compose-dirs: ''           # empty = skip
+#         fail-on-high: true
+#       secrets:
+#         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+#
+# Caller permission contract:
+# #CRITICAL: callers MUST grant security-events: write at workflow or calling-job
+#   level, or the run fails at startup ("startup_failure") before any job runs.
+#   See memory entry "Reusable startup_failure causes".
+# #ASSUME: SNYK_TOKEN may be absent; the workflow no-ops cleanly when it is.
+# #ASSUME: directory paths do not contain spaces (org policy; IFS splitting on
+#   space-separated input would break paths with spaces).
+# #EDGE: snyk iac test exits 2 (error) when no supported files are found.
+#   The detect-iac job probes for file presence before each scan job runs.
+# #VERIFY: after wiring a new caller, confirm detect-iac outputs has-terraform=true
+#   (or has-k8s / has-compose) in the Actions run log.
+
+name: Python Snyk IaC (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      terraform-dirs:
+        description: 'Space-separated directories to scan for Terraform files (.tf). Default scans repo root.'
+        type: string
+        required: false
+        default: '.'
+      k8s-dirs:
+        description: 'Space-separated directories to scan for Kubernetes manifests. Empty = skip.'
+        type: string
+        required: false
+        default: ''
+      compose-dirs:
+        description: 'Space-separated directories to scan for Docker Compose files. Empty = skip.'
+        type: string
+        required: false
+        default: ''
+      fail-on-high:
+        description: 'Fail the build on HIGH/CRITICAL Snyk IaC findings'
+        type: boolean
+        required: false
+        default: true
+    secrets:
+      SNYK_TOKEN:
+        description: 'Snyk API token. When absent, all scan jobs no-op.'
+        required: false
+
+permissions: {}
+
+jobs:
+  detect-iac:
+    name: Detect IaC Files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has-token: ${{ steps.check-token.outputs.has-token }}
+      has-terraform: ${{ steps.detect.outputs.has-terraform }}
+      has-k8s: ${{ steps.detect.outputs.has-k8s }}
+      has-compose: ${{ steps.detect.outputs.has-compose }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Check for SNYK_TOKEN
+        id: check-token
+        env:
+          HAS_TOKEN: ${{ secrets.SNYK_TOKEN != '' }}
+        run: |
+          if [ "$HAS_TOKEN" = "true" ]; then
+            echo "has-token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SNYK_TOKEN not set; Snyk IaC scan jobs will be skipped."
+          fi
+        shell: bash
+      - name: Detect IaC files
+        id: detect
+        env:
+          TERRAFORM_DIRS: ${{ inputs.terraform-dirs }}
+          K8S_DIRS: ${{ inputs.k8s-dirs }}
+          COMPOSE_DIRS: ${{ inputs.compose-dirs }}
+        shell: bash
+        run: |
+          # Terraform: probe terraform-dirs for .tf files.
+          # Default is '.'; if the repo root has no .tf files, has-terraform=false
+          # and the scan job skips, preventing snyk iac test exit 2.
+          has_terraform=false
+          if [ -n "$TERRAFORM_DIRS" ]; then
+            IFS=' ' read -ra dirs <<< "$TERRAFORM_DIRS"
+            for dir in "${dirs[@]}"; do
+              if find "$dir" -maxdepth 5 -name '*.tf' -print -quit 2>/dev/null | grep -q .; then
+                has_terraform=true
+                break
+              fi
+            done
+          fi
+          echo "has-terraform=$has_terraform" >> "$GITHUB_OUTPUT"
+          [ "$has_terraform" = "true" ] || echo "::notice::No .tf files found; Terraform scan skipped."
+
+          # Kubernetes: probe k8s-dirs for .yaml/.yml files (dirs are k8s-specific by convention).
+          has_k8s=false
+          if [ -n "$K8S_DIRS" ]; then
+            IFS=' ' read -ra dirs <<< "$K8S_DIRS"
+            for dir in "${dirs[@]}"; do
+              if find "$dir" -maxdepth 5 \( -name '*.yaml' -o -name '*.yml' \) \
+                  -print -quit 2>/dev/null | grep -q .; then
+                has_k8s=true
+                break
+              fi
+            done
+          fi
+          echo "has-k8s=$has_k8s" >> "$GITHUB_OUTPUT"
+          [ "$has_k8s" = "true" ] || echo "::notice::No YAML files in k8s-dirs; Kubernetes scan skipped."
+
+          # Docker Compose: probe compose-dirs for docker-compose*.yml files.
+          has_compose=false
+          if [ -n "$COMPOSE_DIRS" ]; then
+            IFS=' ' read -ra dirs <<< "$COMPOSE_DIRS"
+            for dir in "${dirs[@]}"; do
+              if find "$dir" -maxdepth 5 -name 'docker-compose*.yml' \
+                  -print -quit 2>/dev/null | grep -q .; then
+                has_compose=true
+                break
+              fi
+            done
+          fi
+          echo "has-compose=$has_compose" >> "$GITHUB_OUTPUT"
+          [ "$has_compose" = "true" ] || \
+            echo "::notice::No docker-compose*.yml files in compose-dirs; Compose scan skipped."
+
+  snyk-terraform:
+    name: Snyk IaC (Terraform)
+    needs: detect-iac
+    if: >-
+      ${{ inputs.terraform-dirs != ''
+        && needs.detect-iac.outputs.has-token == 'true'
+        && needs.detect-iac.outputs.has-terraform == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Setup Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04  # v1.0.0
+      - name: Run Snyk IaC (Terraform)
+        id: terraform
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TERRAFORM_DIRS: ${{ inputs.terraform-dirs }}
+          FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
+        shell: bash
+        run: |
+          set +e
+          THRESHOLD=high
+          [ "$FAIL_ON_HIGH" = "true" ] || THRESHOLD=critical
+          IFS=' ' read -ra dirs <<< "$TERRAFORM_DIRS"
+          snyk iac test "${dirs[@]}" \
+            --severity-threshold="$THRESHOLD" \
+            --sarif-file-output=iac-terraform.sarif
+          CODE=$?
+          # 0 = no issues; 1 = issues at/above threshold; >1 = real error.
+          if [ "$CODE" -gt 1 ]; then
+            echo "::error::Snyk IaC Terraform scan failed (exit $CODE)."
+            exit "$CODE"
+          fi
+          if [ "$CODE" -eq 1 ] && [ "$FAIL_ON_HIGH" = "true" ]; then
+            echo "::error::Snyk IaC found Terraform findings at/above $THRESHOLD."
+            echo "gate=fail" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+      - name: Upload Terraform SARIF
+        if: always() && hashFiles('iac-terraform.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        continue-on-error: true
+        with:
+          sarif_file: iac-terraform.sarif
+          category: snyk-iac-terraform
+      - name: Enforce gate
+        if: steps.terraform.outputs.gate == 'fail'
+        run: exit 1
+
+  snyk-kubernetes:
+    name: Snyk IaC (Kubernetes)
+    needs: detect-iac
+    if: >-
+      ${{ inputs.k8s-dirs != ''
+        && needs.detect-iac.outputs.has-token == 'true'
+        && needs.detect-iac.outputs.has-k8s == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Setup Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04  # v1.0.0
+      - name: Run Snyk IaC (Kubernetes)
+        id: kubernetes
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          K8S_DIRS: ${{ inputs.k8s-dirs }}
+          FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
+        shell: bash
+        run: |
+          set +e
+          THRESHOLD=high
+          [ "$FAIL_ON_HIGH" = "true" ] || THRESHOLD=critical
+          IFS=' ' read -ra dirs <<< "$K8S_DIRS"
+          snyk iac test "${dirs[@]}" \
+            --severity-threshold="$THRESHOLD" \
+            --sarif-file-output=iac-k8s.sarif
+          CODE=$?
+          if [ "$CODE" -gt 1 ]; then
+            echo "::error::Snyk IaC Kubernetes scan failed (exit $CODE)."
+            exit "$CODE"
+          fi
+          if [ "$CODE" -eq 1 ] && [ "$FAIL_ON_HIGH" = "true" ]; then
+            echo "::error::Snyk IaC found Kubernetes findings at/above $THRESHOLD."
+            echo "gate=fail" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+      - name: Upload Kubernetes SARIF
+        if: always() && hashFiles('iac-k8s.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        continue-on-error: true
+        with:
+          sarif_file: iac-k8s.sarif
+          category: snyk-iac-kubernetes
+      - name: Enforce gate
+        if: steps.kubernetes.outputs.gate == 'fail'
+        run: exit 1
+
+  snyk-compose:
+    name: Snyk IaC (Docker Compose)
+    needs: detect-iac
+    if: >-
+      ${{ inputs.compose-dirs != ''
+        && needs.detect-iac.outputs.has-token == 'true'
+        && needs.detect-iac.outputs.has-compose == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Setup Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04  # v1.0.0
+      - name: Run Snyk IaC (Docker Compose)
+        id: compose
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          COMPOSE_DIRS: ${{ inputs.compose-dirs }}
+          FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
+        shell: bash
+        run: |
+          set +e
+          THRESHOLD=high
+          [ "$FAIL_ON_HIGH" = "true" ] || THRESHOLD=critical
+          IFS=' ' read -ra dirs <<< "$COMPOSE_DIRS"
+          snyk iac test "${dirs[@]}" \
+            --severity-threshold="$THRESHOLD" \
+            --sarif-file-output=iac-compose.sarif
+          CODE=$?
+          if [ "$CODE" -gt 1 ]; then
+            echo "::error::Snyk IaC Docker Compose scan failed (exit $CODE)."
+            exit "$CODE"
+          fi
+          if [ "$CODE" -eq 1 ] && [ "$FAIL_ON_HIGH" = "true" ]; then
+            echo "::error::Snyk IaC found Docker Compose findings at/above $THRESHOLD."
+            echo "gate=fail" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+      - name: Upload Docker Compose SARIF
+        if: always() && hashFiles('iac-compose.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        continue-on-error: true
+        with:
+          sarif_file: iac-compose.sarif
+          category: snyk-iac-compose
+      - name: Enforce gate
+        if: steps.compose.outputs.gate == 'fail'
+        run: exit 1
+
+  snyk-iac-gate:
+    name: Snyk IaC Gate
+    needs: [detect-iac, snyk-terraform, snyk-kubernetes, snyk-compose]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Validate IaC results
+        env:
+          R_TERRAFORM: ${{ needs.snyk-terraform.result }}
+          R_K8S: ${{ needs.snyk-kubernetes.result }}
+          R_COMPOSE: ${{ needs.snyk-compose.result }}
+        run: |
+          echo "Terraform: $R_TERRAFORM | Kubernetes: $R_K8S | Compose: $R_COMPOSE"
+          is_ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
+          if is_ok "$R_TERRAFORM" && is_ok "$R_K8S" && is_ok "$R_COMPOSE"; then
+            echo "Snyk IaC gate passed"
+          else
+            echo "Snyk IaC gate failed - review IaC findings in the Security tab"
+            exit 1
+          fi

--- a/.github/workflows/python-snyk.yml
+++ b/.github/workflows/python-snyk.yml
@@ -1,0 +1,304 @@
+# Python Snyk (Reusable)
+# Snyk AI-code-security layer: Code (SAST), optional Open Source (SCA cross-check),
+# and AI-BOM. Complements the existing OSV/Renovate SCA stack; it does not replace it.
+#
+# Usage from downstream repos:
+#   jobs:
+#     snyk:
+#       uses: ByronWilliamsCPA/.github/.github/workflows/python-snyk.yml@v1
+#       permissions:
+#         contents: read
+#         security-events: write   # SARIF upload to the Security tab
+#       with:
+#         source-directory: 'src'
+#         run-code: true           # Snyk Code (SAST)
+#         run-oss: false           # SCA cross-check (OSV/Renovate are primary)
+#         run-aibom: false         # AI-BOM (set true for LLM/RAG/MCP repos)
+#         fail-on-high: true
+#       secrets:
+#         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+#
+# Caller permission contract:
+# #CRITICAL: reusable caller/callee permission inheritance. Callers MUST grant
+#   security-events: write at workflow or calling-job level, or the run fails at
+#   startup ("startup_failure" / generic "workflow file issue") before any job runs.
+# #ASSUME: SNYK_TOKEN may be absent; the workflow no-ops cleanly when it is.
+# #VERIFY: after changing permissions or the secrets block, trigger one caller run and
+#   confirm `gh run view <id> --json conclusion` is not "startup_failure".
+
+name: Python Snyk (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      source-directory:
+        description: 'Source code directory to scan'
+        type: string
+        required: false
+        default: 'src'
+      python-version:
+        description: 'Python version for dependency resolution'
+        type: string
+        required: false
+        default: '3.12'
+      run-code:
+        description: 'Run Snyk Code (SAST)'
+        type: boolean
+        required: false
+        default: true
+      run-oss:
+        description: 'Run Snyk Open Source (SCA cross-check). Advisory; OSV/Renovate are primary.'
+        type: boolean
+        required: false
+        default: false
+      run-aibom:
+        description: 'Generate an AI-BOM (Python only; for LLM/RAG/MCP repos)'
+        type: boolean
+        required: false
+        default: false
+      fail-on-high:
+        description: 'Fail the build on HIGH/CRITICAL Snyk Code findings'
+        type: boolean
+        required: false
+        default: true
+      no-build:
+        description: 'Pass --no-build to uv sync (disable for projects with a build backend)'
+        type: boolean
+        required: false
+        default: true
+    secrets:
+      SNYK_TOKEN:
+        description: 'Snyk API token. When absent, all scan jobs no-op.'
+        required: false
+
+permissions: {}
+
+jobs:
+  detect-config:
+    name: Detect Config
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+      state: ${{ steps.detect.outputs.state }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      # Secrets-in-if antipattern guard: read presence via env, decide in shell.
+      - name: Check for SNYK_TOKEN
+        id: check
+        env:
+          HAS_TOKEN: ${{ secrets.SNYK_TOKEN != '' }}
+        run: |
+          if [ "$HAS_TOKEN" = "true" ]; then
+            echo "has-token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SNYK_TOKEN not set; Snyk scan jobs will be skipped."
+          fi
+        shell: bash
+      - name: Detect repo state
+        id: detect
+        run: |
+          if [ ! -f pyproject.toml ]; then
+            echo "state=skip" >> "$GITHUB_OUTPUT"
+            echo "::notice::No pyproject.toml at repo root; Snyk scans will be skipped."
+          elif [ -f poetry.lock ] || grep -qE '^\[tool\.poetry(\.|])' pyproject.toml; then
+            echo "state=poetry-not-supported" >> "$GITHUB_OUTPUT"
+            echo "::error::This repo uses Poetry. python-snyk.yml is uv-only by org policy."
+            exit 1
+          elif [ -f uv.lock ]; then
+            echo "state=uv-locked" >> "$GITHUB_OUTPUT"
+          else
+            echo "state=uv-no-lock" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+  snyk-code:
+    name: Snyk Code (SAST)
+    needs: detect-config
+    if: >-
+      ${{ inputs.run-code
+        && needs.detect-config.outputs.has-token == 'true'
+        && (needs.detect-config.outputs.state == 'uv-locked' || needs.detect-config.outputs.state == 'uv-no-lock') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Setup Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04  # v1.0.0
+      - name: Run Snyk Code
+        id: code
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SRC_DIR: ${{ inputs.source-directory }}
+          FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
+        shell: bash
+        run: |
+          set +e
+          THRESHOLD=high
+          [ "$FAIL_ON_HIGH" = "true" ] || THRESHOLD=critical
+          snyk code test "$SRC_DIR" \
+            --severity-threshold="$THRESHOLD" \
+            --sarif-file-output=snyk-code.sarif
+          CODE=$?
+          # Exit 0 = no issues; 1 = issues at/above threshold; >1 = real error.
+          if [ "$CODE" -gt 1 ]; then
+            echo "::error::Snyk Code failed to run (exit $CODE)."
+            exit "$CODE"
+          fi
+          if [ "$CODE" -eq 1 ] && [ "$FAIL_ON_HIGH" = "true" ]; then
+            echo "::error::Snyk Code found findings at/above $THRESHOLD."
+            echo "gate=fail" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+      - name: Upload Snyk Code SARIF
+        if: always() && hashFiles('snyk-code.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        continue-on-error: true
+        with:
+          sarif_file: snyk-code.sarif
+          category: snyk-code
+      - name: Enforce gate
+        if: steps.code.outputs.gate == 'fail'
+        run: exit 1
+
+  snyk-oss:
+    name: Snyk Open Source (SCA cross-check)
+    needs: detect-config
+    if: >-
+      ${{ inputs.run-oss
+        && needs.detect-config.outputs.has-token == 'true'
+        && needs.detect-config.outputs.state == 'uv-locked' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Advisory by default: OSV + Renovate are the primary SCA gate. This job never fails the build.
+    continue-on-error: true
+    permissions:
+      contents: read
+      security-events: write
+    env:
+      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install UV
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+      # Snyk SCA does not parse uv.lock. Export the committed lockfile to a requirements file Snyk understands. Restricted to uv-locked state so this never triggers a live network resolve.
+      - name: Export requirements for Snyk
+        shell: bash
+        run: uv export --format requirements-txt --no-emit-project -o requirements-snyk.txt
+      - name: Setup Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04  # v1.0.0
+      - name: Run Snyk Open Source
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        shell: bash
+        run: |
+          set +e
+          snyk test --file=requirements-snyk.txt --package-manager=pip \
+            --severity-threshold=high \
+            --sarif-file-output=snyk-oss.sarif
+          # Advisory: do not propagate the exit code.
+          exit 0
+      - name: Upload Snyk OSS SARIF
+        if: always() && hashFiles('snyk-oss.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        continue-on-error: true
+        with:
+          sarif_file: snyk-oss.sarif
+          category: snyk-oss
+
+  snyk-aibom:
+    name: Snyk AI-BOM
+    needs: detect-config
+    if: >-
+      ${{ inputs.run-aibom
+        && needs.detect-config.outputs.has-token == 'true'
+        && (needs.detect-config.outputs.state == 'uv-locked' || needs.detect-config.outputs.state == 'uv-no-lock') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Setup Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04  # v1.0.0
+      - name: Generate AI-BOM
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        shell: bash
+        run: |
+          set +e
+          # #VERIFY: confirm aibom.json is non-empty on a known LLM/RAG repo during the live phase; AI-BOM detection may require resolved dependencies.
+          snyk aibom --json > aibom.json
+          CODE=$?
+          if [ "$CODE" -ne 0 ]; then
+            echo "::warning::snyk aibom exited $CODE (often: no supported AI project). Continuing."
+          fi
+          exit 0
+      - name: Upload AI-BOM artifact
+        if: always() && hashFiles('aibom.json') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: snyk-aibom
+          path: aibom.json
+
+  snyk-gate:
+    name: Snyk Gate
+    needs: [detect-config, snyk-code, snyk-oss, snyk-aibom]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Validate Snyk results
+        env:
+          R_CODE: ${{ needs.snyk-code.result }}
+          R_OSS: ${{ needs.snyk-oss.result }}
+          R_AIBOM: ${{ needs.snyk-aibom.result }}
+        run: |
+          echo "Snyk Code: $R_CODE | OSS: $R_OSS | AI-BOM: $R_AIBOM"
+          is_ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
+          # OSS is advisory (continue-on-error), so it reports success even with findings.
+          # snyk-oss is in needs for ordering only and is intentionally excluded from the gate decision.
+          if is_ok "$R_CODE" && is_ok "$R_AIBOM"; then
+            echo "Snyk gate passed"
+          else
+            echo "Snyk gate failed - review Snyk Code findings"
+            exit 1
+          fi

--- a/.github/workflows/python-snyk.yml
+++ b/.github/workflows/python-snyk.yml
@@ -191,8 +191,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    env:
-      NO_BUILD_FLAG: ${{ inputs.no-build && '--no-build' || '' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
@@ -208,7 +206,8 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           enable-cache: true
-      # Snyk SCA does not parse uv.lock. Export the committed lockfile to a requirements file Snyk understands. Restricted to uv-locked state so this never triggers a live network resolve.
+      # Snyk SCA does not parse uv.lock; export the committed lockfile to a requirements file Snyk
+      # understands. Restricted to uv-locked state so this never triggers a live network resolve.
       - name: Export requirements for Snyk
         shell: bash
         run: uv export --format requirements-txt --no-emit-project -o requirements-snyk.txt
@@ -260,10 +259,13 @@ jobs:
         run: |
           set +e
           # #VERIFY: confirm aibom.json is non-empty on a known LLM/RAG repo during the live phase; AI-BOM detection may require resolved dependencies.
-          snyk aibom --json > aibom.json
+          snyk aibom --json > aibom.json.tmp
           CODE=$?
           if [ "$CODE" -ne 0 ]; then
             echo "::warning::snyk aibom exited $CODE (often: no supported AI project). Continuing."
+            rm -f aibom.json.tmp
+          else
+            mv aibom.json.tmp aibom.json
           fi
           exit 0
       - name: Upload AI-BOM artifact
@@ -288,17 +290,19 @@ jobs:
           egress-policy: audit
       - name: Validate Snyk results
         env:
+          R_DETECT: ${{ needs.detect-config.result }}
           R_CODE: ${{ needs.snyk-code.result }}
           R_OSS: ${{ needs.snyk-oss.result }}
           R_AIBOM: ${{ needs.snyk-aibom.result }}
+        shell: bash
         run: |
-          echo "Snyk Code: $R_CODE | OSS: $R_OSS | AI-BOM: $R_AIBOM"
+          echo "Detect: $R_DETECT | Snyk Code: $R_CODE | OSS: $R_OSS | AI-BOM: $R_AIBOM"
           is_ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
           # OSS is advisory (continue-on-error), so it reports success even with findings.
           # snyk-oss is in needs for ordering only and is intentionally excluded from the gate decision.
-          if is_ok "$R_CODE" && is_ok "$R_AIBOM"; then
+          if is_ok "$R_DETECT" && is_ok "$R_CODE" && is_ok "$R_AIBOM"; then
             echo "Snyk gate passed"
           else
-            echo "Snyk gate failed - review Snyk Code findings"
+            echo "Snyk gate failed - review Snyk findings in the Security tab"
             exit 1
           fi

--- a/.github/workflows/python-standard-stack.yml
+++ b/.github/workflows/python-standard-stack.yml
@@ -22,9 +22,13 @@
 # For advanced configuration (matrix testing, mutation, fuzzing, custom
 # Scorecard gates), call the individual workflows directly.
 #
+# An optional Snyk AI-code-security job runs when run-snyk is true and a
+# SNYK_TOKEN secret is supplied; it no-ops when the token is absent.
+#
 # Nesting depth: caller (1) -> standard-stack (2) ->
-#   python-ci / python-security-analysis / python-sbom (3).
-# Within GitHub's 4-level reusable workflow limit.
+#   python-ci / python-security-analysis / python-sbom / python-snyk (3).
+# python-snyk's own jobs are not nested reusable calls, so this stays within
+# GitHub's 4-level reusable workflow limit.
 # ============================================================================
 
 name: Standard Stack (Reusable)
@@ -55,6 +59,17 @@ on:
         type: boolean
         required: false
         default: true
+
+      run-snyk:
+        description: 'Run the Snyk AI-code-security layer (requires SNYK_TOKEN)'
+        type: boolean
+        required: false
+        default: false
+
+    secrets:
+      SNYK_TOKEN:
+        description: 'Snyk API token; forwarded to python-snyk.yml when run-snyk is true'
+        required: false
 
 # Workflow-level permissions are the ceiling for all jobs in this workflow.
 # Each job below declares only what it actually needs.
@@ -95,3 +110,18 @@ jobs:
     with:
       python-version: ${{ inputs.python-version }}
       fail-on-vulnerabilities: ${{ inputs.fail-on-high }}
+
+  snyk:
+    name: Snyk
+    needs: [ci]
+    if: ${{ inputs.run-snyk }}
+    uses: ./.github/workflows/python-snyk.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      python-version: ${{ inputs.python-version }}
+      source-directory: ${{ inputs.source-directory }}
+      fail-on-high: ${{ inputs.fail-on-high }}
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/python-standard-stack.yml
+++ b/.github/workflows/python-standard-stack.yml
@@ -62,6 +62,12 @@ on:
 
       run-snyk:
         description: 'Run the Snyk AI-code-security layer (requires SNYK_TOKEN)'
+        # #CRITICAL: callers setting run-snyk: true must also grant
+        # security-events: write at workflow or job level; python-snyk.yml's
+        # per-job grant is bounded by the caller's ceiling, and a missing write
+        # causes startup_failure before any job runs.
+        # #VERIFY: after enabling run-snyk in a caller, confirm no startup_failure
+        # via `gh run view <id> --json conclusion`.
         type: boolean
         required: false
         default: false

--- a/.github/workflows/python-standard-stack.yml
+++ b/.github/workflows/python-standard-stack.yml
@@ -129,6 +129,10 @@ jobs:
       python-version: ${{ inputs.python-version }}
       source-directory: ${{ inputs.source-directory }}
       fail-on-high: ${{ inputs.fail-on-high }}
+      # enable-aibom maps to run-aibom in python-snyk.yml. Rename is intentional:
+      # enable-* signals a feature gate subordinate to run-snyk, not a peer job toggle.
+      # #ASSUME python-snyk.yml exposes run-aibom as a boolean input (verified: line 54).
+      # #VERIFY run with run-snyk: true, enable-aibom: true; confirm no startup_failure.
       run-aibom: ${{ inputs.enable-aibom }}
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/python-standard-stack.yml
+++ b/.github/workflows/python-standard-stack.yml
@@ -66,6 +66,12 @@ on:
         required: false
         default: false
 
+      enable-aibom:
+        description: 'Generate an AI-BOM (requires run-snyk: true and SNYK_TOKEN; for LLM/RAG/MCP repos)'
+        type: boolean
+        required: false
+        default: false
+
     secrets:
       SNYK_TOKEN:
         description: 'Snyk API token; forwarded to python-snyk.yml when run-snyk is true'
@@ -123,5 +129,6 @@ jobs:
       python-version: ${{ inputs.python-version }}
       source-directory: ${{ inputs.source-directory }}
       fail-on-high: ${{ inputs.fail-on-high }}
+      run-aibom: ${{ inputs.enable-aibom }}
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -134,3 +134,18 @@ jobs:
 
       - name: Check workflows match docs/python-versions.md
         run: scripts/check-python-versions.sh
+
+  test-python-snyk:
+    name: Self-test python-snyk
+    uses: ./.github/workflows/python-snyk.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      source-directory: 'scripts'
+      run-code: true
+      run-oss: false
+      run-aibom: false
+      fail-on-high: false
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -149,3 +149,15 @@ jobs:
       fail-on-high: false
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  test-python-snyk-iac:
+    name: Self-test python-snyk-iac
+    uses: ./.github/workflows/python-snyk-iac.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      terraform-dirs: 'scripts'
+      fail-on-high: false
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,18 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
   `uv.lock` to a requirements file because Snyk SCA does not parse `uv.lock`.
   Callers must grant `contents: read` and `security-events: write`. Documented in
   `docs/workflows/python-snyk.md` and ADR-003.
-- `python-standard-stack.yml`: optional `run-snyk` input (default `false`) and a
-  `SNYK_TOKEN` secret passthrough that wire the Snyk Code/OSS layer into the
-  quickstart composite when enabled; AI-BOM remains reachable only via a direct
-  `python-snyk.yml` caller. Covered by the repo self-test.
+- `python-snyk-iac.yml`: new reusable Snyk IaC scanning workflow. Covers
+  Terraform, Kubernetes manifests, and Docker Compose files with independent
+  SARIF uploads per category (`snyk-iac-terraform`, `snyk-iac-kubernetes`,
+  `snyk-iac-compose`). Token-gated and detect-then-scan: a preflight job probes
+  for IaC file presence before any scan runs, preventing `snyk iac test` exit 2
+  on repos with no supported files. No-ops cleanly when `SNYK_TOKEN` is absent.
+  Callers must grant `contents: read` and `security-events: write`. Documented
+  in `docs/workflows/python-snyk-iac.md` and ADR-003.
+- `python-standard-stack.yml`: optional `run-snyk` input (default `false`),
+  `enable-aibom` input, and a `SNYK_TOKEN` secret passthrough that wire the Snyk
+  Code/OSS/AI-BOM layer into the quickstart composite when enabled. Covered by
+  the repo self-test.
 - `claude-baseline-review.yml`: repo-local Tier 0 PR triage review powered by
   `anthropics/claude-code-action` (SHA-pinned, advisory-only). Classifies each
   non-draft same-repo PR (renovate-deps, pattern-series, docs-only, config-tweak,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ### Added
 
+- `python-snyk.yml`: new reusable Snyk AI-code-security workflow. Runs Snyk Code
+  (SAST) as the primary added value over Bandit, an advisory Snyk Open Source
+  (SCA) cross-check that is default-off and `continue-on-error` (OSV plus Renovate
+  remain the primary SCA gate), and an AI-BOM inventory for LLM/RAG/MCP repos. The
+  workflow is opt-in and token-gated: it no-ops cleanly when `SNYK_TOKEN` is absent.
+  It is uv-only (Poetry repos are rejected), and the OSS job exports the committed
+  `uv.lock` to a requirements file because Snyk SCA does not parse `uv.lock`.
+  Callers must grant `contents: read` and `security-events: write`. Documented in
+  `docs/workflows/python-snyk.md` and ADR-003.
+- `python-standard-stack.yml`: optional `run-snyk` input (default `false`) and a
+  `SNYK_TOKEN` secret passthrough that wire the Snyk Code/OSS layer into the
+  quickstart composite when enabled; AI-BOM remains reachable only via a direct
+  `python-snyk.yml` caller. Covered by the repo self-test.
 - `claude-baseline-review.yml`: repo-local Tier 0 PR triage review powered by
   `anthropics/claude-code-action` (SHA-pinned, advisory-only). Classifies each
   non-draft same-repo PR (renovate-deps, pattern-series, docs-only, config-tweak,

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Calling repos must provide:
 - **[REUSE Compliance](.github/workflows/python-reuse.yml)** (`python-reuse.yml`) - FSFE REUSE 3.0 license and copyright compliance
 - **[SBOM](.github/workflows/python-sbom.yml)** (`python-sbom.yml`) - Software Bill of Materials generation and dependency vulnerability scanning
 - **[Snyk](docs/workflows/python-snyk.md)** (`python-snyk.yml`) - Snyk AI-code-security layer: Code/SAST, advisory OSS cross-check, AI-BOM
+- **[Snyk IaC](docs/workflows/python-snyk-iac.md)** (`python-snyk-iac.yml`) - Snyk IaC scanning: Terraform, Kubernetes, and Docker Compose
 - **[OpenSSF Scorecard](.github/workflows/python-scorecard.yml)** (`python-scorecard.yml`) - Repository security health scoring via OpenSSF Scorecard
 - **[Supplemental Checks](.github/workflows/python-supplemental-checks.yml)** (`python-supplemental-checks.yml`) - Optional PR checks including link validation and changelog enforcement
 - **[Standard Stack](.github/workflows/python-standard-stack.yml)** (`python-standard-stack.yml`) - Bundled standard checks for typical Python repositories

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Calling repos must provide:
 - **[Mutation Testing](.github/workflows/python-mutation.yml)** (`python-mutation.yml`) - Validates test suite effectiveness using mutmut mutation testing
 - **[REUSE Compliance](.github/workflows/python-reuse.yml)** (`python-reuse.yml`) - FSFE REUSE 3.0 license and copyright compliance
 - **[SBOM](.github/workflows/python-sbom.yml)** (`python-sbom.yml`) - Software Bill of Materials generation and dependency vulnerability scanning
+- **[Snyk](docs/workflows/python-snyk.md)** (`python-snyk.yml`) - Snyk AI-code-security layer: Code/SAST, advisory OSS cross-check, AI-BOM
 - **[OpenSSF Scorecard](.github/workflows/python-scorecard.yml)** (`python-scorecard.yml`) - Repository security health scoring via OpenSSF Scorecard
 - **[Supplemental Checks](.github/workflows/python-supplemental-checks.yml)** (`python-supplemental-checks.yml`) - Optional PR checks including link validation and changelog enforcement
 - **[Standard Stack](.github/workflows/python-standard-stack.yml)** (`python-standard-stack.yml`) - Bundled standard checks for typical Python repositories

--- a/docs/architecture/adr-000-index.md
+++ b/docs/architecture/adr-000-index.md
@@ -6,6 +6,7 @@ Index of ADRs for the ByronWilliamsCPA/.github reusable workflow library.
 |-------------------------------------------------|--------------------------------------------------------------------|----------|------------|
 | [ADR-001](adr-001-scorecard-publish-results.md) | Scorecard publish-results deprecated; action param hardcoded false | Accepted | 2026-05-14 |
 | [ADR-002](../planning/adr/adr-002-workflow-security-remediation-delivery.md) | Workflow security remediation delivery strategy | Accepted | 2026-04-30 |
+| [ADR-003](../planning/adr/adr-003-snyk-ai-code-security.md) | Snyk AI code security adoption | Accepted | 2026-06-24 |
 
 ## ADR Format
 

--- a/docs/planning/adr/adr-003-snyk-ai-code-security.md
+++ b/docs/planning/adr/adr-003-snyk-ai-code-security.md
@@ -59,12 +59,20 @@ Snyk Code provides cross-file dataflow SAST, an escalation layer over Bandit. Sn
 Open Source (SCA) is advisory, default-off, and `continue-on-error`: OSV plus
 Renovate remain the primary SCA gate. The OSS job never fails the build.
 
-### D4: AI-BOM is reachable only through a direct caller, not the quickstart composite
+### D4: AI-BOM is reachable via the quickstart composite or a direct caller
 
-AI-BOM is available by calling `python-snyk.yml` directly with `run-aibom: true`.
-It is intentionally NOT wired through the `python-standard-stack` quickstart
-composite, keeping that composite minimal and consistent with how it constrains
-the other layers.
+**Updated 2026-06-27**: the initial restriction (direct caller only) was lifted.
+
+AI-BOM is now available via two paths:
+
+- **Via `python-standard-stack.yml`**: set `enable-aibom: true` alongside
+  `run-snyk: true`. The input defaults to `false`, preserving the opt-in intent.
+- **Via a direct caller**: call `python-snyk.yml` directly with `run-aibom: true`.
+
+The original decision reserved AI-BOM for direct callers to keep the quickstart
+composite minimal. Adding `enable-aibom: false` (default off) achieves the same
+intent without requiring a direct caller for LLM/RAG/MCP repos that use the
+standard stack.
 
 ### D5: One Snyk Organization for both GitHub owners
 
@@ -149,3 +157,18 @@ when any of these become true:
 1. The Free 5-monitored-project cap becomes binding on private repos.
 2. The private SAST test cap (100 per month) becomes binding.
 3. A 1-seat Team checkout is confirmed affordable (see Pricing reality).
+
+---
+
+## Future Decisions
+
+### FD1: Snyk MCP Scan / Agent Scan
+
+Snyk MCP Scan (from the Invariant Labs acquisition) scans MCP server configurations
+for prompt injection and tool poisoning. As of 2026-06, this capability is pre-GA
+(preview). The "AI agent surface" section already targets trial runs against
+zen-mcp-server and homelab-infra MCP configs.
+
+**Condition for implementation**: GA announcement in the Snyk changelog. Until GA,
+do not implement a `python-snyk-mcp.yml` workflow or automate agent-scan in CI;
+the Snyk MCP server inside the coding agent covers interactive use.

--- a/docs/planning/adr/adr-003-snyk-ai-code-security.md
+++ b/docs/planning/adr/adr-003-snyk-ai-code-security.md
@@ -1,0 +1,151 @@
+# ADR-003: Snyk AI Code Security Adoption
+
+**Status:** Accepted
+**Date:** 2026-06-24
+**Deciders:** Byron Williams
+
+---
+
+## TL;DR
+
+Adopt Snyk on the Free plan as a dedicated, opt-in, token-gated `python-snyk.yml`
+reusable workflow. Snyk Code (SAST) is the primary added value over Bandit; Snyk
+Open Source (SCA) stays advisory because OSV plus Renovate remain the primary SCA
+gate; AI-BOM and agent-config scanning are the capabilities that justify adoption
+because nothing else in the stack produces them.
+
+---
+
+## Context
+
+The fleet runs 42 active repos, roughly 30 of them Python, maintained by a solo
+operator. Software composition analysis (dependency scanning) is already covered
+by self-hosted Renovate plus OSV-Scanner through `python-sbom.yml`. Prior internal
+analysis (`dependency-tooling-comparison.md`, `fossa-ci-evaluation.md`) concluded
+that a SaaS scanner was not justified for SCA at this fleet size. That conclusion
+still holds for SCA on its own.
+
+What changed in 2025 and 2026 is that Snyk shipped an AI-code-security layer with
+no equivalent in Renovate, OSV, or Bandit:
+
+- An official MCP server that scans code inside an AI coding agent's tool loop.
+- AI-BOM (`snyk aibom`), a Python-only CycloneDX 1.6 inventory of AI models,
+  agents, tool-calls, and MCP connections; generally available.
+- DeepCode AI / Agent Fix autofix.
+- MCP-scan / Agent Scan (from the Invariant Labs acquisition) for scanning MCP
+  server configs for prompt injection and tool poisoning.
+
+The decision is therefore not about SCA. It is about whether the new AI-security
+layer is worth adopting given the fleet's growing AI agent surface.
+
+---
+
+## Decision
+
+### D1: Adopt Snyk on the Free plan
+
+Free scans public repos with unlimited tests; metered limits apply only to private
+repos. At this fleet's public-repo majority, marginal cost on Free is near zero.
+
+### D2: Deliver as a dedicated, opt-in, token-gated reusable workflow
+
+Snyk ships as `python-snyk.yml`, following the one-tool-one-file convention. It is
+opt-in and token-gated: it no-ops cleanly without `SNYK_TOKEN`, so enrolling a repo
+is a deliberate act and an unconfigured repo is never blocked.
+
+### D3: Snyk Code (SAST) is the primary added value; Snyk Open Source (SCA) is advisory
+
+Snyk Code provides cross-file dataflow SAST, an escalation layer over Bandit. Snyk
+Open Source (SCA) is advisory, default-off, and `continue-on-error`: OSV plus
+Renovate remain the primary SCA gate. The OSS job never fails the build.
+
+### D4: AI-BOM is reachable only through a direct caller, not the quickstart composite
+
+AI-BOM is available by calling `python-snyk.yml` directly with `run-aibom: true`.
+It is intentionally NOT wired through the `python-standard-stack` quickstart
+composite, keeping that composite minimal and consistent with how it constrains
+the other layers.
+
+### D5: One Snyk Organization for both GitHub owners
+
+A CI token reports to its org regardless of repo owner, so one Snyk Organization
+suffices on Free for both the ByronWilliamsCPA and williaby owners.
+
+### D6: Store the token mirroring the existing SONAR_TOKEN pattern
+
+Store `SNYK_TOKEN` as an org-level secret for ByronWilliamsCPA and a repo-level
+secret for williaby personal repos, mirroring the established `SONAR_TOKEN` pattern.
+
+### D7: Roll out public-first
+
+Roll out across the 24 public code repos first (unlimited Free scanning). Private
+repos are PR-triggered only and kept within the Free 5-monitored-project cap.
+
+---
+
+## Pricing reality
+
+The Team plan's listed rate is $25 per contributing developer per month, but the
+exact entry cost is unconfirmed and the published figures disagree.
+
+```text
+#CRITICAL: Snyk Team pricing is inconsistent across sources and affects any
+#  paid-upgrade decision. Secondary sources report a 5-developer minimum (about
+#  $125/month), while the official plans page currently renders "starting at
+#  $750/month".
+#VERIFY: confirm the actual minimum and per-seat terms at checkout before any
+#  Team purchase; do not budget against the secondary-source figure.
+```
+
+---
+
+## AI agent surface
+
+The AI-security capabilities target the fleet's AI agent repos. The specific
+targets below are planned for the live rollout phase and are not yet exercised.
+
+```text
+#ASSUME: these repos are the relevant AI agent surface for AI-BOM and agent-config
+#  scanning at rollout time.
+#VERIFY in live phase: run AI-BOM on rag-processor, PromptCraft, reference-library,
+#  image-generation, and image-preprocessing-detector, confirming aibom.json is
+#  non-empty on each. Trial MCP-scan / Agent Scan (preview) against the
+#  zen-mcp-server fork and the homelab-infra MCP configs.
+```
+
+---
+
+## Consequences
+
+**Positive:**
+
+- SAST coverage stronger than Bandit through cross-file dataflow analysis.
+- An AI supply-chain inventory (AI-BOM) that nothing else in the stack produces.
+- Agent-loop scanning via the Snyk MCP server inside the coding agent.
+- Near-zero marginal cost on Free for the public repos.
+
+**Negative / risks:**
+
+- Snyk SCA cannot parse `uv.lock`. Mitigated: the `snyk-oss` job exports a
+  requirements file from the committed lockfile and runs only in the `uv-locked`
+  state, so it never triggers a live network resolve.
+- The Free plan's 5-monitored-project cap and private test caps bound private-repo
+  coverage.
+- Preview features (MCP-scan, Agent Scan) may change before general availability.
+
+**Relationship to prior decisions:**
+
+- Complements, does not replace, the OSV/Renovate stack.
+- Refines the earlier "not justified" conclusion: that conclusion is still true for
+  SCA on its own; the AI-security layer is what justifies adoption.
+
+---
+
+## Revisit Team when
+
+A decision gate roughly 30 days post-rollout. Revisit upgrading to the Team plan
+when any of these become true:
+
+1. The Free 5-monitored-project cap becomes binding on private repos.
+2. The private SAST test cap (100 per month) becomes binding.
+3. A 1-seat Team checkout is confirmed affordable (see Pricing reality).

--- a/docs/workflows/python-snyk-iac.md
+++ b/docs/workflows/python-snyk-iac.md
@@ -1,0 +1,148 @@
+# python-snyk-iac.yml -- Snyk IaC Scanning Layer
+
+The `python-snyk-iac.yml` reusable workflow adds a Snyk Infrastructure-as-Code
+scanning layer to a repository. It covers Terraform, Kubernetes manifests, and
+Docker Compose files, uploading SARIF results to the Security tab for each
+category independently. The workflow is opt-in and token-gated: when `SNYK_TOKEN`
+is absent, all scan jobs no-op cleanly.
+
+## What it runs
+
+- `detect-iac` - checks for `SNYK_TOKEN` via env var and probes configured
+  directories for .tf files, Kubernetes YAML, and Docker Compose files
+- `snyk-terraform` - runs `snyk iac test` on `terraform-dirs`; uploads
+  `iac-terraform.sarif` with category `snyk-iac-terraform`
+- `snyk-kubernetes` - runs `snyk iac test` on `k8s-dirs`; uploads
+  `iac-k8s.sarif` with category `snyk-iac-kubernetes`
+- `snyk-compose` - runs `snyk iac test` on `compose-dirs`; uploads
+  `iac-compose.sarif` with category `snyk-iac-compose`
+- `snyk-iac-gate` - aggregates results with `if: always()`; treats `success`
+  or `skipped` as passing; fails only when a scan job returned `failure`
+
+## Minimal usage
+
+```yaml
+jobs:
+  snyk-iac:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-snyk-iac.yml@v1
+    permissions:
+      contents: read
+      security-events: write   # required for SARIF upload
+    with:
+      terraform-dirs: 'infra'
+      fail-on-high: true
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `terraform-dirs` | string | no | `.` | Space-separated directories to scan for Terraform (.tf) files; default scans repo root |
+| `k8s-dirs` | string | no | `''` | Space-separated directories to scan for Kubernetes manifests; empty string skips this scanner |
+| `compose-dirs` | string | no | `''` | Space-separated directories to scan for Docker Compose files; empty string skips this scanner |
+| `fail-on-high` | boolean | no | `true` | Fail the build on HIGH/CRITICAL Snyk IaC findings |
+
+## Secrets
+
+| Secret | Required | Purpose |
+|--------|----------|---------|
+| `SNYK_TOKEN` | no | Snyk API token. When absent, all scan jobs no-op. |
+
+## Caller permissions required
+
+The caller must grant the following at the workflow or calling-job level:
+
+- `contents: read`
+- `security-events: write`
+
+Omitting `security-events: write` causes a startup failure (`startup_failure` /
+generic "workflow file issue") before any job runs, because a called workflow's
+token is bounded by the caller's permissions.
+
+## IaC detection behavior
+
+The `detect-iac` job runs first and probes for IaC file presence before any
+scan job starts. This is necessary because `snyk iac test` exits with code 2
+(hard error) when passed a directory containing no supported files, which would
+fail the build even when IaC scanning is legitimately not applicable.
+
+Detection logic:
+
+- For Terraform: searches up to 5 directory levels deep for any `*.tf` file in
+  `terraform-dirs`
+- For Kubernetes: searches for `*.yaml` or `*.yml` files in `k8s-dirs`
+- For Compose: searches for `docker-compose*.yml` or `docker-compose*.yaml`
+  in `compose-dirs`
+
+A scan job only runs when its input directory is non-empty, `SNYK_TOKEN` is
+present, AND the corresponding file type was detected.
+
+The gate treats `skipped` as passing, so a repo with no Terraform files passes
+the gate cleanly without operator intervention.
+
+## Operator setup
+
+1. **Create the Snyk account, org, and token.** Create a Snyk account, create
+   one Snyk Organization (a CI token reports to its org regardless of repo
+   owner, so one org covers both GitHub owners on Free), and generate a service
+   token.
+
+2. **Set the secret.** Mirror the existing `SONAR_TOKEN` pattern: an org-level
+   secret for ByronWilliamsCPA and a repo-level secret for williaby personal
+   repos.
+
+   ```bash
+   # ByronWilliamsCPA org repos (visibility: all)
+   gh secret set SNYK_TOKEN --org ByronWilliamsCPA --visibility all
+
+   # williaby personal repos
+   ./scripts/sync-secrets.sh
+   ```
+
+3. **Identify IaC directories.** Map the directories that contain Terraform,
+   Kubernetes, or Docker Compose files. Pass each set as a space-separated
+   string to the corresponding input. If a scanner type is not present in the
+   repo, omit the input (the empty default skips it automatically).
+
+## Example: homelab-infra (Terraform)
+
+homelab-infra contains Terraform in `infra/`, Kubernetes manifests in `k8s/`,
+and Docker Compose files in the repo root:
+
+```yaml
+jobs:
+  snyk-iac:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-snyk-iac.yml@v1
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      terraform-dirs: 'infra'
+      k8s-dirs: 'k8s'
+      compose-dirs: '.'
+      fail-on-high: true
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+```
+
+## Notes
+
+- This workflow is independent of `python-standard-stack.yml`. Call it as a
+  separate job alongside the standard stack; do not try to absorb it into the
+  stack (most Python repos have no IaC files).
+- Directory paths must not contain spaces (org policy; the workflow uses IFS
+  word-splitting on space-separated inputs).
+- Multi-directory input example: `terraform-dirs: 'infra modules'` scans both
+  `infra/` and `modules/` in one job.
+- The self-test in `.github/workflows/self-test.yml` points `terraform-dirs`
+  at `scripts/` (which has no .tf files); this exercises the no-op detection
+  path on every PR.
+- SARIF results appear in the repository's Security tab under Code Scanning.
+  Each scanner uploads with its own category (`snyk-iac-terraform`,
+  `snyk-iac-kubernetes`, `snyk-iac-compose`), so they do not overwrite each
+  other.
+
+See [ADR-003](../planning/adr/adr-003-snyk-ai-code-security.md) for the IaC
+scanning decision.

--- a/docs/workflows/python-snyk-iac.md
+++ b/docs/workflows/python-snyk-iac.md
@@ -74,9 +74,9 @@ Detection logic:
   `terraform-dirs`
 - For Kubernetes: searches up to 5 directory levels deep for `*.yaml` or `*.yml`
   files in `k8s-dirs`
-- For Compose: searches up to 5 directory levels deep for `docker-compose*.yml`
-  files in `compose-dirs` (`.yaml` extension is not matched; name compose files
-  with `.yml` to ensure detection)
+- For Compose: searches up to 5 directory levels deep for all canonical Docker
+  Compose v2 filenames (`compose.yaml`, `compose.yml`, `docker-compose*.yaml`,
+  `docker-compose*.yml`) in `compose-dirs`
 
 A scan job only runs when its input directory is non-empty, `SNYK_TOKEN` is
 present, AND the corresponding file type was detected.

--- a/docs/workflows/python-snyk-iac.md
+++ b/docs/workflows/python-snyk-iac.md
@@ -72,9 +72,11 @@ Detection logic:
 
 - For Terraform: searches up to 5 directory levels deep for any `*.tf` file in
   `terraform-dirs`
-- For Kubernetes: searches for `*.yaml` or `*.yml` files in `k8s-dirs`
-- For Compose: searches for `docker-compose*.yml` or `docker-compose*.yaml`
-  in `compose-dirs`
+- For Kubernetes: searches up to 5 directory levels deep for `*.yaml` or `*.yml`
+  files in `k8s-dirs`
+- For Compose: searches up to 5 directory levels deep for `docker-compose*.yml`
+  files in `compose-dirs` (`.yaml` extension is not matched; name compose files
+  with `.yml` to ensure detection)
 
 A scan job only runs when its input directory is non-empty, `SNYK_TOKEN` is
 present, AND the corresponding file type was detected.

--- a/docs/workflows/python-snyk.md
+++ b/docs/workflows/python-snyk.md
@@ -87,15 +87,16 @@ token is bounded by the caller's permissions.
    snyk auth
    ```
 
-4. **AI-BOM usage.** Generate an AI-BOM locally, or wire it into CI through a direct
-   caller.
+4. **AI-BOM usage.** Generate an AI-BOM locally, or wire it into CI.
 
    ```bash
    # Local
    snyk aibom --json > aibom.json
    ```
 
-   In CI, set `run-aibom: true` in a direct caller of `python-snyk.yml`.
+   In CI, enable it via `enable-aibom: true` in `python-standard-stack.yml`
+   (requires `run-snyk: true` and `SNYK_TOKEN`), or by setting `run-aibom: true`
+   in a direct caller of `python-snyk.yml`.
 
 ## Notes
 
@@ -117,8 +118,8 @@ token is bounded by the caller's permissions.
 SARIF results appear in the repository's Security tab under Code Scanning. Each
 finding includes:
 
-- **Severity**: CRITICAL, HIGH, MEDIUM, or LOW, based on Snyk's CVSS scoring
-- **Rule**: the Snyk Code rule that fired (e.g., `javascript/SQLInjection`)
+- **Severity**: CRITICAL, HIGH, MEDIUM, or LOW, based on Snyk Code's severity rating
+- **Rule**: the Snyk Code rule that fired (e.g., `python/SqlInjection`)
 - **Data flow**: for cross-file findings, a path from source to sink
 
 ### Snyk Open Source (SCA)

--- a/docs/workflows/python-snyk.md
+++ b/docs/workflows/python-snyk.md
@@ -1,0 +1,113 @@
+# python-snyk.yml -- Snyk AI Code Security Layer
+
+The `python-snyk.yml` reusable workflow adds a Snyk AI-code-security layer to a
+Python repository: Snyk Code (SAST), an advisory Snyk Open Source (SCA) cross-check,
+and an AI-BOM inventory. It complements the existing OSV plus Renovate SCA stack; it
+does not replace it. The workflow is opt-in and token-gated, and it no-ops cleanly
+when `SNYK_TOKEN` is absent.
+
+## What it runs
+
+- `detect-config` - checks for `SNYK_TOKEN` and detects repo state (uv-locked, uv-no-lock, poetry-not-supported, or skip)
+- `snyk-code` - Snyk Code (SAST); cross-file dataflow analysis, uploads SARIF to the Security tab
+- `snyk-oss` - Snyk Open Source (SCA cross-check); advisory and `continue-on-error`, never fails the build
+- `snyk-aibom` - generates a CycloneDX AI-BOM and uploads it as a build artifact
+- `snyk-gate` - aggregates results; gates on Snyk Code only (OSS is advisory and excluded from the decision)
+
+## Minimal usage
+
+```yaml
+jobs:
+  snyk:
+    uses: ByronWilliamsCPA/.github/.github/workflows/python-snyk.yml@v1
+    permissions:
+      contents: read
+      security-events: write   # SARIF upload to the Security tab
+    with:
+      source-directory: 'src'
+      run-code: true           # Snyk Code (SAST)
+      run-oss: false           # SCA cross-check (OSV/Renovate are primary)
+      run-aibom: false         # AI-BOM (set true for LLM/RAG/MCP repos)
+      fail-on-high: true
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `source-directory` | string | no | `src` | Source code directory to scan |
+| `python-version` | string | no | `3.12` | Python version for dependency resolution |
+| `run-code` | boolean | no | `true` | Run Snyk Code (SAST) |
+| `run-oss` | boolean | no | `false` | Run Snyk Open Source (SCA cross-check); advisory, OSV/Renovate are primary |
+| `run-aibom` | boolean | no | `false` | Generate an AI-BOM (Python only; for LLM/RAG/MCP repos) |
+| `fail-on-high` | boolean | no | `true` | Fail the build on HIGH/CRITICAL Snyk Code findings |
+| `no-build` | boolean | no | `true` | Pass `--no-build` to `uv sync` (disable for projects with a build backend) |
+
+## Secrets
+
+| Secret | Required | Purpose |
+|--------|----------|---------|
+| `SNYK_TOKEN` | no | Snyk API token. When absent, all scan jobs no-op. |
+
+## Caller permissions required
+
+The caller must grant the following at the workflow or calling-job level:
+
+- `contents: read`
+- `security-events: write`
+
+Omitting `security-events: write` causes a startup failure (`startup_failure` /
+generic "workflow file issue") before any job runs, because a called workflow's
+token is bounded by the caller's permissions.
+
+## Operator setup
+
+1. **Create the Snyk account, org, and token.** Create a Snyk account, create one
+   Snyk Organization (a CI token reports to its org regardless of repo owner, so one
+   org covers both GitHub owners on Free), and generate a service token.
+
+2. **Set the secret.** Mirror the existing `SONAR_TOKEN` pattern: an org-level secret
+   for ByronWilliamsCPA and a repo-level secret for williaby personal repos.
+
+   ```bash
+   # ByronWilliamsCPA org repos (visibility: all)
+   gh secret set SNYK_TOKEN --org ByronWilliamsCPA --visibility all
+
+   # williaby personal repos
+   ./scripts/sync-secrets.sh
+   ```
+
+3. **Configure the Snyk MCP server in Claude Code.** This enables agent-loop scanning
+   inside the coding agent.
+
+   ```bash
+   npx -y snyk@latest mcp configure --tool=claude-cli
+   snyk auth
+   ```
+
+4. **AI-BOM usage.** Generate an AI-BOM locally, or wire it into CI through a direct
+   caller.
+
+   ```bash
+   # Local
+   snyk aibom --json > aibom.json
+   ```
+
+   In CI, set `run-aibom: true` in a direct caller of `python-snyk.yml`.
+
+## Notes
+
+- **uv-only.** This workflow is uv-only by org policy. Poetry repos are rejected with
+  an actionable error.
+- **Snyk SCA does not parse `uv.lock`.** The OSS job exports the committed lockfile to
+  a requirements file Snyk understands, and runs only in the `uv-locked` state so it
+  never triggers a live network resolve.
+- **OSS is advisory and default-off.** OSV plus Renovate remain the primary SCA gate;
+  the OSS job is `continue-on-error` and is excluded from the gate decision.
+- **AI-BOM is reachable via a direct caller only.** It is intentionally not wired
+  through `python-standard-stack.yml`, to keep that quickstart composite minimal.
+
+See [ADR-003](../planning/adr/adr-003-snyk-ai-code-security.md) for the adoption
+rationale.

--- a/docs/workflows/python-snyk.md
+++ b/docs/workflows/python-snyk.md
@@ -106,8 +106,39 @@ token is bounded by the caller's permissions.
   never triggers a live network resolve.
 - **OSS is advisory and default-off.** OSV plus Renovate remain the primary SCA gate;
   the OSS job is `continue-on-error` and is excluded from the gate decision.
-- **AI-BOM is reachable via a direct caller only.** It is intentionally not wired
-  through `python-standard-stack.yml`, to keep that quickstart composite minimal.
+- **AI-BOM** is enabled via `enable-aibom: true` in `python-standard-stack.yml`
+  (requires `run-snyk: true` and `SNYK_TOKEN`), or by setting `run-aibom: true`
+  in a direct caller of this workflow.
+
+## Reading Results
+
+### Snyk Code (SAST)
+
+SARIF results appear in the repository's Security tab under Code Scanning. Each
+finding includes:
+
+- **Severity**: CRITICAL, HIGH, MEDIUM, or LOW, based on Snyk's CVSS scoring
+- **Rule**: the Snyk Code rule that fired (e.g., `javascript/SQLInjection`)
+- **Data flow**: for cross-file findings, a path from source to sink
+
+### Snyk Open Source (SCA)
+
+When `run-oss: true`, `snyk test --json` output includes exploit maturity fields
+on any paid Snyk plan:
+
+- `isExploitable` (boolean): `true` when a public PoC or in-the-wild exploit exists
+- `exploitMaturity`: one of `No Known Exploit`, `Proof of Concept`, `Functional`,
+  or `Mature`
+
+These fields are the primary reason to run the OSS job even when Renovate is the
+fix-PR source: Snyk surfaces vulnerabilities in the pre-NVD window (days to weeks
+before CVE assignment) and labels them as exploitable before NVD data is available.
+Renovate's advisories trail NVD by design, so a Snyk OSS finding with
+`exploitMaturity: Functional` and no CVE yet is a genuine early-warning signal worth
+acting on rather than waiting for a Renovate fix-PR.
+
+Results appear in the Snyk dashboard (app.snyk.io) under the connected project, not
+in the GitHub Security tab (OSS findings are not uploaded as SARIF).
 
 See [ADR-003](../planning/adr/adr-003-snyk-ai-code-security.md) for the adoption
 rationale.

--- a/docs/workflows/python-standard-stack.md
+++ b/docs/workflows/python-standard-stack.md
@@ -11,6 +11,7 @@ into a single workflow call.
 - pytest with coverage measurement
 - Bandit security scan
 - pip-audit dependency vulnerability scan
+- Optional: Snyk AI-code-security layer (when `run-snyk: true`)
 
 ## Minimal usage
 
@@ -41,6 +42,11 @@ jobs:
 | `source-directory` | string | no | `src` | Source code directory |
 | `coverage-threshold` | number | no | `80` | Minimum line coverage percentage |
 | `fail-on-high` | boolean | no | `true` | Fail on HIGH or CRITICAL security findings |
+| `run-snyk` | boolean | no | `false` | Run the Snyk AI-code-security layer; requires SNYK_TOKEN |
+
+When `run-snyk: true`, pass `SNYK_TOKEN` (via `secrets: inherit` or an explicit
+`secrets:` block) and ensure the caller grants `security-events: write`. The Snyk
+layer is documented in [python-snyk.md](python-snyk.md).
 
 ## Extending the stack
 

--- a/docs/workflows/python-standard-stack.md
+++ b/docs/workflows/python-standard-stack.md
@@ -43,10 +43,13 @@ jobs:
 | `coverage-threshold` | number | no | `80` | Minimum line coverage percentage |
 | `fail-on-high` | boolean | no | `true` | Fail on HIGH or CRITICAL security findings |
 | `run-snyk` | boolean | no | `false` | Run the Snyk AI-code-security layer; requires SNYK_TOKEN |
+| `enable-aibom` | boolean | no | `false` | Generate an AI-BOM (requires `run-snyk: true` and SNYK_TOKEN; for LLM/RAG/MCP repos) |
 
 When `run-snyk: true`, pass `SNYK_TOKEN` (via `secrets: inherit` or an explicit
 `secrets:` block) and ensure the caller grants `security-events: write`. The Snyk
-layer is documented in [python-snyk.md](python-snyk.md).
+layer is documented in [python-snyk.md](python-snyk.md). Set `enable-aibom: true`
+alongside `run-snyk: true` to generate a CycloneDX AI-BOM for repos that host LLM
+integrations, RAG pipelines, or MCP servers.
 
 ## Extending the stack
 
@@ -55,5 +58,6 @@ After `python-standard-stack.yml` passes, chain additional workflows for:
 - Coverage upload: `python-codecov.yml`
 - SBOM generation: `python-sbom.yml`
 - Release: `python-release.yml`
+- IaC scanning (Terraform/Kubernetes/Compose): `python-snyk-iac.yml` (see [python-snyk-iac.md](python-snyk-iac.md))
 
 See [docs/workflows/](.) for individual workflow documentation.


### PR DESCRIPTION
## Summary

Delivers the full Snyk reusable workflow layer for the ByronWilliamsCPA fleet,
covering code security (SAST), infrastructure scanning (IaC), and AI inventory
(AI-BOM). All workflows are opt-in and token-gated: they no-op cleanly when
\`SNYK_TOKEN\` is absent.

**New workflows:**
- \`python-snyk.yml\` - Snyk Code (SAST), optional SCA cross-check, optional AI-BOM; token-gated, uv-only
- \`python-snyk-iac.yml\` - Snyk IaC scanning for Terraform, Kubernetes manifests, and Docker Compose; detect-then-scan pattern prevents \`snyk iac test\` exit-2 on repos with no IaC files; SARIF upload per category

**Updated workflows:**
- \`python-standard-stack.yml\` - added \`run-snyk: false\` and \`enable-aibom: false\` inputs; both default off; \`enable-aibom\` maps to \`run-aibom\` in the callee (rename is documented with RAD marker)
- \`self-test.yml\` - two new self-test jobs: \`test-python-snyk\` (scripts dir, no token) and \`test-python-snyk-iac\` (scripts dir, no .tf files); both exercise the no-op detection path

**New docs:**
- \`docs/workflows/python-snyk.md\` - operator guide including Reading Results section (SARIF fields, exploit maturity, pre-NVD window rationale)
- \`docs/workflows/python-snyk-iac.md\` - operator guide with IaC detection behavior explanation, homelab-infra example, and all canonical Compose filename variants
- \`docs/planning/adr/adr-003-snyk-ai-code-security.md\` - new ADR recording the Snyk AI-code-security adoption decision, IaC scope extension (D4), and MCP Scan pre-GA stub (FD1)

**Updated docs:**
- \`docs/workflows/python-standard-stack.md\` - \`enable-aibom\` input row, IaC workflow in "Extending the stack"
- \`docs/architecture/adr-000-index.md\` - adds ADR-003 row to the index

## Test plan

- [ ] Verify \`test-python-snyk-iac\` CI job on this PR: \`detect-iac\` should log "No .tf files found; Terraform scan skipped" and \`snyk-iac-gate\` should pass
- [ ] Confirm \`test-python-snyk\` CI job no-ops cleanly (no \`SNYK_TOKEN\` in self-test context)
- [ ] After merging: wire \`terraform-dirs: 'infra'\` in homelab-infra CI and confirm Terraform findings appear in the Security tab
- [ ] After merging: set \`enable-aibom: true, run-snyk: true\` in an LLM repo calling \`python-standard-stack.yml\`; confirm \`snyk-aibom\` artifact uploads
- [ ] Confirm \`security-events: write\` is granted at calling-job level in any new caller (startup_failure if omitted; see \`#CRITICAL\` in \`python-snyk-iac.yml\` header)

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional, reusable Snyk scanning workflows for Python code and infrastructure-as-code.
  * Expanded the standard Python stack to optionally include Snyk checks and AI-BOM generation.
  * Added self-test coverage for the new reusable workflows.

* **Documentation**
  * Updated the README and workflow docs with setup, inputs, permissions, and usage examples.
  * Added a new architecture decision record and updated the ADR index.

* **Chores**
  * Recorded the new workflow capabilities in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->