### PR TITLE
fix(ci): make baseline review submodule init best-effort

### DIFF
--- a/.github/workflows/claude-baseline-review.yml
+++ b/.github/workflows/claude-baseline-review.yml
@@ -120,12 +120,22 @@ jobs:
           # the gh CLI, not local git history.
           fetch-depth: 1
           persist-credentials: false
-          # #CRITICAL: caller repos symlink files under .claude/ (e.g.
-          # .claude/commands/review-pr.md) into .submodules/. Without submodule
-          # checkout those symlinks dangle and claude-code-action aborts with
-          # `ENOENT ... statx '.claude/commands/review-pr.md'`. Recursive
-          # checkout resolves them. Submodules are public, so no extra token.
-          submodules: recursive
+
+      - name: Initialize submodules (best-effort)
+        # #CRITICAL: caller repos symlink files under .claude/ (e.g.
+        # .claude/commands/review-pr.md) into .submodules/. Without submodule
+        # checkout those symlinks dangle and claude-code-action aborts with
+        # `ENOENT ... statx '.claude/commands/review-pr.md'`. Submodule init
+        # resolves them. Submodules are public, so no extra token.
+        # #CRITICAL: this is a best-effort step, NOT `submodules: recursive` on
+        # actions/checkout. Third-party submodules (e.g. obra/superpowers)
+        # rebase and force-push, so a pinned commit can vanish upstream; with
+        # recursive checkout `git` then exits 128 and fails the ENTIRE job for
+        # every PR, fleet-wide. continue-on-error degrades gracefully: a stale
+        # upstream pin leaves one symlink dangling instead of blocking all
+        # reviews. The owning repo should still re-pin the stale submodule.
+        continue-on-error: true
+        run: git submodule update --init --recursive
 
       - name: Run baseline triage review
         uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb  # v1.0.153

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ the latest reviewed commit on `main` and is re-pointed as changes land.
 
 ### Fixed
 
+- `claude-baseline-review.yml`: initialize submodules as a best-effort step
+  (`git submodule update --init --recursive` with `continue-on-error: true`)
+  instead of `submodules: recursive` on `actions/checkout`. Third-party
+  submodules (e.g. `obra/superpowers`) rebase and force-push, so a pinned commit
+  can vanish upstream; recursive checkout then fails with `git` exit 128 and
+  blocks the entire review job on every PR, fleet-wide. The best-effort step
+  degrades gracefully so a stale upstream pin in one consumer leaves a symlink
+  dangling rather than breaking all reviews.
 - `sbom-nightly.yml`: grant `contents: read` and `security-events: write` on the
   calling job. The caller previously set `permissions: {}`, which is below the
   ceiling the reusable `python-sbom.yml` SARIF-upload jobs require, so every


### PR DESCRIPTION
## Summary

The Tier 0 baseline reviewer checks out caller repos with `submodules: recursive` because some callers (notably `.claude`) symlink files under `.claude/` into `.submodules/`. But third-party submodules (e.g. `obra/superpowers`) rebase and force-push, so a pinned commit can vanish upstream. When that happens, `actions/checkout`'s recursive submodule update fails with `git` **exit code 128** and **fails the entire review job on every PR**, fleet-wide.

This is not hypothetical: `.claude`'s `superpowers` submodule is pinned to `32eee92`, which `obra/superpowers` no longer has (`422 No commit found`). Every `.claude` review since the rollout started has failed at the checkout step for this reason.

## Fix

Move submodule init out of `actions/checkout` into a dedicated **best-effort** step:

```yaml
- name: Initialize submodules (best-effort)
  continue-on-error: true
  run: git submodule update --init --recursive
```

A stale upstream pin in one consumer now leaves a single symlink dangling instead of blocking all reviews. Submodules that resolve still check out, so the symlink-resolution need is met in the normal case. Consumers should still re-pin their stale submodules (a companion `.claude` PR bumps `superpowers`).

## Verification

This PR edits the reusable workflow, so the action's tamper guard will skip the actual review on this PR; the fix is validated by the companion `.claude` submodule-bump PR's run reaching a passing review.