### PR TITLE
docs(planning): add Snyk CI/CD and developer experience handoff docs

### DIFF
--- a/docs/planning/handoff-snyk-cicd.md
+++ b/docs/planning/handoff-snyk-cicd.md
@@ -5,6 +5,14 @@
 **Next branch:** claude/snyk-iac-aibom-1
 **Session date:** 2026-06-25
 
+> **STATUS: IMPLEMENTED (as of PR #224)**
+> Items 1-3 below were fully delivered by PR #224 (merged 2026-06-09):
+> `python-snyk-iac.yml`, `enable-aibom` input on `python-standard-stack.yml`,
+> exploit maturity docs, and the IaC self-test job are all on `main`.
+> The base branch `claude/snyk-integration-0` was deleted after squash-merge.
+> The only open item is **item 4 (MCP Scan stub)**, which intentionally awaits GA.
+> This document is preserved as a historical record and reference for that TODO.
+
 ---
 
 ## Context
@@ -26,8 +34,10 @@ Files on that branch:
 - `docs/workflows/python-snyk.md` -- operator guide
 
 The evaluation compared Snyk against Cycode, Checkmarx One, and Endor Labs.
-Snyk was selected. The full comparison JSON is in the scratchpad at:
-`/tmp/claude-1000/-home-byron-dev--github/b617e56f-1680-44d7-83bc-ff79cc722db5/scratchpad/security-tool-comparison.json`
+Snyk was selected on: breadth of coverage (SAST + SCA + IaC + secrets), GitHub
+Actions native integration, MCP Server availability (Invariant Labs acquisition),
+and a free tier that covers the org's use pattern. Cycode and Checkmarx One both
+require enterprise sales contacts; Endor Labs lacks an MCP integration.
 
 ---
 

--- a/docs/planning/handoff-snyk-cicd.md
+++ b/docs/planning/handoff-snyk-cicd.md
@@ -1,0 +1,139 @@
+# Handoff: Snyk CI/CD Extension
+
+**Repo:** ByronWilliamsCPA/.github (working dir: ~/dev/.github)
+**Base branch:** claude/snyk-integration-0
+**Next branch:** claude/snyk-iac-aibom-1
+**Session date:** 2026-06-25
+
+---
+
+## Context
+
+The `claude/snyk-integration-0` branch (not yet merged) added the initial Snyk
+reusable workflow layer. Before starting this work, read that branch:
+
+```bash
+git checkout claude/snyk-integration-0
+```
+
+Files on that branch:
+- `.github/workflows/python-snyk.yml` -- reusable workflow: Snyk Code (SAST),
+  optional OSS advisory, optional AI-BOM
+- `.github/workflows/python-standard-stack.yml` -- added `run-snyk: false`
+  input, forwarded `SNYK_TOKEN` secret
+- `.github/workflows/self-test.yml` -- added `test-python-snyk` job
+- `docs/planning/adr/adr-003-snyk-ai-code-security.md` -- decision record
+- `docs/workflows/python-snyk.md` -- operator guide
+
+The evaluation compared Snyk against Cycode, Checkmarx One, and Endor Labs.
+Snyk was selected. The full comparison JSON is in the scratchpad at:
+`/tmp/claude-1000/-home-byron-dev--github/b617e56f-1680-44d7-83bc-ff79cc722db5/scratchpad/security-tool-comparison.json`
+
+---
+
+## What is NOT yet implemented (this session's scope)
+
+### 1. IaC scanning workflow (HIGH priority, HIGH value)
+
+The baseline stack has no IaC scanner. Snyk IaC fills three gaps simultaneously:
+Terraform, Kubernetes manifests, and Docker Compose. All are rated HIGH in the
+comparison because the baseline is completely absent.
+
+**Create** `.github/workflows/python-snyk-iac.yml` as a new reusable workflow.
+Model it on `python-snyk.yml`'s structure (token-gated no-op, detect-config job
+pattern). Jobs needed:
+
+- `detect-iac`: check SNYK_TOKEN via env var (not `secrets.SNYK_TOKEN` in an
+  `if:` expression -- that is the secrets-in-if antipattern documented in
+  memory). Check whether any .tf / k8s YAML / docker-compose*.yml files exist
+  under the configured directories.
+- `snyk-terraform`: `snyk iac test <terraform-dirs> --sarif-file-output=iac-terraform.sarif`
+- `snyk-kubernetes`: `snyk iac test <k8s-dirs> --sarif-file-output=iac-k8s.sarif`
+- `snyk-compose`: `snyk iac test <compose-dirs> --sarif-file-output=iac-compose.sarif`
+
+Each job should upload its SARIF via `github/codeql-action/upload-sarif@v3`.
+
+Inputs needed:
+- `terraform-dirs` (string, default: `.`) -- space-separated dirs to scan
+- `k8s-dirs` (string, default: ``) -- empty string = skip k8s job
+- `compose-dirs` (string, default: ``) -- empty string = skip compose job
+- `fail-on-high` (bool, default: true)
+
+Token input: `SNYK_TOKEN` (required: false; skip all jobs if absent).
+
+**Tag RAD markers** on: permission scopes for SARIF upload
+(`security-events: write` must be at caller-job level), SNYK_TOKEN absent
+behavior, directory glob edge cases.
+
+**Create** `docs/workflows/python-snyk-iac.md` following the same structure
+as `docs/workflows/python-snyk.md`. Include an example caller block for
+homelab-infra (the primary Terraform target).
+
+**Update** `docs/workflows/python-standard-stack.md` to reference the new
+IaC workflow as a separate opt-in call (it cannot be absorbed into
+`python-standard-stack.yml` because most Python repos have no IaC files).
+
+**Add a self-test job** to `.github/workflows/self-test.yml` scanning the
+`scripts/` directory with `fail-on-high: false`.
+
+### 2. AI-BOM shortcut in python-standard-stack (MEDIUM priority)
+
+Current state: `python-snyk.yml` has `run-aibom: false` as an input, but
+`python-standard-stack.yml` does not expose this input. To enable AI-BOM via
+the standard stack, callers today must call `python-snyk.yml` directly.
+
+**Add** `enable-aibom: false` input to `python-standard-stack.yml`. Forward it
+to the `snyk` job's `run-aibom` input. This is a one-line addition to the snyk
+job's `with:` block. No new workflow file needed.
+
+**Update** `docs/workflows/python-standard-stack.md` to document the new input.
+
+**ADR-003 update**: The current ADR notes that AI-BOM requires a direct caller.
+Add a "Status" note that this restriction was lifted by adding `enable-aibom`
+to `python-standard-stack.yml`.
+
+### 3. Exploit maturity / pre-NVD notes (LOW priority, documentation only)
+
+Snyk's exploit maturity fields (isExploitable, exploitMaturity) are surfaced in
+`snyk test --json` output automatically on any paid plan. The `python-snyk.yml`
+OSS advisory job already runs `snyk test`; no workflow change is needed.
+
+Document in `docs/workflows/python-snyk.md` (under a "Reading Results" section)
+that the Snyk dashboard exposes exploit maturity and that the pre-NVD window
+is the primary reason to run `snyk-oss` even when Renovate is the fix-PR source.
+
+### 4. MCP Scan (DO NOT IMPLEMENT YET)
+
+Snyk MCP Scan (from the Invariant Labs acquisition) is pre-GA as of 2026-06.
+Add a stub section in ADR-003 under "Future Decisions" noting this capability
+and the condition for implementation: GA announcement in the Snyk changelog.
+
+---
+
+## Implementation order
+
+1. Create branch: `git checkout -b claude/snyk-iac-aibom-1 claude/snyk-integration-0`
+2. Write `python-snyk-iac.yml`
+3. Add self-test job for IaC
+4. Add `enable-aibom` to `python-standard-stack.yml`
+5. Write `docs/workflows/python-snyk-iac.md`
+6. Update `docs/workflows/python-snyk.md` (Reading Results section)
+7. Update ADR-003 (remove direct-caller restriction, add MCP Scan stub)
+8. Run `pre-commit run --all-files`
+9. Commit with signed commit, conventional commit format
+
+---
+
+## Key constraints
+
+- **Secrets-in-if antipattern**: Never write `if: ${{ secrets.SNYK_TOKEN == '' }}`.
+  Use `env: HAS_TOKEN: ${{ secrets.SNYK_TOKEN != '' }}` then `if: env.HAS_TOKEN == 'true'`
+  in the step, or the detect-config pattern from `python-snyk.yml`.
+- **startup_failure**: Callers must grant `security-events: write` at the calling-job
+  level (not workflow level) or the reusable starts with `startup_failure` before any
+  job runs. See ADR-003 #CRITICAL note and memory entry "Reusable startup_failure causes".
+- **No em-dashes** in any file content (pre-commit hook will block the commit).
+- **uv-only org policy**: The IaC workflow needs no Python dependency resolution;
+  this constraint does not apply to `python-snyk-iac.yml`.
+- **Branch naming**: `claude/<description>-<id>` format.
+- **Signed commits**: `git commit -S` on every commit.

--- a/docs/planning/handoff-snyk-developer.md
+++ b/docs/planning/handoff-snyk-developer.md
@@ -4,6 +4,13 @@
 **Branch:** claude/snyk-developer-experience-0 (new branch, off main)
 **Session date:** 2026-06-25
 
+> **SCOPE NOTE:** All work items below target the `~/.claude/` global config
+> repository (symlinked from `~/dev/.github`), NOT the ByronWilliamsCPA/.github
+> org repo. Files created or edited are under `~/.claude/rules/`,
+> `~/.claude/standards/`, and `~/.claude/settings.json`. This PR lives in the
+> `.github` repo only because `~/.claude/` is symlinked there; the actual
+> changes will land in that global config repo's working tree.
+
 ---
 
 ## Context
@@ -24,8 +31,11 @@ The capabilities being wired in:
 - **MCP Scan** (`ai-mcp-scan`): rated HIGH but pre-GA as of 2026-06. Document
   the gap; implement the hook stub when GA.
 
-Reference evaluation data:
-`/tmp/claude-1000/-home-byron-dev--github/b617e56f-1680-44d7-83bc-ff79cc722db5/scratchpad/security-tool-comparison.json`
+Evaluation summary: Snyk was selected over Cycode, Checkmarx One, and Endor Labs
+based on breadth of coverage (SAST + SCA + IaC + secrets), GitHub Actions native
+integration, MCP Server availability (Invariant Labs acquisition), and a free tier
+matching the org's use pattern. See `handoff-snyk-cicd.md` for full selection
+rationale.
 
 ---
 
@@ -56,7 +66,9 @@ Content to cover:
 **One-time setup (per workstation):**
 ```bash
 # Install Snyk CLI globally
-npm install -g snyk          # or: brew install snyk
+npm install -g snyk          # pin to a specific version; e.g. snyk@1.1293.1
+                             # check latest: https://github.com/snyk/cli/releases
+                             # or: brew install snyk (brew manages versions separately)
 
 # Authenticate (browser opens; use GitHub SSO or personal token)
 snyk auth
@@ -164,6 +176,10 @@ hook configuration to avoid duplicates).
 **Add** a `PostToolUse` hook that fires when Write or Edit modifies
 `pyproject.toml` or `requirements*.txt`:
 
+<!-- #ASSUME: `"condition": "match_files(...)"` is valid PostToolUse hook schema. -->
+<!-- #VERIFY: Read `~/.claude/rules/settings-and-permissions.md` and inspect -->
+<!-- the live `~/.claude/settings.json` schema before pasting. The `condition` -->
+<!-- field may be silently inert or absent from older Claude Code hook schemas. -->
 ```json
 {
   "hooks": {

--- a/docs/planning/handoff-snyk-developer.md
+++ b/docs/planning/handoff-snyk-developer.md
@@ -1,0 +1,231 @@
+# Handoff: Snyk Developer Experience (.claude repo)
+
+**Repo:** ~/dev/.github (this is the global ~/.claude/ config, symlinked)
+**Branch:** claude/snyk-developer-experience-0 (new branch, off main)
+**Session date:** 2026-06-25
+
+---
+
+## Context
+
+The CI/CD layer (handled in the parallel `claude/snyk-iac-aibom-1` branch in
+the same repo) covers scanning code after it is pushed to GitHub. This work
+package covers scanning during authoring: inside the Claude Code session and at
+pre-commit time. These are the two vectors where Snyk can block problems before
+they enter the repo at all.
+
+The capabilities being wired in:
+- **MCP Server** (`ai-mcp-server`): rated HIGH. Snyk MCP Server lets Claude
+  Code invoke `snyk test` or `snyk code test` inline while writing code, before
+  any commit exists.
+- **Secrets CI gate** (`sast-secrets-ci-gate`): rated MEDIUM. Snyk Code's
+  secrets detection can be added as a pre-commit hook to close the bypass window
+  that `--no-verify` opens for local trufflehog/detect-secrets hooks.
+- **MCP Scan** (`ai-mcp-scan`): rated HIGH but pre-GA as of 2026-06. Document
+  the gap; implement the hook stub when GA.
+
+Reference evaluation data:
+`/tmp/claude-1000/-home-byron-dev--github/b617e56f-1680-44d7-83bc-ff79cc722db5/scratchpad/security-tool-comparison.json`
+
+---
+
+## Existing files to be aware of
+
+These files exist in `~/.claude/` and must not be duplicated or contradicted:
+
+- `rules/mcp-strategy.md` -- tiered MCP loading strategy; Snyk MCP Server
+  will be added here as a Tier 2 (on-demand) server.
+- `rules/pre-commit.md` -- pre-commit checklist; add a Snyk item to the
+  Security section.
+- `standards/mcp-minimal-bloat.md` -- guidance on keeping MCP tool surface
+  small; reference this when specifying which Snyk MCP tools to expose.
+
+The global `~/.claude/settings.json` controls Claude Code hooks. Check its
+current content before writing any hook additions.
+
+---
+
+## Work items
+
+### 1. Snyk MCP Server setup standard (HIGH priority)
+
+**Create** `~/.claude/standards/snyk-mcp-setup.md`.
+
+Content to cover:
+
+**One-time setup (per workstation):**
+```bash
+# Install Snyk CLI globally
+npm install -g snyk          # or: brew install snyk
+
+# Authenticate (browser opens; use GitHub SSO or personal token)
+snyk auth
+
+# Configure MCP Server for Claude Code
+npx -y snyk@latest mcp configure --tool=claude-cli
+# This writes an MCP server entry to ~/.claude/settings.json automatically
+```
+
+**Verify the MCP entry** was written by checking `~/.claude/settings.json` for
+a `snyk-mcp` entry after running the configure command.
+
+**Which Snyk MCP tools to expose**: Snyk MCP Server exposes multiple tools.
+Per the minimal-bloat standard, document which tools are active in Claude Code
+sessions and why. The high-value tools are:
+- `snyk_test`: runs `snyk test` on the current project (SCA check)
+- `snyk_code_test`: runs `snyk code test` on specified paths (SAST check)
+- `snyk_monitor`: pushes a snapshot to the Snyk dashboard (use sparingly;
+  this creates a project entry in the Snyk org)
+
+**When to invoke in a Claude Code session** (rules for the agent):
+- Before adding a new dependency to pyproject.toml: invoke `snyk_test` after
+  the uv add command to check the new dep against the Snyk advisory database.
+- Before committing a new authentication or data-handling module: invoke
+  `snyk_code_test` on the changed files to surface SAST findings.
+- When reviewing a PR that adds new MCP tool dependencies: invoke `snyk_test`.
+
+Document that `snyk_monitor` should NOT be called automatically because it
+creates persistent project entries in the Snyk org dashboard that require
+manual cleanup.
+
+**Add** a MEMORY.md entry pointing to this file:
+```
+- [Snyk MCP setup](standards/snyk-mcp-setup.md): workstation setup for Snyk MCP Server; which tools to call and when
+```
+
+### 2. Rules file for Snyk MCP usage (HIGH priority)
+
+**Create** `~/.claude/rules/snyk-mcp.md`.
+
+This is a path-scoped rule that should activate when editing Python package
+files (pyproject.toml, requirements*.txt, uv.lock). Content structure:
+
+```markdown
+---
+path: "**/{pyproject.toml,requirements*.txt,uv.lock}"
+---
+# Snyk MCP: Dependency Review Rule
+
+When a dependency is added or upgraded in a file this rule matches:
+
+1. After the change is written, invoke the snyk_test MCP tool on the project root.
+2. If snyk_test returns HIGH or CRITICAL findings on the newly added package,
+   surface the finding to the user before proceeding.
+3. Do NOT invoke snyk_monitor automatically.
+4. Do NOT block the edit based solely on snyk_test output; report findings and
+   let the user decide.
+
+When snyk_test is not available (SNYK_TOKEN not set or MCP server not configured),
+note the gap and continue without blocking.
+```
+
+Note: path-scoped rules in `~/.claude/rules/` use the `path:` frontmatter field.
+Check existing rule files for the exact frontmatter format before writing.
+
+### 3. Pre-commit hook: Snyk secrets gate (MEDIUM priority)
+
+Snyk Code includes secrets detection. Adding it as a pre-commit hook closes
+the bypass window that `--no-verify` opens for the local trufflehog or
+detect-secrets hooks already in place.
+
+The challenge: `snyk code test` is too slow (10-30 seconds) for a synchronous
+pre-commit hook that runs on every commit. The right approach is a faster,
+targeted secrets-only check.
+
+**Option to implement**: Use Snyk CLI's `--detection-type=secrets` flag (if
+available in the installed version) to run only the secrets scanner, which is
+fast. Alternatively, this belongs in a `pre-push` hook rather than `pre-commit`.
+
+**Document** in `~/.claude/rules/pre-commit.md` under the Security section:
+
+Add to the checklist:
+```
+- [ ] **Snyk Secrets Gate**: If SNYK_TOKEN is set, run `snyk code test
+  --detection-type=secrets <changed-dirs>` on staged Python files before push.
+  This closes the --no-verify bypass vector for the local trufflehog hook.
+```
+
+**Do NOT add** a slow `snyk code test` full SAST scan as a pre-commit hook.
+The CI job covers that. Pre-commit must remain fast.
+
+**Future**: When Snyk MCP Scan (MCP server config prompt-injection scanning)
+reaches GA, add a pre-push hook that runs `snyk mcp-scan` on `.claude/settings.json`
+and any project-local MCP configuration files.
+
+### 4. Claude Code hook: dependency change notification (MEDIUM priority)
+
+Claude Code hooks (configured in `~/.claude/settings.json` or
+`.claude/settings.json`) can fire on tool events. A `PostToolUse` hook on Edit
+or Write targeting pyproject.toml can remind the session to run a Snyk check.
+
+**Read** `~/.claude/settings.json` before making changes (check the current
+hook configuration to avoid duplicates).
+
+**Add** a `PostToolUse` hook that fires when Write or Edit modifies
+`pyproject.toml` or `requirements*.txt`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Dependency file modified. If SNYK_TOKEN is set, consider invoking snyk_test via the Snyk MCP Server before committing.'",
+            "condition": "match_files('**/pyproject.toml', '**/requirements*.txt')"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Check the existing settings.json hook format before writing; the exact schema
+may differ from the example above. Reference `~/.claude/rules/settings-and-permissions.md`
+for the correct format.
+
+### 5. CLAUDE.md update for the .github project-local scope (LOW priority)
+
+The project-local `.claude/CLAUDE.md` in `~/dev/.github` documents project-specific
+Claude instructions. Add a Developer Setup section that references:
+- Snyk CLI auth requirement (`snyk auth` before first use)
+- Snyk MCP Server config step (`npx snyk mcp configure --tool=claude-cli`)
+- Link to `~/.claude/standards/snyk-mcp-setup.md` for full setup instructions
+
+---
+
+## Implementation order
+
+1. Create branch: `git checkout -b claude/snyk-developer-experience-0 main`
+2. Read `~/.claude/settings.json` (understand current hook structure before touching it)
+3. Read `~/.claude/rules/mcp-strategy.md` (understand Tier 1/2/3 structure before adding Snyk)
+4. Create `~/.claude/standards/snyk-mcp-setup.md`
+5. Create `~/.claude/rules/snyk-mcp.md` (check frontmatter format against existing rules)
+6. Update `~/.claude/rules/pre-commit.md` (add Snyk secrets gate checkbox)
+7. Update `~/.claude/rules/mcp-strategy.md` (add Snyk as Tier 2 on-demand server)
+8. Add PostToolUse hook to `~/.claude/settings.json` (or project-local `.claude/settings.json`)
+9. Update `.claude/CLAUDE.md` (project-local developer setup section)
+10. Update `MEMORY.md` (add snyk-mcp-setup pointer)
+11. Run `pre-commit run --all-files`
+12. Commit with signed commit, conventional commit format
+
+---
+
+## Key constraints
+
+- **No em-dashes** in any file content (pre-commit hook will block the commit).
+- **Signed commits**: `git commit -S` on every commit.
+- **mcp-minimal-bloat standard**: Only document tools that earn their token cost.
+  `snyk_monitor` does not belong in the on-by-default set.
+- **Path-scoped rules**: Rules in `~/.claude/rules/` with a `path:` frontmatter
+  field only activate when Claude is editing files matching that path. Verify the
+  exact frontmatter syntax by reading an existing path-scoped rule first.
+- **settings.json hook schema**: The hook format has changed across Claude Code
+  versions. Read the current file and the settings-and-permissions rule before
+  writing any hook additions to avoid syntax errors.
+- **Branch naming**: `claude/<description>-<id>` format.
+- **MCP Scan is pre-GA**: Document the gap; do not implement MCP Scan hooks yet.
+  Add a TODO in the pre-commit rules file noting the condition for implementation.


### PR DESCRIPTION
## Summary

Adds two planning handoff documents capturing Snyk security integration work:

- **`docs/planning/handoff-snyk-cicd.md`**: Historical record of the Snyk CI/CD
  work delivered by PR #224 (IaC workflow, AI-BOM input, self-test job, exploit
  maturity docs). Items 1-3 are implemented and on `main`; item 4 (MCP Scan stub)
  intentionally awaits GA. Preserved for reference.

- **`docs/planning/handoff-snyk-developer.md`**: Active handoff targeting the
  `~/.claude/` global config repo (not this org repo). Covers Snyk MCP Server
  setup standard, path-scoped dependency review rule, pre-commit secrets gate,
  and a PostToolUse hook. None of this work is done yet; it picks up where the
  CI/CD layer leaves off.

## What changed since the initial commit

Fixes applied in ff695dd per pr-fix:
- Added `STATUS: IMPLEMENTED` callout to the cicd handoff (was ambiguous)
- Replaced ephemeral scratchpad path in both files with inline rationale
- Added repo scope callout to developer handoff (targets `~/.claude/`, not org repo)
- Added `#ASSUME`/`#VERIFY` RAD markers on unverified hook schema example
- Added version-pin note to `npm install -g snyk` setup step

## Test plan

- [ ] Pre-commit passes (trim whitespace, markdownlint, no-em-dash, detect-secrets)
- [ ] Reviewer can confirm scope of each file without reading git history
- [ ] MCP Scan stub condition is documented (GA announcement required to implement)